### PR TITLE
Provide a default fly.toml file

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -2,56 +2,17 @@
 
 ## Deploying to Fly
 
-First create a Fly config file (pick an application name):
+You can use the existing `fly.toml` file from this repository.
 
-```toml
-app = "<app name>"
-kill_signal = "SIGINT"
-kill_timeout = 5
-processes = []
-
-[env]
-
-[experimental]
-  allowed_public_ports = []
-  auto_rollback = true
-
-[[services]]
-  internal_port = 5000
-  protocol = "tcp"
-
-  [[services.ports]]
-    port = 5000
-```
-
-Then run (but say not for deploy):
-
+Just run
 ```console
 flyctl launch
 ```
+... then pick a name and respond "Yes" when the prompt asks you to deploy.
 
-Build the Docker image:
-
-```console
-podman build . -t sqld
+Finaly, allocate a IPv4 addres:
 ```
-
-Push to Fly registry:
-
-```console
-podman push --format v2s2 sqld:latest docker://registry.fly.io/<app name>:latest
-```
-
-Finally, deploy:
-
-```console
-flyctl deploy -i registry.fly.io/<app name>:latest
-```
-
-and allocate a IPv4 addres:
-
-```
-flyctl ips allocate-v4 -a <app name>
+flyctl ips allocate-v4 -a <your app name>
 ```
 
 You now have `sqld` running on Fly listening to port `5000`.

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,17 @@
+app = "sqld"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[env]
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]
+  internal_port = 5000
+  protocol = "tcp"
+
+  [[services.ports]]
+    port = 5000


### PR DESCRIPTION
A default file will make it easier for people to just deploy on free tier and play with sqld.

Tested on my free tier account, but without allocating the IP.