### PR TITLE
add rubygem-sqlite3 in install-dep.sh 

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -20,7 +20,8 @@ elif [ "$ID" = "fedora" ]; then
     nodejs \
     npm \
     protobuf-compiler \
-    rubygem-bundler
+    rubygem-bundler \
+    rubygem-sqlite3 
 else
   echo "Operating system $ID is not supported by this installer."
 fi


### PR DESCRIPTION
adding rubyrem-sqlit3 so that  ruby ruby-sqlite.rb example will work in Fedora