### PR TITLE
adding ruby-devel for fedora, needed in testing

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -24,7 +24,8 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
       npm \
       protobuf-compiler \
       rubygem-bundler \
-      rubygem-sqlite3 
+      rubygem-sqlite3 \
+      ruby-devel
   else
     echo "Linux distribution $ID is not supported by this installer."
   fi


### PR DESCRIPTION
- Get following result with this one-liner addition on a Fedora 35 test box, before typing "make".

![image](https://user-images.githubusercontent.com/378638/213025923-39efe8bb-d9eb-437e-b453-c88e818850a4.png)
