### PR TITLE
Full support for query parameters

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,7 +27,7 @@ pin-project-lite = "0.2.9"
 postgres-protocol = "0.6.4"
 prost = "0.11.3"
 regex = "1.7.0"
-rusqlite = { version = "0.28.0", features = [ "buildtime_bindgen", "column_decltype" ] }
+rusqlite = { version = "0.28.0", features = [ "buildtime_bindgen", "column_decltype", "modern_sqlite" ] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.91"
 smallvec = "1.10.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,7 +27,7 @@ pin-project-lite = "0.2.9"
 postgres-protocol = "0.6.4"
 prost = "0.11.3"
 regex = "1.7.0"
-rusqlite = { version = "0.28.0", features = [ "buildtime_bindgen", "column_decltype", "modern_sqlite" ] }
+rusqlite = { version = "0.28.0", features = [ "buildtime_bindgen", "column_decltype" ] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.91"
 smallvec = "1.10.0"

--- a/server/src/http/mod.rs
+++ b/server/src/http/mod.rs
@@ -15,7 +15,7 @@ use tower::balance::pool;
 use tower::load::Load;
 use tower::{service_fn, BoxError, MakeService, Service};
 
-use crate::query::{self, Queries, Query, QueryResponse, QueryResult, ResultSet};
+use crate::query::{self, Params, Queries, Query, QueryResponse, QueryResult, ResultSet};
 use crate::query_analysis::{final_state, State, Statement};
 
 impl TryFrom<query::Value> for serde_json::Value {
@@ -90,7 +90,7 @@ fn parse_queries(queries: Vec<String>) -> anyhow::Result<Vec<Query>> {
             .unwrap_or_default();
         let query = Query {
             stmt,
-            params: Vec::new(),
+            params: Params::new(),
         };
         out.push(query);
     }

--- a/server/src/http/mod.rs
+++ b/server/src/http/mod.rs
@@ -1,3 +1,5 @@
+mod types;
+
 use std::future::poll_fn;
 use std::{convert::Infallible, net::SocketAddr};
 
@@ -8,15 +10,17 @@ use hyper::body::to_bytes;
 use hyper::server::conn::AddrStream;
 use hyper::service::make_service_fn;
 use hyper::{Body, Method, Request, Response};
-use serde::Deserialize;
 use serde_json::{json, Number};
 use tokio::sync::{mpsc, oneshot};
 use tower::balance::pool;
 use tower::load::Load;
 use tower::{service_fn, BoxError, MakeService, Service};
 
+use crate::http::types::HttpQuery;
 use crate::query::{self, Params, Queries, Query, QueryResponse, QueryResult, ResultSet};
 use crate::query_analysis::{final_state, State, Statement};
+
+use self::types::QueryObject;
 
 impl TryFrom<query::Value> for serde_json::Value {
     type Error = anyhow::Error;
@@ -81,17 +85,18 @@ fn error(msg: &str, code: u16) -> Response<Body> {
         .unwrap()
 }
 
-fn parse_queries(queries: Vec<String>) -> anyhow::Result<Vec<Query>> {
+fn parse_queries(queries: Vec<QueryObject>) -> anyhow::Result<Vec<Query>> {
     let mut out = Vec::with_capacity(queries.len());
     for query in queries {
-        let stmt = Statement::parse(&query)
+        let stmt = Statement::parse(&query.q)
             .next()
             .transpose()?
             .unwrap_or_default();
         let query = Query {
             stmt,
-            params: Params::new(),
+            params: Params::new(query.params.inner),
         };
+
         out.push(query);
     }
 
@@ -116,7 +121,7 @@ async fn handle_query(
     sender: mpsc::Sender<Message>,
 ) -> anyhow::Result<Response<Body>> {
     let bytes = to_bytes(req.body_mut()).await?;
-    let req: HttpQueryRequest = serde_json::from_slice(&bytes)?;
+    let req: HttpQuery = serde_json::from_slice(&bytes)?;
     let (s, resp) = oneshot::channel();
 
     let queries = match parse_queries(req.statements) {
@@ -199,9 +204,4 @@ where
     server.await?;
 
     Ok(())
-}
-
-#[derive(Debug, Deserialize)]
-pub struct HttpQueryRequest {
-    statements: Vec<String>,
 }

--- a/server/src/http/types.rs
+++ b/server/src/http/types.rs
@@ -1,0 +1,214 @@
+use base64::prelude::BASE64_STANDARD_NO_PAD;
+use base64::Engine;
+use serde::de::Error as _;
+use serde::Deserialize;
+
+use crate::query;
+
+#[derive(Debug, Deserialize)]
+pub struct HttpQuery {
+    pub statements: Vec<QueryObject>,
+}
+
+#[derive(Debug)]
+pub struct QueryObject {
+    pub q: String,
+    pub params: QueryParams,
+}
+
+#[derive(Debug, Default)]
+pub struct QueryParams {
+    pub inner: Vec<(Option<String>, query::Value)>,
+}
+
+/// Wrapper type to deserialize a payload into a query::Value
+struct ValueDeserializer(query::Value);
+
+impl<'de> Deserialize<'de> for ValueDeserializer {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = query::Value;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a valid SQLite value")
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(query::Value::Null)
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(query::Value::Null)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(query::Value::Text(v))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(query::Value::Text(v.to_string()))
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(query::Value::Integer(v))
+            }
+
+            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(query::Value::Real(v))
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                match map.next_entry::<&str, &str>()? {
+                    Some((k, v)) => {
+                        if k == "blob" {
+                            // FIXME: If the blog payload is too big, it may block the main thread
+                            // for too long in an async context. In this case, it may be necessary
+                            // to offload deserialization to a separate thread.
+                            let data = BASE64_STANDARD_NO_PAD.decode(v).map_err(|e| {
+                                A::Error::invalid_value(
+                                    serde::de::Unexpected::Str(v),
+                                    &e.to_string().as_str(),
+                                )
+                            })?;
+
+                            Ok(query::Value::Blob(data))
+                        } else {
+                            Err(A::Error::unknown_field(k, &["blob"]))
+                        }
+                    }
+                    None => Err(A::Error::missing_field("blob")),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(Visitor).map(ValueDeserializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for QueryParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = QueryParams;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("an array or a map of parameters")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut inner = Vec::new();
+                while let Some(val) = seq.next_element::<ValueDeserializer>()? {
+                    inner.push((None, val.0));
+                }
+
+                Ok(QueryParams { inner })
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut inner = Vec::new();
+                while let Some((k, v)) = map.next_entry::<String, ValueDeserializer>()? {
+                    inner.push((Some(k), v.0))
+                }
+
+                Ok(QueryParams { inner })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for QueryObject {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = QueryObject;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string or an object")
+            }
+
+            fn visit_str<E>(self, q: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(QueryObject {
+                    q: q.to_string(),
+                    params: Default::default(),
+                })
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut q = None;
+                let mut params = None;
+                while let Some(k) = map.next_key::<&str>()? {
+                    match k {
+                        "q" => {
+                            if q.is_none() {
+                                q.replace(map.next_value::<String>()?);
+                            } else {
+                                return Err(A::Error::duplicate_field("q"));
+                            }
+                        }
+                        "params" => {
+                            if params.is_none() {
+                                params.replace(map.next_value::<QueryParams>()?);
+                            } else {
+                                return Err(A::Error::duplicate_field("params"));
+                            }
+                        }
+                        _ => return Err(A::Error::unknown_field(k, &["q", "params"])),
+                    }
+                }
+
+                Ok(QueryObject {
+                    q: q.ok_or_else(|| A::Error::missing_field("q"))?,
+                    params: params.unwrap_or_default(),
+                })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}

--- a/server/src/postgres/proto.rs
+++ b/server/src/postgres/proto.rs
@@ -66,7 +66,7 @@ where
             .map(|s| {
                 s.map(|stmt| Query {
                     stmt,
-                    params: Params::new(),
+                    params: Params::empty(),
                 })
             })
             .collect::<anyhow::Result<Vec<_>>>();
@@ -97,7 +97,6 @@ where
     {
         debug_assert_eq!(portal.parameter_types().len(), portal.parameter_len());
 
-        dbg!(portal.statement());
         let stmt = Statement::parse(portal.statement())
             .next()
             .transpose()
@@ -119,7 +118,7 @@ where
 }
 
 fn parse_params(types: &[Type], data: &[Option<Bytes>]) -> Params {
-    let mut params = Params::new();
+    let mut params = Params::empty();
     for (val, ty) in data.iter().zip(types) {
         let value = if val.is_none() {
             Value::Null

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -1,11 +1,13 @@
 use std::convert::Infallible;
-use std::fmt;
 use std::str::FromStr;
+use std::{fmt, usize};
 
 use futures::stream;
 use pgwire::api::results::{text_query_response, FieldInfo, Response, TextDataRowEncoder};
 use pgwire::api::Type as PgType;
 use pgwire::{error::PgWireResult, messages::data::DataRow};
+use rusqlite::types::ToSqlOutput;
+use rusqlite::ToSql;
 use serde::{Deserialize, Serialize};
 
 use crate::query_analysis::Statement;
@@ -123,18 +125,6 @@ pub enum Value {
     Real(f64),
     Text(String),
     Blob(Vec<u8>),
-}
-
-impl From<Value> for rusqlite::types::Value {
-    fn from(value: Value) -> Self {
-        match value {
-            Value::Null => Self::Null,
-            Value::Integer(i) => Self::Integer(i),
-            Value::Real(x) => Self::Real(x),
-            Value::Text(s) => Self::Text(s),
-            Value::Blob(b) => Self::Blob(b),
-        }
-    }
 }
 
 impl From<rusqlite::types::Value> for Value {
@@ -256,7 +246,72 @@ pub enum QueryResponse {
 #[derive(Debug)]
 pub struct Query {
     pub stmt: Statement,
-    pub params: Vec<Value>,
+    pub params: Params,
+}
+
+#[derive(Debug)]
+pub struct Params {
+    params: Vec<(Option<String>, Value)>,
+}
+
+impl ToSql for Value {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        let val = match self {
+            Value::Null => ToSqlOutput::Owned(rusqlite::types::Value::Null),
+            Value::Integer(i) => ToSqlOutput::Owned(rusqlite::types::Value::Integer(*i)),
+            Value::Real(x) => ToSqlOutput::Owned(rusqlite::types::Value::Real(*x)),
+            Value::Text(s) => ToSqlOutput::Borrowed(rusqlite::types::ValueRef::Text(s.as_bytes())),
+            Value::Blob(b) => ToSqlOutput::Borrowed(rusqlite::types::ValueRef::Blob(b)),
+        };
+
+        Ok(val)
+    }
+}
+
+impl Params {
+    pub fn new() -> Self {
+        Self { params: Vec::new() }
+    }
+
+    pub fn push(&mut self, name: Option<String>, value: Value) {
+        self.params.push((name, value));
+    }
+
+    fn get_name(&self, k: &str) -> Option<&Value> {
+        // posgres passes positional params with $NNN wheras sqlite expect a named param: https://www.sqlite.org/c3ref/bind_blob.html
+        if let Some(index) = k.strip_prefix("$").and_then(|s| s.parse::<usize>().ok()) {
+            return self.get_pos(index);
+        }
+        self.params.iter().find_map(|(name, val)| match name {
+            Some(name) if name == k => Some(val),
+            _ => None,
+        })
+    }
+
+    fn get_pos(&self, i: usize) -> Option<&Value> {
+        self.params.get(i - 1).map(|(_, val)| val)
+    }
+
+    pub fn bind(&self, stmt: &mut rusqlite::Statement) -> anyhow::Result<()> {
+        let param_count = stmt.parameter_count();
+        if param_count > 0 {
+            for index in 1..=param_count {
+                // get by name
+                if let Some(name) = stmt.parameter_name(index) {
+                    if let Some(val) = self.get_name(name) {
+                        stmt.raw_bind_parameter(index, val)?;
+                    }
+                } else {
+                    // get by pos
+                    if let Some(val) = self.get_pos(index) {
+                        stmt.raw_bind_parameter(index, val)?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 pub type Queries = Vec<Query>;

--- a/server/src/rpc/proxy.rs
+++ b/server/src/rpc/proxy.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::database::service::DbFactory;
 use crate::database::Database;
-use crate::query::Query;
+use crate::query::{Params, Query};
 use crate::query_analysis::Statement;
 use crate::rpc::proxy::proxy_rpc::execute_results::State;
 use proxy_rpc::proxy_server::Proxy;
@@ -157,7 +157,7 @@ where
                     .unwrap_or_default();
                 Query {
                     stmt,
-                    params: Vec::new(),
+                    params: Params::new(),
                 }
             })
             .collect();

--- a/server/src/rpc/proxy.rs
+++ b/server/src/rpc/proxy.rs
@@ -157,7 +157,7 @@ where
                     .unwrap_or_default();
                 Query {
                     stmt,
-                    params: Params::new(),
+                    params: Params::empty(),
                 }
             })
             .collect();


### PR DESCRIPTION
This PR introduces full support for query parameters. Both positional and named parameters are supported.

The supported syntax is the same as the one described in https://www.sqlite.org/c3ref/bind_blob.html.
Unbound parameters are interpreted as NULL.

## HTTP query parameters

Parameters can also be bound in http request. The syntax is quite flexible:

* Request without params:
```json
{
    "statements": ["select * from users where name = 'adhoc'"]
}
```
or (syntaxes can be mixed in the same array):
```json
{
    "statements": [{"q": "select * from users where name = 'adhoc'"}]
}
```

* Request with params:
- positional:
```json
{
    "statements": [
        {"q": "select * from users where name = ?", "params": ["adhoc"]},
        {"q": "select * from users where name = ?1", "params": ["adhoc"]},
        {"q": "select * from users where name = $1", "params": ["adhoc"]}
    ]
}
```

- named:
```json
{
    "statements": [
        {"q": "select * from users where name = $name", "params": {"name": "adhoc"}},
        {"q": "select * from users where name = :name", "params": {"name": "adhoc"}},
        {"q": "select * from users where name = @name", "params": {"name": "adhoc"}},
        {"q": "select * from users where name = $1", "params": {"name": "adhoc"}}, # object is order sensitive
        {"q": "select * from users where name = ?", "params": {"name": "adhoc"}},
    ]
}
```

### Handling of BLOB

BLOBS are handled as base64 encoded string (standards alphabet, no padding), and are nested into an object for disambiguition:
```json
{
    "statements": [
    {"q": "select * from users where name = $name", "params": {"name": {"blob": "984HG3e"}}},
                                                                  # some b64 blob --^
    ]
}
```
