### PR TITLE
http: make the HTTP console opt-in

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -41,6 +41,7 @@ pub struct Config {
     pub tcp_addr: SocketAddr,
     pub ws_addr: Option<SocketAddr>,
     pub http_addr: Option<SocketAddr>,
+    pub enable_http_console: bool,
     pub backend: Backend,
     #[cfg(feature = "mwal_backend")]
     pub mwal_addr: Option<String>,
@@ -70,6 +71,7 @@ where
         let handle = tokio::spawn(http::run_http(
             addr,
             service.map_response(|s| Constant::new(s, 1)),
+            config.enable_http_console,
         ));
 
         handles.push(handle);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -47,6 +47,8 @@ struct Cli {
 
     #[clap(long, env = "SQLD_HTTP_LISTEN_ADDR")]
     http_listen_addr: Option<SocketAddr>,
+    #[clap(long)]
+    enable_http_console: bool,
 }
 
 impl From<Cli> for Config {
@@ -56,6 +58,7 @@ impl From<Cli> for Config {
             tcp_addr: cli.pg_listen_addr,
             ws_addr: cli.ws_listen_addr,
             http_addr: cli.http_listen_addr,
+            enable_http_console: cli.enable_http_console,
             backend: cli.backend,
             writer_rpc_addr: cli.primary_grpc_url,
             rpc_server_addr: cli.grpc_listen_addr,


### PR DESCRIPTION
From now on, unless explicitly enabled with --enable-http-console, the /console route serving the HTTP console will not be available.

Fixes #36