### PR TITLE
Add support for queries over HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "base64ct"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,6 +2210,7 @@ dependencies = [
  "anyhow",
  "async-lock",
  "async-trait",
+ "base64 0.21.0",
  "bincode",
  "byteorder",
  "bytes",
@@ -2211,6 +2218,7 @@ dependencies = [
  "crossbeam",
  "futures",
  "hex",
+ "hyper",
  "mvfs",
  "mwal",
  "once_cell",
@@ -2225,6 +2233,7 @@ dependencies = [
  "regex",
  "rusqlite",
  "serde",
+ "serde_json",
  "smallvec",
  "sqlparser",
  "tempfile",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       - SQLD_NODE=replica
       - SQLD_PRIMARY_URL=http://writer:5001
+      - SQLD_HTTP_LISTEN_ADDR=0.0.0.0:8080
     depends_on:
       - writer
   nginx:
@@ -21,3 +22,4 @@ services:
       - reader
     ports:
       - "6001:6001"
+      - "8080:8080"

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,3 +14,16 @@ stream {
         proxy_pass reader;
     }
 }
+
+http {
+    upstream reader {
+        server reader:8080;
+    }
+
+    server {
+        listen 8080;
+        location / {
+            proxy_pass http://reader;
+        }
+    }
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 anyhow = "1.0.66"
 async-lock = "2.6.0"
 async-trait = "0.1.58"
+base64 = "0.21.0"
 bincode = "1.3.3"
 byteorder = "1.4.3"
 bytes = { version = "1.2.1", features = ["serde"] }
@@ -14,6 +15,7 @@ clap = { version = "4.0.23", features = [ "derive" ] }
 crossbeam = "0.8.2"
 futures = "0.3.25"
 hex = "0.4.3"
+hyper = { version = "0.14.23", features = ["http2"] }
 # Regular mvfs prevents users from enabling WAL mode
 mvfs = { git = "https://github.com/psarna/mvsqlite", branch = "mwal", optional = true }
 mwal = { git = "https://github.com/psarna/mvsqlite", branch = "mwal", optional = true }
@@ -26,6 +28,7 @@ prost = "0.11.3"
 regex = "1.7.0"
 rusqlite = { version = "0.28.0", features = [ "buildtime_bindgen", "column_decltype" ] }
 serde = { version = "1.0.149", features = ["derive"] }
+serde_json = "1.0.91"
 smallvec = "1.10.0"
 sqlparser = "0.27.0"
 tokio = { version = "1.21.2", features = ["full"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,7 +11,7 @@ base64 = "0.21.0"
 bincode = "1.3.3"
 byteorder = "1.4.3"
 bytes = { version = "1.2.1", features = ["serde"] }
-clap = { version = "4.0.23", features = [ "derive" ] }
+clap = { version = "4.0.23", features = [ "derive", "env"] }
 crossbeam = "0.8.2"
 futures = "0.3.25"
 hex = "0.4.3"

--- a/server/src/database/service.rs
+++ b/server/src/database/service.rs
@@ -30,6 +30,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub struct DbFactoryService<F> {
     factory: F,
 }

--- a/server/src/http/mod.rs
+++ b/server/src/http/mod.rs
@@ -33,7 +33,8 @@ fn query_response_to_json(rows: QueryResponse) -> anyhow::Result<Bytes> {
                         query::Value::Null => serde_json::Value::Null,
                         query::Value::Integer(i) => serde_json::Value::Number(Number::from(i)),
                         query::Value::Real(x) => serde_json::Value::Number(
-                            Number::from_f64(x).ok_or(anyhow::anyhow!("invalid float value"))?,
+                            Number::from_f64(x)
+                                .ok_or_else(|| anyhow::anyhow!("invalid float value"))?,
                         ),
                         query::Value::Text(s) => serde_json::Value::String(s),
                         query::Value::Blob(v) => {

--- a/server/src/http/mod.rs
+++ b/server/src/http/mod.rs
@@ -1,0 +1,124 @@
+use std::collections::HashMap;
+use std::future::poll_fn;
+use std::{convert::Infallible, net::SocketAddr};
+
+use base64::prelude::BASE64_STANDARD_NO_PAD;
+use base64::Engine;
+use bytes::{BufMut, Bytes, BytesMut};
+use hyper::body::to_bytes;
+use hyper::server::conn::AddrStream;
+use hyper::service::make_service_fn;
+use hyper::{Body, Request, Response};
+use serde::Deserialize;
+use serde_json::Number;
+use tokio::sync::{mpsc, oneshot};
+use tower::balance::pool;
+use tower::load::Load;
+use tower::{service_fn, BoxError, MakeService, Service};
+
+use crate::query::{self, Query, QueryError, QueryResponse, ResultSet};
+
+fn query_response_to_json(rows: QueryResponse) -> anyhow::Result<Bytes> {
+    let QueryResponse::ResultSet(ResultSet { columns, rows }) = rows;
+    let mut values = Vec::new();
+    for row in rows {
+        let val = row
+            .values
+            .into_iter()
+            .zip(columns.iter().map(|c| &c.name))
+            .try_fold(
+                HashMap::new(),
+                |mut map, (value, name)| -> anyhow::Result<_> {
+                    let value = match value {
+                        query::Value::Null => serde_json::Value::Null,
+                        query::Value::Integer(i) => serde_json::Value::Number(Number::from(i)),
+                        query::Value::Real(x) => serde_json::Value::Number(
+                            Number::from_f64(x).ok_or(anyhow::anyhow!("invalid float value"))?,
+                        ),
+                        query::Value::Text(s) => serde_json::Value::String(s),
+                        query::Value::Blob(v) => {
+                            serde_json::Value::String(BASE64_STANDARD_NO_PAD.encode(v))
+                        }
+                    };
+
+                    map.insert(name.to_string(), value);
+                    Ok(map)
+                },
+            )?;
+
+        values.push(val);
+    }
+
+    let mut buffer = BytesMut::new().writer();
+    serde_json::to_writer(&mut buffer, &values)?;
+
+    Ok(buffer.into_inner().freeze())
+}
+
+async fn handle_request(
+    mut req: Request<Body>,
+    sender: mpsc::Sender<(oneshot::Sender<Result<QueryResponse, BoxError>>, Query)>,
+) -> anyhow::Result<Response<Body>> {
+    let bytes = to_bytes(req.body_mut()).await?;
+    let req: HttpQueryRequest = serde_json::from_slice(&bytes)?;
+    let (s, resp) = oneshot::channel();
+    let _ = sender
+        .send((s, Query::SimpleQuery(req.statements.join(";"), Vec::new())))
+        .await;
+
+    let result = resp.await?;
+    match result {
+        Ok(rows) => {
+            let json = query_response_to_json(rows)?;
+            Ok(Response::new(Body::from(json)))
+        }
+        Err(_) => todo!(),
+    }
+}
+
+pub async fn run_http<F>(addr: SocketAddr, db_factory: F) -> anyhow::Result<()>
+where
+    F: MakeService<(), Query> + Send + 'static,
+    F::Service: Load + Service<Query, Response = QueryResponse, Error = QueryError>,
+    <F::Service as Load>::Metric: std::fmt::Debug,
+    F::MakeError: Into<BoxError>,
+    F::Error: Into<BoxError>,
+    <F as MakeService<(), Query>>::Service: Send,
+    <F as MakeService<(), Query>>::Future: Send,
+    <<F as MakeService<(), Query>>::Service as Service<Query>>::Future: Send,
+{
+    tracing::info!("listening for HTTP requests on {addr}");
+
+    let (sender, mut receiver) = mpsc::channel(1024);
+    let server =
+        hyper::server::Server::bind(&addr).serve(make_service_fn(move |_: &AddrStream| {
+            let sender = sender.clone();
+            async move {
+                Ok::<_, Infallible>(service_fn(move |req| handle_request(req, sender.clone())))
+            }
+        }));
+
+    tokio::spawn(async move {
+        let mut pool = pool::Builder::new().build(db_factory, ());
+        while let Some((resp, query)) = receiver.recv().await {
+            if let Err(e) = poll_fn(|c| pool.poll_ready(c)).await {
+                tracing::error!("Connection pool error: {e}");
+                continue;
+            }
+
+            let fut = pool.call(query);
+            tokio::spawn(async move {
+                let _ = resp.send(fut.await);
+            });
+        }
+    });
+
+    server.await?;
+
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HttpQueryRequest {
+    statements: Vec<String>,
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -54,10 +54,6 @@ where
     S::Response: Service<Query, Response = QueryResponse, Error = QueryError> + Sync + Send,
     S::Future: Send + Sync,
     <S::Response as Service<Query>>::Future: Send,
-    // F: MakeService<(), Query, MakeError = anyhow::Error> + Sync + Send,
-    // F::Future: 'static + Send + Sync,
-    // F::Service: Service<Query, Response = QueryResponse, Error = QueryError> + Sync + Send,
-    // <F::Service as Service<Query>>::Future: Send,
 {
     let mut server = Server::new();
     server.bind_tcp(config.tcp_addr).await?;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -28,6 +28,9 @@ struct Cli {
     #[cfg(feature = "mwal_backend")]
     #[clap(long, short)]
     mwal_addr: Option<String>,
+
+    #[clap(long)]
+    http_addr: Option<SocketAddr>,
 }
 
 #[tokio::main]
@@ -53,6 +56,7 @@ async fn main() -> Result<()> {
         args.db_path,
         args.pg_listen_addr,
         args.ws_listen_addr,
+        args.http_addr,
         args.backend,
         #[cfg(feature = "mwal_backend")]
         args.mwal_addr,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -9,29 +9,44 @@ use sqld::Config;
 #[command(name = "sqld")]
 #[command(about = "SQL daemon", long_about = None)]
 struct Cli {
-    #[clap(long, short, default_value = "iku.db")]
+    #[clap(long, short, default_value = "iku.db", env = "SQLD_DB_PATH")]
     db_path: PathBuf,
     /// The address and port the PostgreSQL server listens to.
-    #[clap(long, short, default_value = "127.0.0.1:5000")]
+    #[clap(
+        long,
+        short,
+        default_value = "127.0.0.1:5000",
+        env = "SQLD_PG_LISTEN_ADDR"
+    )]
     pg_listen_addr: SocketAddr,
     /// The address and port the PostgreSQL over WebSocket server listens to.
-    #[clap(long, short)]
+    #[clap(long, short, env = "SQLD_WS_LISTEN_ADDR")]
     ws_listen_addr: Option<SocketAddr>,
     /// The address and port the inter-node RPC protocol listens to. Example: `0.0.0.0:5001`.
-    #[clap(long, conflicts_with = "primary_grpc_url")]
+    #[clap(
+        long,
+        conflicts_with = "primary_grpc_url",
+        env = "SQLD_GRPC_LISTEN_ADDR"
+    )]
     grpc_listen_addr: Option<SocketAddr>,
     /// The gRPC URL of the primary node to connect to for writes. Example: `http://localhost:5001`.
-    #[clap(long)]
+    #[clap(long, env = "SQLD_PRIMARY_GRPC_URL")]
     primary_grpc_url: Option<String>,
-    #[clap(long, short, value_enum, default_value = "libsql")]
+    #[clap(
+        long,
+        short,
+        value_enum,
+        default_value = "libsql",
+        env = "SQLD_WS_LISTEN_ADDR"
+    )]
     backend: sqld::Backend,
     // The url to connect with mWAL backend, based on mvSQLite
     #[cfg(feature = "mwal_backend")]
-    #[clap(long, short)]
+    #[clap(long, short, env = "SQLD_MWAL_ADDR")]
     mwal_addr: Option<String>,
 
-    #[clap(long)]
-    http_addr: Option<SocketAddr>,
+    #[clap(long, env = "SQLD_HTTP_LISTEN_ADDR")]
+    http_listen_addr: Option<SocketAddr>,
 }
 
 impl From<Cli> for Config {
@@ -40,7 +55,7 @@ impl From<Cli> for Config {
             db_path: cli.db_path,
             tcp_addr: cli.pg_listen_addr,
             ws_addr: cli.ws_listen_addr,
-            http_addr: cli.http_addr,
+            http_addr: cli.http_listen_addr,
             backend: cli.backend,
             writer_rpc_addr: cli.primary_grpc_url,
             rpc_server_addr: cli.grpc_listen_addr,

--- a/server/src/postgres/service.rs
+++ b/server/src/postgres/service.rs
@@ -119,13 +119,13 @@ impl<S> PgConnectionFactory<S> {
     }
 }
 
-impl<T, F, S> Service<(T, SocketAddr)> for PgConnectionFactory<F>
+impl<T, F> Service<(T, SocketAddr)> for PgConnectionFactory<F>
 where
     T: AsyncRead + AsyncWrite + AsyncPeekable + Unpin + Send + Sync + 'static,
-    F: MakeService<(), Query, MakeError = anyhow::Error, Service = S> + Sync,
+    F: MakeService<(), Query, MakeError = anyhow::Error> + Sync,
     F::Future: 'static + Send + Sync,
-    S: Service<Query, Response = QueryResponse, Error = QueryError> + Sync + Send,
-    S::Future: Send,
+    F::Service: Service<Query, Response = QueryResponse, Error = QueryError> + Sync + Send,
+    <F::Service as Service<Query>>::Future: Send,
 {
     type Response = ();
     type Error = anyhow::Error;

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -1,4 +1,5 @@
 use std::convert::Infallible;
+use std::fmt;
 use std::str::FromStr;
 
 use futures::stream;
@@ -252,6 +253,14 @@ pub enum Query {
 pub struct QueryError {
     pub code: ErrorCode,
     pub msg: String,
+}
+
+impl std::error::Error for QueryError {}
+
+impl fmt::Display for QueryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.msg)
+    }
 }
 
 impl From<RpcError> for QueryError {

--- a/server/src/server/mod.rs
+++ b/server/src/server/mod.rs
@@ -20,7 +20,7 @@ use self::ws::WsAdapter;
 mod tcp;
 mod ws;
 
-type Listener = Box<dyn Stream<Item = io::Result<(NetStream, SocketAddr)>> + Unpin>;
+type Listener = Box<dyn Stream<Item = io::Result<(NetStream, SocketAddr)>> + Unpin + Send>;
 
 pub struct Server {
     listeners: Vec<Listener>,
@@ -47,7 +47,7 @@ impl Server {
         Ok(self)
     }
 
-    pub async fn serve<S>(self, mut make_svc: S)
+    pub async fn serve<S>(self, mut make_svc: S) -> anyhow::Result<()>
     where
         S: Service<(NetStream, SocketAddr)>,
         S::Future: Send,
@@ -78,6 +78,8 @@ impl Server {
                 }
             }
         }
+
+        Ok(())
     }
 }
 

--- a/server/src/server/ws.rs
+++ b/server/src/server/ws.rs
@@ -148,7 +148,8 @@ impl<S> WsStreamAdapter<S> {
     }
 }
 
-type WsAdapterInitFut = Pin<Box<dyn Future<Output = (WebSocketStream<TcpStream>, SocketAddr)>>>;
+type WsAdapterInitFut =
+    Pin<Box<dyn Future<Output = (WebSocketStream<TcpStream>, SocketAddr)> + Send>>;
 
 pub struct WsAdapter {
     listener: TcpListener,


### PR DESCRIPTION
This PR adds support for queries over HTTP.

It is enabled by runnign the server with the `--http-listen-addr <SOCKET_ADDR>` option.

The server is responding to `POST /` with a payload json with the following shape:
```json
{
        "statements": ["some SQL statement", "some other statement", ...]
    }
```

if the query should return rows, they are returned to the JSON format.

The BLOB rows are encoded in base64 with the standard alphabet and no padding.

unlike stateful connections that open a DB connection for every session, the HTTP approach uses a connection pool instead. The number of connections in the pool can scale up and down depending on load

I also added end variables for all cli args, to simplify configuration from docker-compose. Env vars are documented in the `--help` command for the binary.
