### PR TITLE
docker-entrypoint.sh: Make listen addresses configurable

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,20 +4,24 @@ set -Eeuo pipefail
 
 SQLD_NODE="${SQLD_NODE:-primary}"
 
+SQLD_PG_LISTEN_ADDR="${SQLD_PG_LISTEN_ADDR:-"0.0.0.0:5432"}"
+SQLD_HTTP_LISTEN_ADDR="${SQLD_HTTP_LISTEN_ADDR:-"0.0.0.0:8080"}"
+SQLD_GRPC_LISTEN_ADDR="${SQLD_GRPC_LISTEN_ADDR:-"0.0.0.0:5001"}"
+
 if [ "$1" = '/bin/sqld' ]; then
   # We are running the server.
   declare -a server_args=()
 
   # Listen to PostgreSQL port by default.
-  server_args+=("--pg-listen-addr" "0.0.0.0:5432")
+  server_args+=("--pg-listen-addr" "$SQLD_PG_LISTEN_ADDR")
 
   # Listen on HTTP 8080 port by default.
-  server_args+=("--http-listen-addr" "0.0.0.0:8080")
+  server_args+=("--http-listen-addr" "$SQLD_HTTP_LISTEN_ADDR")
 
   # Set remaining arguments depending on what type of node we are.
   case "$SQLD_NODE" in
     primary)
-      server_args+=("--grpc-listen-addr" "0.0.0.0:5001")
+      server_args+=("--grpc-listen-addr" "$SQLD_GRPC_LISTEN_ADDR")
       ;;
     replica)
       server_args+=("--primary-grpc-url" "$SQLD_PRIMARY_URL")


### PR DESCRIPTION
Let's make the listen addresses configurable to give more flexibility at deployment time. For example, you might want to expose the PostgreSQL and HTTP services to public internet via IPv4, but use a cluster-private network for gRPC.