### PR TITLE
change postgres' default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cargo run
 and connect to it with psql:
 
 ```console
-psql -h 127.0.0.1 -p 5000
+psql -h 127.0.0.1 -p 5432
 ```
 
 ## Building from Sources

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$1" = '/bin/sqld' ]; then
   declare -a server_args=()
 
   # Listen to PostgreSQL port by default.
-  server_args+=("--pg-listen-addr" "0.0.0.0:5000")
+  server_args+=("--pg-listen-addr" "0.0.0.0:5432")
 
   # Listen on HTTP 8080 port by default.
   server_args+=("--http-listen-addr" "0.0.0.0:8080")

--- a/examples/javascript/README.md
+++ b/examples/javascript/README.md
@@ -13,5 +13,5 @@ DB_URI=":memory:" node index.js
 With `sqld` client:
 
 ```
-DB_URI="postgresl://127.0.0.1:5000" LD_PRELOAD=../../target/debug/libsqlc.so node index.js
+DB_URI="postgresl://127.0.0.1:5432" LD_PRELOAD=../../target/debug/libsqlc.so node index.js
 ```

--- a/perf/pgbench/README.md
+++ b/perf/pgbench/README.md
@@ -3,11 +3,11 @@
 Setup database:
 
 ```
-psql -h 127.0.0.1 -p 5000 < pg_bench_schema.sql 
+psql -h 127.0.0.1 -p 5432 < pg_bench_schema.sql
 ````
 
 Run `pgbench`:
 
 ```console
-pgbench -h 127.0.0.1 -p 5000 -f pg_bench_script.sql -c 10 -t 1000
+pgbench -h 127.0.0.1 -p 5432 -f pg_bench_script.sql -c 10 -t 1000
 ```

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -15,7 +15,7 @@ struct Cli {
     #[clap(
         long,
         short,
-        default_value = "127.0.0.1:5000",
+        default_value = "127.0.0.1:5432",
         env = "SQLD_PG_LISTEN_ADDR"
     )]
     pg_listen_addr: SocketAddr,

--- a/testing/client/ruby/Makefile
+++ b/testing/client/ruby/Makefile
@@ -6,5 +6,5 @@ setup:
 .PHONY: setup
 
 test:
-	LD_PRELOAD=../../../target/debug/libsqlc.so DB_URI=postgres://127.0.0.1:5000 bundle exec rspec sqlite_spec.rb
+	LD_PRELOAD=../../../target/debug/libsqlc.so DB_URI=postgres://127.0.0.1:5432 bundle exec rspec sqlite_spec.rb
 .PHONY: test

--- a/testing/server/javascript/postgres.test.js
+++ b/testing/server/javascript/postgres.test.js
@@ -4,7 +4,7 @@ const { Client } = require('pg')
 test('Connect to server', async () => {
     const client = new Client({
         host: "127.0.0.1",
-        port: 5000,
+        port: 5432,
     })
     await client.connect()
     await client.end()
@@ -13,7 +13,7 @@ test('Connect to server', async () => {
 test('Change schema', async () => {
     const client = new Client({
         host: "127.0.0.1",
-        port: 5000,
+        port: 5432,
     })
     await client.connect()
     await client.query("CREATE TABLE IF NOT EXISTS users (username TEXT)")
@@ -23,7 +23,7 @@ test('Change schema', async () => {
 test('Query tables', async () => {
     const client = new Client({
         host: "127.0.0.1",
-        port: 5000,
+        port: 5432,
     })
     await client.connect()
     await client.query("CREATE TABLE IF NOT EXISTS users (username TEXT)")

--- a/testing/server/ruby/postgresql_spec.rb
+++ b/testing/server/ruby/postgresql_spec.rb
@@ -2,16 +2,16 @@ require "pg"
 
 describe "PostgreSQL client" do
   it "connects" do
-    conn = PG.connect(host: "127.0.0.1", port: 5000)
+    conn = PG.connect(host: "127.0.0.1", port: 5432)
   end
 
   it "performs schema changes" do
-    conn = PG.connect(host: "127.0.0.1", port: 5000)
+    conn = PG.connect(host: "127.0.0.1", port: 5432)
     conn.exec("CREATE TABLE IF NOT EXISTS users (username TEXT, pass TEXT)")
   end
 
   it "queries tables" do
-    conn = PG.connect(host: "127.0.0.1", port: 5000)
+    conn = PG.connect(host: "127.0.0.1", port: 5432)
     conn.exec("CREATE TABLE IF NOT EXISTS users (username TEXT, pass TEXT)")
     conn.exec("DELETE FROM users")
     conn.exec("INSERT INTO users VALUES ('me', 'my_pass')")


### PR DESCRIPTION
The postgres default port is 5432, so I suggest we default to the same, so that clients don't have to specify a port.