### PR TITLE
Pass along top-level error messages

### DIFF
--- a/packages/libsql-client/src/lib/driver/HttpDriver.ts
+++ b/packages/libsql-client/src/lib/driver/HttpDriver.ts
@@ -32,7 +32,12 @@ export class HttpDriver implements Driver {
             }
             return resultSets;
         } else {
-            throw new Error(`${response.status} ${response.statusText}`)
+            const errorObj = await response.json();
+            if (typeof errorObj === "object" && "error" in errorObj) {
+                throw new Error(errorObj.error)
+            } else {
+                throw new Error(`${response.status} ${response.statusText}`)
+            }
         }
     }
 }


### PR DESCRIPTION
Handles cases where there are no result sets (such as SQL syntax errors)