### PR TITLE
safe-guarded parameter binding

### DIFF
--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -47,7 +47,9 @@ fn execute_query(conn: &rusqlite::Connection, stmt: &Statement, params: Params) 
         })
         .collect::<Vec<_>>();
 
-    params.bind(&mut prepared).unwrap();
+    params
+        .bind(&mut prepared)
+        .map_err(|e| QueryError::new(ErrorCode::SQLError, e))?;
 
     let mut qresult = prepared.raw_query();
 

--- a/sqld/src/http/types.rs
+++ b/sqld/src/http/types.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use base64::prelude::BASE64_STANDARD_NO_PAD;
 use base64::Engine;
 use serde::de::Error as _;
@@ -18,7 +20,7 @@ pub struct QueryObject {
 
 #[derive(Debug, Default)]
 pub struct QueryParams {
-    pub inner: Vec<(Option<String>, query::Value)>,
+    pub inner: HashMap<String, query::Value>,
 }
 
 /// Wrapper type to deserialize a payload into a query::Value
@@ -127,9 +129,11 @@ impl<'de> Deserialize<'de> for QueryParams {
             where
                 A: serde::de::SeqAccess<'de>,
             {
-                let mut inner = Vec::new();
+                let mut inner = HashMap::new();
+                let mut index = 1;
                 while let Some(val) = seq.next_element::<ValueDeserializer>()? {
-                    inner.push((None, val.0));
+                    inner.insert(index.to_string(), val.0);
+                    index += 1;
                 }
 
                 Ok(QueryParams { inner })
@@ -139,9 +143,9 @@ impl<'de> Deserialize<'de> for QueryParams {
             where
                 A: serde::de::MapAccess<'de>,
             {
-                let mut inner = Vec::new();
+                let mut inner = HashMap::new();
                 while let Some((k, v)) = map.next_entry::<String, ValueDeserializer>()? {
-                    inner.push((Some(k), v.0))
+                    inner.insert(k, v.0);
                 }
 
                 Ok(QueryParams { inner })

--- a/sqld/src/postgres/proto.rs
+++ b/sqld/src/postgres/proto.rs
@@ -119,7 +119,7 @@ where
 
 fn parse_params(types: &[Type], data: &[Option<Bytes>]) -> Params {
     let mut params = Params::empty();
-    for (val, ty) in data.iter().zip(types) {
+    for (index, (val, ty)) in data.iter().zip(types).enumerate() {
         let value = if val.is_none() {
             Value::Null
         } else if ty == &Type::VARCHAR {
@@ -137,7 +137,7 @@ fn parse_params(types: &[Type], data: &[Option<Bytes>]) -> Params {
             unimplemented!("unsupported type")
         };
 
-        params.push(None, value);
+        params.push(index.to_string(), value);
     }
 
     params


### PR DESCRIPTION
This PR is an iteration on parameter bindings. It implements strictrrer rules for parameters binding.

- There can't be unspecified parameters
- There can't be unused parameters
- maps are not ordered, i.e, you need to refer to position if using a map:
```json
{
    "q": "SELECT * from users WHERE name = ?1 AND email = ?2",
    "params": {
        "1": "hello",
        "2": "blabla"
    }
}
```

- params prefix must match that of their use:

```json
{
    "q": "SELECT * from users WHERE name = :name AND email = $email",
    "params": {
        ":name": "hello",
        "$email": "blabla"
    }
}
```
in other word, this is not valid anymore:

```json
{
    "q": "SELECT * from users WHERE name = :name AND email = $email",
    "params": {
        "name": "hello",
        "email": "blabla"
    }
}
```

- Array syntax remains unchanged.
