### PR TITLE
fly: simplify user guide by switching to the HTTP API

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -10,9 +10,14 @@ flyctl launch
 ```
 ... then pick a name and respond "Yes" when the prompt asks you to deploy.
 
-Finaly, allocate a IPv4 addres:
-```
-flyctl ips allocate-v4 -a <your app name>
-```
+You now have `sqld` running on Fly listening for HTTP connections.
 
-You now have `sqld` running on Fly listening to port `5000`.
+Give it a try with this snippet, replacing `$YOUR_APP` with your app name:
+```
+curl -X POST -d '{"statements": ["create table testme(a,b,c)"]}' $YOUR_APP.fly.dev
+curl -X POST -d '{"statements": ["insert into testme values(1,2,3)"]}' $YOUR_APP.fly.dev
+curl -X POST -d '{"statements": ["select * from testme"]}' $YOUR_APP.fly.dev
+```
+```
+[{"b":2,"a":1,"c":3}]
+```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,6 +11,9 @@ if [ "$1" = '/bin/sqld' ]; then
   # Listen to PostgreSQL port by default.
   server_args+=("--pg-listen-addr" "0.0.0.0:5000")
 
+  # Listen on HTTP 8080 port by default.
+  server_args+=("--http-listen-addr" "0.0.0.0:8080")
+
   # Set remaining arguments depending on what type of node we are.
   case "$SQLD_NODE" in
     primary)

--- a/fly.toml
+++ b/fly.toml
@@ -10,8 +10,23 @@ processes = []
   auto_rollback = true
 
 [[services]]
-  internal_port = 5000
+  http_checks = []
+  app = "sqld"
+  internal_port = 8080
   protocol = "tcp"
 
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
   [[services.ports]]
-    port = 5000
+    force_https = false
+    handlers = ["http"]
+    port = 80
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"


### PR DESCRIPTION
With our HTTP API, running a free tier example app is as simple as running `fly launch` on the example configuration file.

Tested with http://sqld.fly.dev with my free tier account:
```
curl -s -X POST -d '{"statements": ["select * from testme"]}' sqld.fly.dev | jtbl
  a    b    c
---  ---  ---
  1    2    3
  4    5    6
```