### PR TITLE
batch query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,8 +2335,7 @@ dependencies = [
 [[package]]
 name = "sqlite3-parser"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3e42304077fd98c51f96c5c2c55203eb9ba505e5539881cc935b83e77bbc7f"
+source = "git+https://github.com/MarinPostma/lemon-rs.git?rev=d3a6365#d3a63653356261de9a6663d109147d4e7d5ca238"
 dependencies = [
  "bitflags",
  "buf_redux",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,5 @@ members = [
 mvfs = { git = "https://github.com/MarinPostma/mvsqlite", branch = "use-cchar" }
 mwal = { git = "https://github.com/MarinPostma/mvsqlite", branch = "use-cchar" }
 
+[patch.crates-io]
+sqlite3-parser = { git = "https://github.com/MarinPostma/lemon-rs.git", rev = "d3a6365" }

--- a/server/proto/proxy.proto
+++ b/server/proto/proxy.proto
@@ -1,20 +1,17 @@
 syntax = "proto3";
 package proxy;
 
-message SimpleQuery {
-  string q = 1;
-  // Uuid
-  bytes clientId = 2;
-  }
+message Queries {
+    repeated string queries = 1;
+    // Uuid
+    bytes clientId = 2;
+}
 
 message QueryResult {
-    optional Error          error = 1;
-    optional ResultRows     rows = 2;
-    enum Result {
-        Ok = 0;
-        Err = 1;
+    oneof row_result {
+        Error error = 1;
+        ResultRows row = 2;
     }
-    Result result = 3;
 }
 
 message Error {
@@ -62,7 +59,18 @@ message DisconnectMessage {
 
 message Ack {}
 
+message ExecuteResults {
+    repeated QueryResult results = 1;
+    enum State {
+        Init = 0;
+        Invalid = 1;
+        Txn = 2;
+    }
+    /// State after executing the queries
+    State state = 2;
+}
+
 service Proxy {
-  rpc Query(SimpleQuery) returns (QueryResult) {}
+  rpc Execute(Queries) returns (ExecuteResults) {}
   rpc Disconnect(DisconnectMessage) returns (Ack) {}
 }

--- a/server/src/database/mod.rs
+++ b/server/src/database/mod.rs
@@ -1,5 +1,5 @@
-use crate::query::{QueryResult, Value};
-use crate::query_analysis::Statement;
+use crate::query::{Queries, QueryResult};
+use crate::query_analysis::State;
 
 pub mod libsql;
 pub mod service;
@@ -9,5 +9,7 @@ const TXN_TIMEOUT_SECS: u64 = 5;
 
 #[async_trait::async_trait]
 pub trait Database {
-    async fn execute(&self, query: Statement, params: Vec<Value>) -> QueryResult;
+    /// Executes a batch of queries, and return the a vec of results corresponding to the queries,
+    /// and the state the database is in after the call to execute.
+    async fn execute(&self, queries: Queries) -> anyhow::Result<(Vec<QueryResult>, State)>;
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -10,7 +10,7 @@ use database::service::DbFactoryService;
 use database::write_proxy::WriteProxyDbFactory;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use query::{Query, QueryError, QueryResponse};
+use query::{Queries, QueryResult};
 use rpc::run_rpc_server;
 use tower::load::Constant;
 use tower::{Service, ServiceExt};
@@ -25,7 +25,7 @@ mod libsql;
 mod postgres;
 mod query;
 mod query_analysis;
-mod rpc;
+pub mod rpc;
 mod server;
 mod wal_logger;
 
@@ -51,9 +51,9 @@ pub struct Config {
 async fn run_service<S>(service: S, config: Config) -> Result<()>
 where
     S: Service<(), Error = anyhow::Error> + Sync + Send + 'static + Clone,
-    S::Response: Service<Query, Response = QueryResponse, Error = QueryError> + Sync + Send,
+    S::Response: Service<Queries, Response = Vec<QueryResult>, Error = anyhow::Error> + Sync + Send,
     S::Future: Send + Sync,
-    <S::Response as Service<Query>>::Future: Send,
+    <S::Response as Service<Queries>>::Future: Send,
 {
     let mut server = Server::new();
     server.bind_tcp(config.tcp_addr).await?;

--- a/server/src/rpc/proxy.rs
+++ b/server/src/rpc/proxy.rs
@@ -5,17 +5,103 @@ use uuid::Uuid;
 
 use crate::database::service::DbFactory;
 use crate::database::Database;
-use crate::query::{ErrorCode, QueryResponse, QueryResult, ResultSet};
+use crate::query::Query;
 use crate::query_analysis::Statement;
+use crate::rpc::proxy::proxy_rpc::execute_results::State;
 use proxy_rpc::proxy_server::Proxy;
-use proxy_rpc::{
-    error::ErrorCode as RpcErrorCode, query_result::Result as RpcResult, Ack, DisconnectMessage,
-    Error as RpcError, QueryResult as RpcQueryResult, SimpleQuery,
-};
+use proxy_rpc::{Ack, DisconnectMessage, Queries};
+
+use self::proxy_rpc::ExecuteResults;
 
 pub mod proxy_rpc {
     #![allow(clippy::all)]
+
+    use crate::query::{self, QueryError, QueryResponse};
+
+    use self::{error::ErrorCode, execute_results::State, query_result::RowResult};
     tonic::include_proto!("proxy");
+
+    impl From<query::QueryResult> for RowResult {
+        fn from(other: query::QueryResult) -> Self {
+            match other {
+                Ok(QueryResponse::ResultSet(set)) => RowResult::Row(set.into()),
+                Err(e) => RowResult::Error(e.into()),
+            }
+        }
+    }
+
+    impl From<QueryError> for Error {
+        fn from(other: QueryError) -> Self {
+            Error {
+                code: ErrorCode::from(other.code).into(),
+                message: other.msg,
+            }
+        }
+    }
+
+    impl From<ErrorCode> for query::ErrorCode {
+        fn from(other: ErrorCode) -> Self {
+            match other {
+                ErrorCode::SqlError => query::ErrorCode::SQLError,
+                ErrorCode::TxBusy => query::ErrorCode::TxBusy,
+                ErrorCode::TxTimeout => query::ErrorCode::TxTimeout,
+                ErrorCode::Internal => query::ErrorCode::Internal,
+            }
+        }
+    }
+
+    impl From<query::ErrorCode> for ErrorCode {
+        fn from(other: query::ErrorCode) -> Self {
+            match other {
+                query::ErrorCode::SQLError => ErrorCode::SqlError,
+                query::ErrorCode::TxBusy => ErrorCode::TxBusy,
+                query::ErrorCode::TxTimeout => ErrorCode::TxTimeout,
+                query::ErrorCode::Internal => ErrorCode::Internal,
+            }
+        }
+    }
+
+    impl From<Error> for QueryError {
+        fn from(other: Error) -> Self {
+            Self::new(other.code().into(), other.message)
+        }
+    }
+
+    impl From<query::QueryResult> for QueryResult {
+        fn from(other: query::QueryResult) -> Self {
+            let res = match other {
+                Ok(query::QueryResponse::ResultSet(q)) => {
+                    let rows = q.into();
+                    RowResult::Row(rows)
+                }
+                Err(e) => RowResult::Error(e.into()),
+            };
+
+            QueryResult {
+                row_result: Some(res),
+            }
+        }
+    }
+
+    impl From<crate::query_analysis::State> for State {
+        fn from(other: crate::query_analysis::State) -> Self {
+            match other {
+                crate::query_analysis::State::Txn => Self::Txn,
+                crate::query_analysis::State::Init => Self::Init,
+                crate::query_analysis::State::Invalid => Self::Invalid,
+            }
+        }
+    }
+
+    impl From<State> for crate::query_analysis::State {
+        fn from(other: State) -> Self {
+            match other {
+                State::Txn => crate::query_analysis::State::Txn,
+                State::Init => crate::query_analysis::State::Init,
+                State::Invalid => crate::query_analysis::State::Invalid,
+            }
+        }
+    }
 }
 
 pub struct ProxyService<F: DbFactory> {
@@ -32,40 +118,6 @@ impl<F: DbFactory> ProxyService<F> {
     }
 }
 
-impl From<QueryResult> for RpcQueryResult {
-    fn from(other: QueryResult) -> Self {
-        match other {
-            Ok(QueryResponse::ResultSet(q)) => {
-                let rows = q.into();
-                RpcQueryResult {
-                    error: None,
-                    rows: Some(rows),
-                    result: RpcResult::Ok.into(),
-                }
-            }
-            Err(e) => {
-                let code = match e.code {
-                    ErrorCode::SQLError => RpcErrorCode::SqlError,
-                    ErrorCode::TxBusy => RpcErrorCode::TxBusy,
-                    ErrorCode::TxTimeout => RpcErrorCode::TxTimeout,
-                    ErrorCode::Internal => RpcErrorCode::Internal,
-                };
-
-                let err = RpcError {
-                    code: code.into(),
-                    message: e.msg,
-                };
-
-                RpcQueryResult {
-                    error: Some(err),
-                    rows: None,
-                    result: RpcResult::Err.into(),
-                }
-            }
-        }
-    }
-}
-
 #[tonic::async_trait]
 impl<F> Proxy for ProxyService<F>
 where
@@ -73,11 +125,11 @@ where
     F::Db: Send + Sync + Clone,
     F::Future: Send + Sync,
 {
-    async fn query(
+    async fn execute(
         &self,
-        req: tonic::Request<SimpleQuery>,
-    ) -> Result<tonic::Response<RpcQueryResult>, tonic::Status> {
-        let SimpleQuery { client_id, q } = req.into_inner();
+        req: tonic::Request<Queries>,
+    ) -> Result<tonic::Response<ExecuteResults>, tonic::Status> {
+        let Queries { client_id, queries } = req.into_inner();
         let client_id = Uuid::from_slice(&client_id).unwrap();
 
         let lock = self.clients.upgradable_read().await;
@@ -92,14 +144,31 @@ where
             }
         };
 
-        tracing::debug!("executing request for {client_id}: {q}");
-        let stmt = Statement::parse(q).unwrap();
-        let result = match stmt {
-            Some(stmt) => db.execute(stmt, Vec::new()).await,
-            None => Ok(QueryResponse::ResultSet(ResultSet::empty())),
-        };
+        tracing::debug!("executing request for {client_id}");
+        let queries = queries
+            .iter()
+            .map(|q| {
+                // FIXME: we assume the statement is valid because we trust the caller to have verified
+                // it before: do proper error handling instead
+                let stmt = Statement::parse(q)
+                    .next()
+                    .transpose()
+                    .unwrap()
+                    .unwrap_or_default();
+                Query {
+                    stmt,
+                    params: Vec::new(),
+                }
+            })
+            .collect();
 
-        Ok(tonic::Response::new(result.into()))
+        let (results, state) = db.execute(queries).await.unwrap();
+        let results = results.into_iter().map(|r| r.into()).collect();
+
+        Ok(tonic::Response::new(ExecuteResults {
+            results,
+            state: State::from(state).into(),
+        }))
     }
 
     //TODO: also handle cleanup on peer disconnect


### PR DESCRIPTION
Add support for batch queries

This was more work than I expected, because of the different protocols we support and different modes of operations. Queries are always batched now (singular queries are in batches on 1).

If any statement in the batch does not parse, then the whole batch is rejected.

fix #18 