### PR TITLE
Add `--http-auth <AUTH>` command line option

### DIFF
--- a/sqld/src/http/auth.rs
+++ b/sqld/src/http/auth.rs
@@ -1,0 +1,54 @@
+use anyhow::{anyhow, Result};
+use hyper::{Body, Request};
+use std::sync::Arc;
+
+/// HTTP request authorizer.
+pub trait Authorizer {
+    fn is_authorized(&self, req: &Request<Body>) -> bool;
+}
+
+pub fn parse_auth(auth: Option<String>) -> Result<Arc<dyn Authorizer + Sync + Send>> {
+    match auth {
+        Some(auth) => match auth.split_once(':') {
+            Some((scheme, param)) => match scheme {
+                "basic" => Ok(Arc::new(BasicAuthAuthorizer {
+                    expected_auth: format!("Basic {}", param).to_lowercase(),
+                })),
+                _ => Err(anyhow!("unsupported HTTP auth scheme: {}", scheme)),
+            },
+            None if auth == "always" => Ok(Arc::new(AlwaysAllowAuthorizer {})),
+            None => Err(anyhow!("invalid HTTP auth config: {}", auth)),
+        },
+        None => Ok(Arc::new(AlwaysAllowAuthorizer {})),
+    }
+}
+
+/// An authorizer that always allows all requests.
+pub struct AlwaysAllowAuthorizer {}
+
+impl Authorizer for AlwaysAllowAuthorizer {
+    fn is_authorized(&self, _req: &Request<Body>) -> bool {
+        true
+    }
+}
+
+/// Basic authentication authorizer.
+pub struct BasicAuthAuthorizer {
+    // Expected value in `Authorization` header.
+    expected_auth: String,
+}
+
+impl Authorizer for BasicAuthAuthorizer {
+    fn is_authorized(&self, req: &Request<Body>) -> bool {
+        let headers = req.headers();
+        let actual_auth = headers.get(hyper::header::AUTHORIZATION);
+        if let Some(actual_auth) = actual_auth {
+            actual_auth
+                .to_str()
+                .map(|actual_auth| actual_auth.to_lowercase() == self.expected_auth)
+                .unwrap_or(false)
+        } else {
+            false
+        }
+    }
+}

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -43,6 +43,7 @@ pub struct Config {
     pub tcp_addr: SocketAddr,
     pub ws_addr: Option<SocketAddr>,
     pub http_addr: Option<SocketAddr>,
+    pub http_auth: Option<String>,
     pub enable_http_console: bool,
     pub backend: Backend,
     #[cfg(feature = "mwal_backend")]
@@ -70,8 +71,10 @@ where
     handles.push(tokio::spawn(server.serve(factory)));
 
     if let Some(addr) = config.http_addr {
+        let authorizer = http::auth::parse_auth(config.http_auth)?;
         let handle = tokio::spawn(http::run_http(
             addr,
+            authorizer,
             service.map_response(|s| Constant::new(s, 1)),
             config.enable_http_console,
         ));

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -47,6 +47,8 @@ struct Cli {
 
     #[clap(long, env = "SQLD_HTTP_LISTEN_ADDR")]
     http_listen_addr: Option<SocketAddr>,
+    #[clap(long, env = "SQLD_HTTP_AUTH")]
+    http_auth: Option<String>,
     #[clap(long)]
     enable_http_console: bool,
 }
@@ -58,6 +60,7 @@ impl From<Cli> for Config {
             tcp_addr: cli.pg_listen_addr,
             ws_addr: cli.ws_listen_addr,
             http_addr: cli.http_listen_addr,
+            http_auth: cli.http_auth,
             enable_http_console: cli.enable_http_console,
             backend: cli.backend,
             writer_rpc_addr: cli.primary_grpc_url,


### PR DESCRIPTION
This adds a `--http-auth <AUTH>` command line option to `sqld`. If it is enabled, HTTP requests are denied unless the authornization string matches. You can use the mechanism with basic authentication or OAuth bearer tokens.

For example, to configure basic authentication, run:

```console
cargo run -- --http-listen-addr 127.0.0.1:8080 --http-auth "Basic cGVuYmVyZzpwZW5iZXJn"
```

and then access the URL with:

```console
curl -i http://penberg:penberg@127.0.0.1:8080
```

Fixes #49