### PR TITLE
replace sqlparser with lemon parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
+dependencies = [
+ "memchr",
+ "safemem",
+ "slice-deque",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1111,15 @@ dependencies = [
 
 [[package]]
 name = "mach"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
@@ -1494,6 +1514,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56ac890c5e3ca598bbdeaa99964edb5b0258a583a9eb6ef4e89fc85d9224770"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+dependencies = [
+ "siphasher",
+ "uncased",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,7 +1762,7 @@ checksum = "b7e31331286705f455e56cca62e0e717158474ff02b7936c1fa596d983f4ae27"
 dependencies = [
  "crossbeam-utils",
  "libc",
- "mach",
+ "mach 0.3.2",
  "once_cell",
  "raw-cpuid",
  "wasi 0.10.2+wasi-snapshot-preview1",
@@ -1969,6 +2028,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,6 +2208,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "skeptic"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,6 +2235,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slice-deque"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffddf594f5f597f63533d897427a570dbaa9feabaaa06595b74b71b7014507d7"
+dependencies = [
+ "libc",
+ "mach 0.2.3",
+ "winapi",
 ]
 
 [[package]]
@@ -2216,6 +2298,7 @@ dependencies = [
  "bytes",
  "clap",
  "crossbeam",
+ "fallible-iterator",
  "futures",
  "hex",
  "hyper",
@@ -2235,7 +2318,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sqlparser",
+ "sqlite3-parser",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -2250,12 +2333,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlparser"
-version = "0.27.0"
+name = "sqlite3-parser"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba319938d4bfe250a769ac88278b629701024fe16f34257f9563bc628081970"
+checksum = "9e3e42304077fd98c51f96c5c2c55203eb9ba505e5539881cc935b83e77bbc7f"
 dependencies = [
+ "bitflags",
+ "buf_redux",
+ "cc",
+ "fallible-iterator",
+ "indexmap",
  "log",
+ "memchr",
+ "phf",
+ "phf_codegen",
+ "phf_shared",
+ "smallvec",
+ "uncased",
 ]
 
 [[package]]
@@ -2686,6 +2780,15 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "uncased"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicase"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,6 +13,7 @@ byteorder = "1.4.3"
 bytes = { version = "1.2.1", features = ["serde"] }
 clap = { version = "4.0.23", features = [ "derive", "env"] }
 crossbeam = "0.8.2"
+fallible-iterator = "0.2.0"
 futures = "0.3.25"
 hex = "0.4.3"
 hyper = { version = "0.14.23", features = ["http2"] }
@@ -30,7 +31,7 @@ rusqlite = { version = "0.28.0", features = [ "buildtime_bindgen", "column_declt
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.91"
 smallvec = "1.10.0"
-sqlparser = "0.27.0"
+sqlite3-parser = "0.5.0"
 tokio = { version = "1.21.2", features = ["full"] }
 tokio-stream = "0.1.11"
 tokio-tungstenite = "0.17.2"

--- a/server/src/database/mod.rs
+++ b/server/src/database/mod.rs
@@ -1,5 +1,5 @@
 use crate::query::{QueryResult, Value};
-use crate::query_analysis::Statements;
+use crate::query_analysis::Statement;
 
 pub mod libsql;
 pub mod service;
@@ -9,5 +9,5 @@ const TXN_TIMEOUT_SECS: u64 = 5;
 
 #[async_trait::async_trait]
 pub trait Database {
-    async fn execute(&self, query: Statements, params: Vec<Value>) -> QueryResult;
+    async fn execute(&self, query: Statement, params: Vec<Value>) -> QueryResult;
 }

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -157,6 +157,15 @@ pub struct ResultSet {
     pub rows: Vec<Row>,
 }
 
+impl ResultSet {
+    pub fn empty() -> Self {
+        Self {
+            columns: Vec::new(),
+            rows: Vec::new(),
+        }
+    }
+}
+
 fn encode_row(row: Row) -> PgWireResult<DataRow> {
     let mut encoder = TextDataRowEncoder::new(row.values.len());
     for value in row.values {

--- a/server/src/query_analysis.rs
+++ b/server/src/query_analysis.rs
@@ -1,23 +1,20 @@
-use std::fmt;
-
 use anyhow::Result;
-use sqlparser::{ast::Statement, dialect::SQLiteDialect, parser::Parser};
+use fallible_iterator::FallibleIterator;
+use sqlite3_parser::{
+    ast::{Cmd, Stmt},
+    lexer::sql::Parser,
+};
 
 /// A group of statements to be executed together.
-pub struct Statements {
-    pub stmts: String,
-    kinds: Vec<StmtKind>,
-}
-
-impl fmt::Debug for Statements {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.stmts)
-    }
+#[derive(Debug)]
+pub struct Statement {
+    pub stmt: String,
+    pub kind: StmtKind,
 }
 
 /// Classify statement in categories of interest.
 #[derive(Debug, PartialEq, Clone, Copy)]
-enum StmtKind {
+pub enum StmtKind {
     /// The begining of a transaction
     TxnBegin,
     /// The end of a transaction
@@ -28,22 +25,21 @@ enum StmtKind {
 }
 
 impl StmtKind {
-    fn kind(stmt: &Statement) -> Self {
-        match stmt {
-            Statement::StartTransaction { .. } => Self::TxnBegin,
-            Statement::SetTransaction { .. } => todo!("handle set txn"),
-            Statement::Rollback { .. } | Statement::Commit { .. } => Self::TxnEnd,
-            Statement::Savepoint { .. } => todo!("handle savepoint"),
-
-            Statement::Query(_) => Self::Read,
-
-            Statement::Insert { .. } | Statement::Update { .. } | Statement::Delete { .. } => {
-                Self::Write
-            }
-            Statement::Prepare { .. } => todo!(),
-            // FIXME: this contains lots of dialect specific nodes, when porting to Postges, check what's
-            // in there.
-            _ => Self::Other,
+    fn kind(cmd: &Cmd) -> Option<Self> {
+        match cmd {
+            Cmd::Explain(_) => Some(Self::Other),
+            Cmd::ExplainQueryPlan(_) => Some(Self::Other),
+            Cmd::Stmt(Stmt::Begin { .. }) => Some(Self::TxnBegin),
+            Cmd::Stmt(Stmt::Commit { .. } | Stmt::Rollback { .. }) => Some(Self::TxnEnd),
+            Cmd::Stmt(
+                Stmt::Insert { .. }
+                | Stmt::CreateTable { .. }
+                | Stmt::Update { .. }
+                | Stmt::Delete { .. }
+                | Stmt::DropTable { .. },
+            ) => Some(Self::Write),
+            Cmd::Stmt(Stmt::Select { .. }) => Some(Self::Read),
+            _ => None,
         }
     }
 }
@@ -61,40 +57,47 @@ pub enum State {
     Invalid,
 }
 
-impl Statements {
-    pub fn parse(s: String) -> Result<Self> {
-        // We don't really care about `StmtKind::Other`, we keep it for conceptual simplicity.
-        let kinds = Parser::parse_sql(&SQLiteDialect {}, &s)
-            .map(|statements| statements.iter().map(StmtKind::kind).collect())
-            .unwrap_or_else(|_| vec![StmtKind::Other]);
-
-        Ok(Self { stmts: s, kinds })
+impl State {
+    pub fn step(&mut self, kind: StmtKind) {
+        *self = match (*self, kind) {
+            (State::TxnOpened, StmtKind::TxnBegin) | (State::TxnClosed, StmtKind::TxnEnd) => {
+                State::Invalid
+            }
+            (State::TxnOpened, StmtKind::TxnEnd) => State::TxnClosed,
+            (State::TxnClosed, StmtKind::TxnBegin) => State::TxnOpened,
+            (state, StmtKind::Other | StmtKind::Write | StmtKind::Read) => state,
+            (State::Invalid, _) => State::Invalid,
+            (State::Start, StmtKind::TxnBegin) => State::TxnOpened,
+            (State::Start, StmtKind::TxnEnd) => State::TxnClosed,
+        };
     }
 
-    /// Given an initial state, returns the final state a transaction should be in after running these
-    /// statements.
-    pub fn state(&self, state: State) -> State {
-        self.kinds
-            .iter()
-            .fold(state, |old_state, current| match (old_state, current) {
-                (State::TxnOpened, StmtKind::TxnBegin) | (State::TxnClosed, StmtKind::TxnEnd) => {
-                    State::Invalid
-                }
-                (State::TxnOpened, StmtKind::TxnEnd) => State::TxnClosed,
-                (State::TxnClosed, StmtKind::TxnBegin) => State::TxnOpened,
-                (state, StmtKind::Other | StmtKind::Write | StmtKind::Read) => state,
-                (State::Invalid, _) => State::Invalid,
-                (State::Start, StmtKind::TxnBegin) => State::TxnOpened,
-                (State::Start, StmtKind::TxnEnd) => State::TxnClosed,
-            })
+    pub fn reset(&mut self) {
+        *self = State::Start
+    }
+}
+
+impl Statement {
+    pub fn parse(s: String) -> Result<Option<Self>> {
+        let mut parser = Parser::new(s.as_bytes());
+        match parser.next()? {
+            Some(cmd) => {
+                let kind =
+                    StmtKind::kind(&cmd).ok_or_else(|| anyhow::anyhow!("unsupported statement"))?;
+
+                Ok(Some(Self {
+                    stmt: cmd.to_string(),
+                    kind,
+                }))
+            }
+            None => Ok(None),
+        }
     }
 
     pub fn is_read_only(&self) -> bool {
-        let state = self.state(State::Start);
-        let is_only_reads = self
-            .kinds
-            .iter()
-            .all(|k| matches!(k, StmtKind::Read | StmtKind::TxnEnd | StmtKind::TxnBegin));
-        (state == State::Start || state == State::TxnClosed) && is_only_reads
+        matches!(
+            self.kind,
+            StmtKind::Read | StmtKind::TxnEnd | StmtKind::TxnBegin
+        )
     }
 }


### PR DESCRIPTION
The PR ~makes lemonade~ replaces sqlparser with lemon-rs, which has up-to-date sqlite3 grammar and working a working code emitter.

close #15 
