### PR TITLE
Dockerfile: use libSQL libraries exclusively

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ WORKDIR /sqld
 # prepare recipe
 FROM compiler AS planner
 COPY . .
+RUN cd libsql && ./configure --with-pic --enable-releasemode && make libsqlite3.la sqlite3.h
+RUN cp ./libsql/.libs/lib* /usr/lib/
+RUN cp ./libsql/sqlite3.h /usr/include
 RUN cargo chef prepare --recipe-path recipe.json
 
 # build sqld
@@ -20,6 +23,7 @@ RUN cargo build --release -p sqld
 # runtime
 FROM debian:bullseye-slim
 COPY --from=builder /sqld/target/release/sqld /bin/sqld
+COPY --from=builder /sqld/libsql/.libs/lib* /usr/lib/
 COPY docker-entrypoint.sh /usr/local/bin
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/sqld/src/database/write_proxy/replication.rs
+++ b/sqld/src/database/write_proxy/replication.rs
@@ -188,7 +188,11 @@ fn make_page_header<'a>(entries: impl Iterator<Item = &'a WalLogEntry>) -> *mut 
                 dirty: current_pg,
                 pager: std::ptr::null(),
                 pgno: *page_no,
+                page_hash: 0,
                 flags: 0,
+                n_ref: 0,
+                dirty_next: std::ptr::null_mut(),
+                dirty_prev: std::ptr::null_mut(),
             };
             headers_count += 1;
             current_pg = Box::into_raw(Box::new(page));

--- a/sqld/src/libsql/ffi/mod.rs
+++ b/sqld/src/libsql/ffi/mod.rs
@@ -161,7 +161,11 @@ pub struct PgHdr {
     pub dirty: *mut PgHdr,
     pub pager: *const c_void,
     pub pgno: u32,
+    pub page_hash: u32,
     pub flags: u16,
+    pub n_ref: u16,
+    pub dirty_next: *mut PgHdr,
+    pub dirty_prev: *mut PgHdr,
 }
 
 extern "C" {


### PR DESCRIPTION
The previous Dockerfile generated bindings from system's libsqlite3.so library. Let's use libSQL instead to ensure compatible bindings.