### PR TITLE
bottomless: move to sqld/ tree

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "uuid_unstable"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg", "uuid_unstable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
  "futures",
  "tokio",
  "tracing",
- "uuid 1.2.2 (git+https://github.com/psarna/uuid?branch=stable_v7)",
+ "uuid 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,338 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-config"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7688e1dfbb9f7804fab0a830820d7e827b8d973906763cf1a855ce4719292f5"
+dependencies = [
+ "aws-http",
+ "aws-sdk-sso",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "hex",
+ "http",
+ "hyper",
+ "ring",
+ "time 0.3.17",
+ "tokio",
+ "tower",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-endpoint"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "253d7cd480bfa59a5323390e9e91885a8f06a275e0517d81eeb1070b6aa7d271"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "aws-types",
+ "http",
+ "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-http"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd1b83859383e46ea8fda633378f9f3f02e6e3a446fd89f0240b5c3662716c9"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "http-body",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4d240ff751efc65099d18f6b0fb80360b31a298cec7b392c511692bec4a6e21"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-client",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http",
+ "http-body",
+ "tokio-stream",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf03342c2b3f52b180f484e60586500765474f2bfc7dcd4ffe893a7a1929db1d"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1de4e07ea87a30a317c7b563b3a40fd18a843ad794216dda81672b6e174bce"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-query",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "http",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sig-auth"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6126c4ff918e35fb9ae1bf2de71157fad36f0cc6a2b1d0f7197ee711713700fc"
+dependencies = [
+ "aws-sigv4",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-types",
+ "http",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c7f88d7395f5411c6eef5889b6cd577ce6b677af461356cbfc20176c26c160"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "sha2 0.10.6",
+ "time 0.3.17",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6a895d68852dd1564328e63ef1583e5eb307dd2a5ebf35d862a5c402957d5e"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b847d960abc993319d77b52e82971e2bbdce94f6192df42142e14ed5c9c917"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc32c",
+ "crc32fast",
+ "hex",
+ "http",
+ "http-body",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2 0.10.6",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-client"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f505bf793eb3e6d7c166ef1275c27b4b2cd5361173fe950ac8e2cfc08c29a7ef"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "lazy_static",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751c99da757aecc1408ab6b2d65e9493220a5e7a68bcafa4f07b6fd1bc473f1"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e4b4304b7ea4af1af3e08535100eb7b6459d5a6264b92078bf85176d04ab85"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-tower"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86072ecc4dc4faf3e2071144285cfd539263fe7102b701d54fb991eafb04af8"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3ddd9275b167bc59e9446469eca56177ec0b51225632f90aaa2cd5f41c940e"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b19d2e0b3ce20e460bad0d0d974238673100edebba6978c2c1aadd925602f7"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987b1e37febb9bd409ca0846e82d35299e572ad8279bc404778caeb5fc05ad56"
+dependencies = [
+ "base64-simd",
+ "itoa",
+ "num-integer",
+ "ryu",
+ "time 0.3.17",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ce3791e14eec75ffac851a5a559f1ce6b31843297f42cc8bfba82714a6a5d8"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c05adca3e2bcf686dd2c47836f216ab52ed7845c177d180c84b08522c1166a3"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "http",
+ "rustc_version",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +545,15 @@ name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
+name = "base64-simd"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
+dependencies = [
+ "simd-abstraction",
+]
 
 [[package]]
 name = "base64ct"
@@ -303,6 +644,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "bottomless"
+version = "0.1.16"
+dependencies = [
+ "anyhow",
+ "async-compression",
+ "aws-config",
+ "aws-sdk-s3",
+ "bytes",
+ "crc",
+ "futures",
+ "tokio",
+ "tracing",
+ "uuid 1.2.2 (git+https://github.com/psarna/uuid?branch=stable_v7)",
+]
+
+[[package]]
+name = "bottomless-cli"
+version = "0.1.14"
+dependencies = [
+ "anyhow",
+ "aws-config",
+ "aws-sdk-s3",
+ "aws-smithy-types",
+ "bottomless",
+ "chrono",
+ "clap",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid 1.2.2 (git+https://github.com/psarna/uuid?branch=stable_v7)",
+]
+
+[[package]]
 name = "brotli"
 version = "3.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +733,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
+dependencies = [
+ "bytes",
+ "either",
 ]
 
 [[package]]
@@ -647,6 +1031,30 @@ dependencies = [
  "smallvec",
  "wasmparser",
  "wasmtime-types",
+]
+
+[[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
+name = "crc32c"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfea2db42e9927a3845fb268a10a72faed6d416065f77873f05e411457c363e"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -1306,6 +1714,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,7 +2176,7 @@ dependencies = [
  "tagptr",
  "thiserror",
  "triomphe",
- "uuid",
+ "uuid 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1819,7 +2243,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid",
+ "uuid 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1983,6 +2407,12 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "outref"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
 name = "overload"
@@ -2688,6 +3118,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,6 +3313,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2916,6 +3369,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simd-abstraction"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
+dependencies = [
+ "outref",
 ]
 
 [[package]]
@@ -3062,7 +3524,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "uuid",
+ "uuid 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vergen",
 ]
 
@@ -3648,6 +4110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3658,6 +4126,15 @@ name = "uuid"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+dependencies = [
+ "atomic",
+ "getrandom",
+]
+
+[[package]]
+name = "uuid"
+version = "1.2.2"
+source = "git+https://github.com/psarna/uuid?branch=stable_v7#c867632f6b962faa7fd19833888c2fc1102c3a2a"
 dependencies = [
  "atomic",
  "getrandom",
@@ -4076,6 +4553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
 name = "which"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4294,6 +4780,18 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
  "futures",
  "tokio",
  "tracing",
- "uuid 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid",
 ]
 
 [[package]]
@@ -673,7 +673,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid 1.2.2 (git+https://github.com/psarna/uuid?branch=stable_v7)",
+ "uuid",
 ]
 
 [[package]]
@@ -2176,7 +2176,7 @@ dependencies = [
  "tagptr",
  "thiserror",
  "triomphe",
- "uuid 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid",
 ]
 
 [[package]]
@@ -2243,7 +2243,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid",
 ]
 
 [[package]]
@@ -3524,7 +3524,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "uuid 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid",
  "vergen",
 ]
 
@@ -4123,18 +4123,9 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
-dependencies = [
- "atomic",
- "getrandom",
-]
-
-[[package]]
-name = "uuid"
-version = "1.2.2"
-source = "git+https://github.com/psarna/uuid?branch=stable_v7#c867632f6b962faa7fd19833888c2fc1102c3a2a"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "atomic",
  "getrandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -728,9 +728,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
  "serde",
 ]
@@ -778,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -810,7 +810,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.43",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -1145,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
+checksum = "322296e2f2e5af4270b54df9e85a02ff037e271af20ba3e7fe1575515dc840b8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1157,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
+checksum = "017a1385b05d631e7875b1f151c9f012d37b53491e2a87f65bff5c262b2111d8"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1172,15 +1172,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
+checksum = "c26bbb078acf09bc1ecda02d4223f03bdd28bd4874edcb0379138efc499ce971"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
+checksum = "357f40d1f06a24b60ae1fe122542c1fb05d28d32acb2aed064e84bc2ad1e252e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encoding_rs"
@@ -1402,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1417,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1427,15 +1427,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1444,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-lite"
@@ -1465,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1476,21 +1476,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2806,7 +2806,7 @@ dependencies = [
  "mach 0.3.2",
  "once_cell",
  "raw-cpuid",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -3219,9 +3219,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c4437699b6d34972de58652c68b98cb5b53a4199ab126db8e20ec8ded29a721"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3672,11 +3672,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -3724,9 +3725,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4124,8 +4125,7 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 [[package]]
 name = "uuid"
 version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+source = "git+https://github.com/psarna/uuid?branch=stable_v7#044e1f812d9ac9e1540b240c6815a5c006e82a57"
 dependencies = [
  "atomic",
  "getrandom",
@@ -4205,9 +4205,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -4805,9 +4805,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.5+zstd.1.5.2"
+version = "2.0.6+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc50ffce891ad571e9f9afe5039c4837bede781ac4bb13052ed7ae695518596"
+checksum = "68a3f9792c0c3dc6c165840a75f47ae1f4da402c2d006881129579f6597e801b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,13 @@
 [workspace]
 
 members = [
+    "bottomless",
+    "bottomless-cli",
+    "libsql-client",
+    "sqlc",
+    "sqld",
+]
+default-members = [
     "sqlc",
     "sqld",
     "libsql-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,3 @@ members = [
     "sqlc",
     "sqld",
 ]
-default-members = [
-    "sqlc",
-    "sqld",
-    "libsql-client",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ members = [
     "sqlc",
     "sqld",
 ]
+
+[patch.crates-io]
+uuid = { git = "https://github.com/psarna/uuid", branch = "stable_v7" }

--- a/bottomless-cli/Cargo.toml
+++ b/bottomless-cli/Cargo.toml
@@ -20,5 +20,4 @@ clap = { version = "4.0.29", features = ["derive"] }
 tokio = { version = "1.23.0", features = ["macros", "rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
-# FIXME: temporary measure until v7 uuid gets stable again
-uuid = { version = "1.2.2", git = "https://github.com/psarna/uuid", branch = "stable_v7", features = ["v7"] }
+uuid = { version = "1.3", features = ["v7"] }

--- a/bottomless-cli/Cargo.toml
+++ b/bottomless-cli/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "bottomless-cli"
+version = "0.1.14"
+edition = "2021"
+license = "MIT"
+keywords = ["libsql", "sqlite", "s3", "cli", "replication"]
+repository = "https://github.com/libsql/bottomless"
+description = "Command-line interface for bottomless replication for libSQL"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.66"
+aws-config = "0.52.0"
+aws-sdk-s3 = "0.22.0"
+aws-smithy-types = "0.52.0"
+bottomless = { version = "0", path = "../bottomless" }
+chrono = "0.4.23"
+clap = { version = "4.0.29", features = ["derive"] }
+tokio = { version = "1.23.0", features = ["macros", "rt", "rt-multi-thread"] }
+tracing = "0.1.37"
+tracing-subscriber = "0.3.16"
+# FIXME: temporary measure until v7 uuid gets stable again
+uuid = { version = "1.2.2", git = "https://github.com/psarna/uuid", branch = "stable_v7", features = ["v7"] }

--- a/bottomless-cli/src/main.rs
+++ b/bottomless-cli/src/main.rs
@@ -1,0 +1,150 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+mod replicator_extras;
+use replicator_extras::Replicator;
+
+#[derive(Debug, Parser)]
+#[command(name = "bottomless-cli")]
+#[command(about = "Bottomless CLI", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+    #[clap(long, short)]
+    endpoint: Option<String>,
+    #[clap(long, short)]
+    bucket: Option<String>,
+    #[clap(long, short)]
+    database: Option<String>,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    #[clap(about = "List available generations")]
+    Ls {
+        #[clap(long, short, long_help = "List details about single generation")]
+        generation: Option<uuid::Uuid>,
+        #[clap(
+            long,
+            short,
+            conflicts_with = "generation",
+            long_help = "List only <limit> newest generations"
+        )]
+        limit: Option<u64>,
+        #[clap(
+            long,
+            conflicts_with = "generation",
+            long_help = "List only generations older than given date"
+        )]
+        older_than: Option<chrono::NaiveDate>,
+        #[clap(
+            long,
+            conflicts_with = "generation",
+            long_help = "List only generations newer than given date"
+        )]
+        newer_than: Option<chrono::NaiveDate>,
+        #[clap(
+            long,
+            short,
+            long_help = "Print detailed information on each generation"
+        )]
+        verbose: bool,
+    },
+    #[clap(about = "Restore the database")]
+    Restore {
+        #[clap(
+            long,
+            short,
+            long_help = "Generation to restore from.\nSkip this parameter to restore from the newest generation."
+        )]
+        generation: Option<uuid::Uuid>,
+    },
+    #[clap(about = "Remove given generation from remote storage")]
+    Rm {
+        #[clap(long, short)]
+        generation: Option<uuid::Uuid>,
+        #[clap(
+            long,
+            conflicts_with = "generation",
+            long_help = "Remove generations older than given date"
+        )]
+        older_than: Option<chrono::NaiveDate>,
+        #[clap(long, short)]
+        verbose: bool,
+    },
+}
+
+async fn run() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    let options = Cli::parse();
+
+    if let Some(ep) = options.endpoint {
+        std::env::set_var("LIBSQL_BOTTOMLESS_ENDPOINT", ep)
+    }
+
+    if let Some(bucket) = options.bucket {
+        std::env::set_var("LIBSQL_BOTTOMLESS_BUCKET", bucket)
+    }
+
+    let mut client = Replicator::new().await?;
+
+    let database = match options.database {
+        Some(db) => db,
+        None => {
+            match client.detect_db().await {
+                Some(db) => db,
+                None => {
+                    println!("Could not autodetect the database. Please pass it explicitly with -d option");
+                    return Ok(());
+                }
+            }
+        }
+    };
+    tracing::info!("Database: {}", database);
+
+    client.register_db(database);
+
+    match options.command {
+        Commands::Ls {
+            generation,
+            limit,
+            older_than,
+            newer_than,
+            verbose,
+        } => match generation {
+            Some(gen) => client.list_generation(gen).await?,
+            None => {
+                client
+                    .list_generations(limit, older_than, newer_than, verbose)
+                    .await?
+            }
+        },
+        Commands::Restore { generation } => {
+            match generation {
+                Some(gen) => client.restore_from(gen).await?,
+                None => client.restore().await?,
+            };
+        }
+        Commands::Rm {
+            generation,
+            older_than,
+            verbose,
+        } => match (generation, older_than) {
+            (None, Some(older_than)) => client.remove_many(older_than, verbose).await?,
+            (Some(generation), None) => client.remove(generation, verbose).await?,
+            (Some(_), Some(_)) => unreachable!(),
+            (None, None) => println!(
+                "rm command cannot be run without parameters; see -h or --help for details"
+            ),
+        },
+    };
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(e) = run().await {
+        eprintln!("Error: {}", e);
+        std::process::exit(1)
+    }
+}

--- a/bottomless-cli/src/main.rs
+++ b/bottomless-cli/src/main.rs
@@ -144,7 +144,7 @@ async fn run() -> Result<()> {
 #[tokio::main]
 async fn main() {
     if let Err(e) = run().await {
-        eprintln!("Error: {}", e);
+        eprintln!("Error: {e}");
         std::process::exit(1)
     }
 }

--- a/bottomless-cli/src/replicator_extras.rs
+++ b/bottomless-cli/src/replicator_extras.rs
@@ -1,0 +1,294 @@
+use anyhow::Result;
+
+pub(crate) struct Replicator {
+    inner: bottomless::replicator::Replicator,
+}
+
+impl std::ops::Deref for Replicator {
+    type Target = bottomless::replicator::Replicator;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl std::ops::DerefMut for Replicator {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+fn uuid_to_datetime(uuid: &uuid::Uuid) -> chrono::NaiveDateTime {
+    let (seconds, nanos) = uuid
+        .get_timestamp()
+        .map(|ts| ts.to_unix())
+        .unwrap_or((0, 0));
+    let (seconds, nanos) = (253370761200 - seconds, 999000000 - nanos);
+    chrono::NaiveDateTime::from_timestamp_opt(seconds as i64, nanos)
+        .unwrap_or(chrono::NaiveDateTime::MIN)
+}
+
+impl Replicator {
+    pub(crate) async fn new() -> Result<Self> {
+        Ok(Self {
+            inner: bottomless::replicator::Replicator::new().await?,
+        })
+    }
+
+    pub(crate) async fn print_snapshot_summary(&self, generation: &uuid::Uuid) -> Result<()> {
+        match self
+            .client
+            .get_object_attributes()
+            .bucket(&self.bucket)
+            .key(format!("{}-{}/db.gz", self.db_name, generation))
+            .object_attributes(aws_sdk_s3::model::ObjectAttributes::ObjectSize)
+            .send()
+            .await
+        {
+            Ok(attrs) => {
+                println!("\tmain database snapshot:");
+                println!("\t\tobject size:   {}", attrs.object_size());
+                println!(
+                    "\t\tlast modified: {}",
+                    attrs
+                        .last_modified()
+                        .map(|s| s
+                            .fmt(aws_smithy_types::date_time::Format::DateTime)
+                            .unwrap_or_else(|e| e.to_string()))
+                        .as_deref()
+                        .unwrap_or("never")
+                );
+            }
+            Err(aws_sdk_s3::types::SdkError::ServiceError(err)) if err.err().is_no_such_key() => {
+                println!("\tno main database snapshot file found")
+            }
+            Err(e) => println!("\tfailed to fetch main database snapshot info: {}", e),
+        };
+        Ok(())
+    }
+
+    pub(crate) async fn list_generations(
+        &self,
+        limit: Option<u64>,
+        older_than: Option<chrono::NaiveDate>,
+        newer_than: Option<chrono::NaiveDate>,
+        verbose: bool,
+    ) -> Result<()> {
+        let mut next_marker = None;
+        let mut limit = limit.unwrap_or(u64::MAX);
+        loop {
+            let mut list_request = self
+                .client
+                .list_objects()
+                .bucket(&self.bucket)
+                .set_delimiter(Some("/".to_string()))
+                .prefix(&self.db_name);
+
+            if let Some(marker) = next_marker {
+                list_request = list_request.marker(marker)
+            }
+
+            if verbose {
+                println!("Database {}:", self.db_name);
+            }
+
+            let response = list_request.send().await?;
+            let prefixes = match response.common_prefixes() {
+                Some(prefixes) => prefixes,
+                None => {
+                    println!("No generations found");
+                    return Ok(());
+                }
+            };
+
+            for prefix in prefixes {
+                if let Some(prefix) = &prefix.prefix {
+                    let prefix = &prefix[self.db_name.len() + 1..prefix.len() - 1];
+                    let uuid = uuid::Uuid::try_parse(prefix)?;
+                    let datetime = uuid_to_datetime(&uuid);
+                    if datetime.date() < newer_than.unwrap_or(chrono::NaiveDate::MIN) {
+                        continue;
+                    }
+                    if datetime.date() > older_than.unwrap_or(chrono::NaiveDate::MAX) {
+                        continue;
+                    }
+                    println!("{}", uuid);
+                    if verbose {
+                        let counter = self.get_remote_change_counter(&uuid).await?;
+                        let (consistent_frame, checksum) =
+                            self.get_last_consistent_frame(&uuid).await?;
+                        println!("\tcreated at (UTC):     {}", datetime);
+                        println!("\tchange counter:       {:?}", counter);
+                        println!("\tconsistent WAL frame: {}", consistent_frame);
+                        println!("\tWAL frame checksum:   {:x}", checksum);
+                        self.print_snapshot_summary(&uuid).await?;
+                        println!()
+                    }
+                }
+                limit -= 1;
+                if limit == 0 {
+                    return Ok(());
+                }
+            }
+
+            next_marker = response.next_marker().map(|s| s.to_owned());
+            if next_marker.is_none() {
+                return Ok(());
+            }
+        }
+    }
+
+    pub(crate) async fn remove(&self, generation: uuid::Uuid, verbose: bool) -> Result<()> {
+        let mut removed = 0;
+        let mut next_marker = None;
+        loop {
+            let mut list_request = self
+                .client
+                .list_objects()
+                .bucket(&self.bucket)
+                .prefix(format!("{}-{}/", &self.db_name, generation));
+
+            if let Some(marker) = next_marker {
+                list_request = list_request.marker(marker)
+            }
+
+            let response = list_request.send().await?;
+            let objs = match response.contents() {
+                Some(prefixes) => prefixes,
+                None => {
+                    if verbose {
+                        println!("No objects found")
+                    }
+                    return Ok(());
+                }
+            };
+
+            for obj in objs {
+                if let Some(key) = obj.key() {
+                    if verbose {
+                        println!("Removing {}", key)
+                    }
+                    self.client
+                        .delete_object()
+                        .bucket(&self.bucket)
+                        .key(key)
+                        .send()
+                        .await?;
+                    removed += 1;
+                }
+            }
+
+            next_marker = response.next_marker().map(|s| s.to_owned());
+            if next_marker.is_none() {
+                if verbose {
+                    println!("Removed {} snapshot generations", removed);
+                }
+                return Ok(());
+            }
+        }
+    }
+
+    pub(crate) async fn remove_many(
+        &self,
+        older_than: chrono::NaiveDate,
+        verbose: bool,
+    ) -> Result<()> {
+        let mut next_marker = None;
+        let mut removed_count = 0;
+        loop {
+            let mut list_request = self
+                .client
+                .list_objects()
+                .bucket(&self.bucket)
+                .set_delimiter(Some("/".to_string()))
+                .prefix(&self.db_name);
+
+            if let Some(marker) = next_marker {
+                list_request = list_request.marker(marker)
+            }
+
+            let response = list_request.send().await?;
+            let prefixes = match response.common_prefixes() {
+                Some(prefixes) => prefixes,
+                None => {
+                    if verbose {
+                        println!("No generations found")
+                    }
+                    return Ok(());
+                }
+            };
+
+            for prefix in prefixes {
+                if let Some(prefix) = &prefix.prefix {
+                    let prefix = &prefix[self.db_name.len() + 1..prefix.len() - 1];
+                    let uuid = uuid::Uuid::try_parse(prefix)?;
+                    let datetime = uuid_to_datetime(&uuid);
+                    if datetime.date() >= older_than {
+                        continue;
+                    }
+                    if verbose {
+                        println!("Removing {}", uuid);
+                    }
+                    self.remove(uuid, verbose).await?;
+                    removed_count += 1;
+                }
+            }
+
+            next_marker = response.next_marker().map(|s| s.to_owned());
+            if next_marker.is_none() {
+                break;
+            }
+        }
+        if verbose {
+            println!("Removed {} generations", removed_count);
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn list_generation(&self, generation: uuid::Uuid) -> Result<()> {
+        self.client
+            .list_objects()
+            .bucket(&self.bucket)
+            .prefix(format!("{}-{}/", &self.db_name, generation))
+            .max_keys(1)
+            .send()
+            .await?
+            .contents()
+            .ok_or_else(|| {
+                anyhow::anyhow!("Generation {} not found for {}", generation, &self.db_name)
+            })?;
+
+        let counter = self.get_remote_change_counter(&generation).await?;
+        let (consistent_frame, checksum) = self.get_last_consistent_frame(&generation).await?;
+        println!("Generation {} for {}", generation, self.db_name);
+        println!("\tcreated at:           {}", uuid_to_datetime(&generation));
+        println!("\tchange counter:       {:?}", counter);
+        println!("\tconsistent WAL frame: {}", consistent_frame);
+        println!("\tWAL frame checksum:   {:x}", checksum);
+        self.print_snapshot_summary(&generation).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn detect_db(&self) -> Option<String> {
+        let response = match self
+            .client
+            .list_objects()
+            .bucket(&self.bucket)
+            .set_delimiter(Some("/".to_string()))
+            .prefix(&self.db_name)
+            .send()
+            .await
+        {
+            Ok(resp) => resp,
+            Err(_) => return None,
+        };
+
+        let prefix = response.common_prefixes()?.first()?.prefix()?;
+        // 38 is the length of the uuid part
+        if let Some('-') = prefix.chars().nth(prefix.len().saturating_sub(38)) {
+            Some(prefix[..prefix.len().saturating_sub(38)].to_owned())
+        } else {
+            None
+        }
+    }
+}

--- a/bottomless-cli/src/replicator_extras.rs
+++ b/bottomless-cli/src/replicator_extras.rs
@@ -62,7 +62,7 @@ impl Replicator {
             Err(aws_sdk_s3::types::SdkError::ServiceError(err)) if err.err().is_no_such_key() => {
                 println!("\tno main database snapshot file found")
             }
-            Err(e) => println!("\tfailed to fetch main database snapshot info: {}", e),
+            Err(e) => println!("\tfailed to fetch main database snapshot info: {e}"),
         };
         Ok(())
     }
@@ -112,15 +112,15 @@ impl Replicator {
                     if datetime.date() > older_than.unwrap_or(chrono::NaiveDate::MAX) {
                         continue;
                     }
-                    println!("{}", uuid);
+                    println!("{uuid}");
                     if verbose {
                         let counter = self.get_remote_change_counter(&uuid).await?;
                         let (consistent_frame, checksum) =
                             self.get_last_consistent_frame(&uuid).await?;
-                        println!("\tcreated at (UTC):     {}", datetime);
-                        println!("\tchange counter:       {:?}", counter);
-                        println!("\tconsistent WAL frame: {}", consistent_frame);
-                        println!("\tWAL frame checksum:   {:x}", checksum);
+                        println!("\tcreated at (UTC):     {datetime}");
+                        println!("\tchange counter:       {counter:?}");
+                        println!("\tconsistent WAL frame: {consistent_frame}");
+                        println!("\tWAL frame checksum:   {checksum:x}");
                         self.print_snapshot_summary(&uuid).await?;
                         println!()
                     }
@@ -166,7 +166,7 @@ impl Replicator {
             for obj in objs {
                 if let Some(key) = obj.key() {
                     if verbose {
-                        println!("Removing {}", key)
+                        println!("Removing {key}")
                     }
                     self.client
                         .delete_object()
@@ -181,7 +181,7 @@ impl Replicator {
             next_marker = response.next_marker().map(|s| s.to_owned());
             if next_marker.is_none() {
                 if verbose {
-                    println!("Removed {} snapshot generations", removed);
+                    println!("Removed {removed} snapshot generations");
                 }
                 return Ok(());
             }
@@ -227,7 +227,7 @@ impl Replicator {
                         continue;
                     }
                     if verbose {
-                        println!("Removing {}", uuid);
+                        println!("Removing {uuid}");
                     }
                     self.remove(uuid, verbose).await?;
                     removed_count += 1;
@@ -240,7 +240,7 @@ impl Replicator {
             }
         }
         if verbose {
-            println!("Removed {} generations", removed_count);
+            println!("Removed {removed_count} generations");
         }
         Ok(())
     }
@@ -262,9 +262,9 @@ impl Replicator {
         let (consistent_frame, checksum) = self.get_last_consistent_frame(&generation).await?;
         println!("Generation {} for {}", generation, self.db_name);
         println!("\tcreated at:           {}", uuid_to_datetime(&generation));
-        println!("\tchange counter:       {:?}", counter);
-        println!("\tconsistent WAL frame: {}", consistent_frame);
-        println!("\tWAL frame checksum:   {:x}", checksum);
+        println!("\tchange counter:       {counter:?}");
+        println!("\tconsistent WAL frame: {consistent_frame}");
+        println!("\tWAL frame checksum:   {checksum:x}");
         self.print_snapshot_summary(&generation).await?;
         Ok(())
     }

--- a/bottomless/Cargo.toml
+++ b/bottomless/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "bottomless"
+version = "0.1.16"
+edition = "2021"
+license = "MIT"
+keywords = ["libsql", "sqlite", "s3", "wal", "replication"]
+repository = "https://github.com/libsql/bottomless"
+description = "Bottomless replication for libSQL"
+
+[dependencies]
+anyhow = "1.0.66"
+async-compression = { version = "0.3.15", features = ["tokio", "gzip"] }
+aws-config = { version = "0.52.0" }
+aws-sdk-s3 = { version = "0.22.0" }
+bytes = "1"
+crc = "3.0.0"
+futures = { version = "0.3.25" }
+tokio = { version = "1.22.0", features = ["full"] }
+tracing = "0.1.37"
+uuid = { version = "1.2.2", features = ["v7"] }
+
+[features]
+libsql_linked_statically = []
+
+[lib]
+crate-type = ["rlib", "staticlib"]

--- a/bottomless/Cargo.toml
+++ b/bottomless/Cargo.toml
@@ -17,7 +17,7 @@ crc = "3.0.0"
 futures = { version = "0.3.25" }
 tokio = { version = "1.22.0", features = ["full"] }
 tracing = "0.1.37"
-uuid = { version = "1.2.2", features = ["v7"] }
+uuid = { version = "1.3", features = ["v7"] }
 
 [features]
 libsql_linked_statically = []

--- a/bottomless/src/ffi.rs
+++ b/bottomless/src/ffi.rs
@@ -1,0 +1,263 @@
+use std::ffi::c_void;
+
+pub const SQLITE_OK: i32 = 0;
+pub const SQLITE_CANTOPEN: i32 = 14;
+pub const SQLITE_IOERR_WRITE: i32 = 778;
+
+pub const SQLITE_CHECKPOINT_TRUNCATE: i32 = 3;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct sqlite3_file {
+    pub methods: *const sqlite3_io_methods,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct sqlite3_vfs {
+    iVersion: i32,
+    szOsFile: i32,
+    mxPathname: i32,
+    pNext: *mut sqlite3_vfs,
+    pub(crate) zName: *const i8,
+    pData: *const c_void,
+    xOpen: unsafe extern "C" fn(
+        vfs: *mut sqlite3_vfs,
+        name: *const i8,
+        file: *mut sqlite3_file,
+        flags: i32,
+        out_flags: *mut i32,
+    ) -> i32,
+    xDelete: unsafe extern "C" fn(vfs: *mut sqlite3_vfs, name: *const i8, sync_dir: i32) -> i32,
+    xAccess: unsafe extern "C" fn(
+        vfs: *mut sqlite3_vfs,
+        name: *const i8,
+        flags: i32,
+        res: *mut i32,
+    ) -> i32,
+    xFullPathname:
+        unsafe extern "C" fn(vfs: *mut sqlite3_vfs, name: *const i8, n: i32, out: *mut i8) -> i32,
+    xDlOpen: unsafe extern "C" fn(vfs: *mut sqlite3_vfs, name: *const i8) -> *const c_void,
+    xDlError: unsafe extern "C" fn(vfs: *mut sqlite3_vfs, n: i32, msg: *mut u8),
+    xDlSym: unsafe extern "C" fn(
+        vfs: *mut sqlite3_vfs,
+        arg: *mut c_void,
+        symbol: *const u8,
+    ) -> unsafe extern "C" fn(),
+    xDlClose: unsafe extern "C" fn(vfs: *mut sqlite3_vfs, arg: *mut c_void),
+    xRandomness: unsafe extern "C" fn(vfs: *mut sqlite3_vfs, n_bytes: i32, out: *mut u8) -> i32,
+    xSleep: unsafe extern "C" fn(vfs: *mut sqlite3_vfs, ms: i32) -> i32,
+    xCurrentTime: unsafe extern "C" fn(vfs: *mut sqlite3_vfs, time: *mut f64) -> i32,
+    xGetLastError: unsafe extern "C" fn(vfs: *mut sqlite3_vfs, n: i32, buf: *mut u8) -> i32,
+    xCurrentTimeInt64: unsafe extern "C" fn(vfs: *mut sqlite3_vfs, time: *mut i64) -> i32,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct sqlite3_io_methods {
+    iVersion: i32,
+    xClose: unsafe extern "C" fn(file_ptr: *mut sqlite3_file) -> i32,
+    xRead: unsafe extern "C" fn(file_ptr: *mut sqlite3_file, buf: *mut u8, n: i32, off: i64) -> i32,
+    xWrite:
+        unsafe extern "C" fn(file_ptr: *mut sqlite3_file, buf: *const u8, n: i32, off: i64) -> i32,
+    xTruncate: unsafe extern "C" fn(file_ptr: *mut sqlite3_file, size: i64) -> i32,
+    xSync: unsafe extern "C" fn(file_ptr: *mut sqlite3_file, flags: i32) -> i32,
+    pub xFileSize: unsafe extern "C" fn(file_ptr: *mut sqlite3_file, size: *mut i64) -> i32,
+    xLock: unsafe extern "C" fn(file_ptr: *mut sqlite3_file, lock: i32) -> i32,
+    xUnlock: unsafe extern "C" fn(file_ptr: *mut sqlite3_file, lock: i32) -> i32,
+    xCheckReservedLock: unsafe extern "C" fn(file_ptr: *mut sqlite3_file, res: *mut i32) -> i32,
+    xFileControl:
+        unsafe extern "C" fn(file_ptr: *mut sqlite3_file, op: i32, arg: *mut c_void) -> i32,
+    xSectorSize: unsafe extern "C" fn(file_ptr: *mut sqlite3_file) -> i32,
+    xDeviceCharacteristics: unsafe extern "C" fn(file_ptr: *mut sqlite3_file) -> i32,
+    /* v2
+    xShmMap: unsafe extern "C" fn(
+        file_ptr: *mut sqlite3_file,
+        pgno: i32,
+        pgsize: i32,
+        arg: i32,
+        addr: *mut *mut c_void,
+    ) -> i32,
+    xShmLock:
+        unsafe extern "C" fn(file_ptr: *mut sqlite3_file, offset: i32, n: i32, flags: i32) -> i32,
+    xShmBarrier: unsafe extern "C" fn(file_ptr: *mut sqlite3_file),
+    xShmUnmap: unsafe extern "C" fn(file_ptr: *mut sqlite3_file, delete_flag: i32) -> i32,
+    // v3
+    xFetch: unsafe extern "C" fn(
+        file_ptr: *mut sqlite3_file,
+        off: i64,
+        n: i32,
+        addr: *mut *mut c_void,
+    ) -> i32,
+    xUnfetch:
+        unsafe extern "C" fn(file_ptr: *mut sqlite3_file, off: i64, addr: *mut c_void) -> i32,
+    */
+}
+
+#[repr(C)]
+pub struct Wal {
+    vfs: *const sqlite3_vfs,
+    db_fd: *mut sqlite3_file,
+    pub wal_fd: *mut sqlite3_file,
+    callback_value: u32,
+    max_wal_size: i64,
+    wi_data: i32,
+    size_first_block: i32,
+    ap_wi_data: *const *mut u32,
+    page_size: u32,
+    read_lock: i16,
+    sync_flags: u8,
+    exclusive_mode: u8,
+    write_lock: u8,
+    checkpoint_lock: u8,
+    read_only: u8,
+    truncate_on_commit: u8,
+    sync_header: u8,
+    pad_to_section_boundary: u8,
+    b_shm_unreliable: u8,
+    pub(crate) hdr: WalIndexHdr,
+    min_frame: u32,
+    recalculate_checksums: u32,
+    wal_name: *const i8,
+    n_checkpoints: u32,
+    lock_error: u8,
+    p_snapshot: *const c_void,
+    p_db: *const c_void,
+    pub wal_methods: *mut libsql_wal_methods,
+    pub replicator_context: *mut crate::replicator::Context,
+}
+
+#[repr(C)]
+pub struct WalIndexHdr {
+    version: u32,
+    unused: u32,
+    change: u32,
+    is_init: u8,
+    big_endian_checksum: u8,
+    page_size: u16,
+    pub(crate) last_valid_frame: u32,
+    n_pages: u32,
+    pub(crate) frame_checksum: [u32; 2],
+    salt: [u32; 2],
+    checksum: [u32; 2],
+}
+
+#[repr(C)]
+pub struct libsql_wal_methods {
+    pub iVersion: i32,
+    pub xOpen: extern "C" fn(
+        vfs: *const sqlite3_vfs,
+        file: *mut sqlite3_file,
+        wal_name: *const i8,
+        no_shm_mode: i32,
+        max_size: i64,
+        methods: *mut libsql_wal_methods,
+        wal: *mut *mut Wal,
+    ) -> i32,
+    pub xClose: extern "C" fn(
+        wal: *mut Wal,
+        db: *mut c_void,
+        sync_flags: i32,
+        n_buf: i32,
+        z_buf: *mut u8,
+    ) -> i32,
+    pub xLimit: extern "C" fn(wal: *mut Wal, limit: i64),
+    pub xBeginReadTransaction: extern "C" fn(wal: *mut Wal, changed: *mut i32) -> i32,
+    pub xEndReadTransaction: extern "C" fn(wal: *mut Wal) -> i32,
+    pub xFindFrame: extern "C" fn(wal: *mut Wal, pgno: i32, frame: *mut i32) -> i32,
+    pub xReadFrame: extern "C" fn(wal: *mut Wal, frame: u32, n_out: i32, p_out: *mut u8) -> i32,
+    pub xDbSize: extern "C" fn(wal: *mut Wal) -> i32,
+    pub xBeginWriteTransaction: extern "C" fn(wal: *mut Wal) -> i32,
+    pub xEndWriteTransaction: extern "C" fn(wal: *mut Wal) -> i32,
+    pub xUndo: extern "C" fn(
+        wal: *mut Wal,
+        func: extern "C" fn(*mut c_void, i32) -> i32,
+        ctx: *mut c_void,
+    ) -> i32,
+    pub xSavepoint: extern "C" fn(wal: *mut Wal, wal_data: *mut u32),
+    pub xSavepointUndo: extern "C" fn(wal: *mut Wal, wal_data: *mut u32) -> i32,
+    pub xFrames: extern "C" fn(
+        wal: *mut Wal,
+        page_size: u32,
+        page_headers: *const PgHdr,
+        size_after: u32,
+        is_commit: i32,
+        sync_flags: i32,
+    ) -> i32,
+    pub xCheckpoint: extern "C" fn(
+        wal: *mut Wal,
+        db: *mut c_void,
+        emode: i32,
+        busy_handler: extern "C" fn(busy_param: *mut c_void) -> i32,
+        busy_arg: *const c_void,
+        sync_flags: i32,
+        n_buf: i32,
+        z_buf: *mut u8,
+        frames_in_wal: *mut i32,
+        backfilled_frames: *mut i32,
+    ) -> i32,
+    pub xCallback: extern "C" fn(wal: *mut Wal) -> i32,
+    pub xExclusiveMode: extern "C" fn(wal: *mut Wal) -> i32,
+    pub xHeapMemory: extern "C" fn(wal: *mut Wal) -> i32,
+    // snapshot stubs
+    pub snapshot_get_stub: *const c_void,
+    pub snapshot_open_stub: *const c_void,
+    pub snapshot_recover_stub: *const c_void,
+    pub snapshot_check_stub: *const c_void,
+    pub snapshot_unlock_stub: *const c_void,
+    pub framesize_stub: *const c_void, // enable_zipvfs stub
+    pub xFile: extern "C" fn(wal: *mut Wal) -> *const c_void,
+    pub write_lock_stub: *const c_void, // setlk stub
+    pub xDb: extern "C" fn(wal: *mut Wal, db: *const c_void),
+    pub xPathnameLen: extern "C" fn(orig_len: i32) -> i32,
+    pub xGetPathname: extern "C" fn(buf: *mut u8, orig: *const u8, orig_len: i32),
+    pub xPreMainDbOpen: extern "C" fn(methods: *mut libsql_wal_methods, path: *const i8) -> i32,
+    pub b_uses_shm: i32,
+    pub name: *const u8,
+    pub p_next: *const c_void,
+
+    // User data
+    pub underlying_methods: *const libsql_wal_methods,
+}
+
+#[repr(C)]
+pub struct PgHdr {
+    page: *const c_void,
+    data: *const c_void,
+    extra: *const c_void,
+    pcache: *const c_void,
+    dirty: *const PgHdr,
+    pager: *const c_void,
+    pgno: i32,
+    flags: u16,
+}
+
+pub(crate) struct PageHdrIter {
+    current_ptr: *const PgHdr,
+    page_size: usize,
+}
+
+impl PageHdrIter {
+    pub fn new(current_ptr: *const PgHdr, page_size: usize) -> Self {
+        Self {
+            current_ptr,
+            page_size,
+        }
+    }
+}
+
+impl std::iter::Iterator for PageHdrIter {
+    type Item = (i32, &'static [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_ptr.is_null() {
+            return None;
+        }
+        let current_hdr: &PgHdr = unsafe { &*self.current_ptr };
+        let raw_data =
+            unsafe { std::slice::from_raw_parts(current_hdr.data as *const u8, self.page_size) };
+        let item = Some((current_hdr.pgno, raw_data));
+        self.current_ptr = current_hdr.dirty;
+        item
+    }
+}

--- a/bottomless/src/lib.rs
+++ b/bottomless/src/lib.rs
@@ -1,0 +1,564 @@
+#![allow(non_snake_case)]
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+#![allow(improper_ctypes)]
+
+mod ffi;
+
+pub mod replicator;
+
+use crate::ffi::{libsql_wal_methods, sqlite3_file, sqlite3_vfs, PgHdr, Wal};
+use std::ffi::c_void;
+
+// Just heuristics, but should work for ~100% of cases
+fn is_regular(vfs: *const sqlite3_vfs) -> bool {
+    let vfs = unsafe { std::ffi::CStr::from_ptr((*vfs).zName) }
+        .to_str()
+        .unwrap_or("[error]");
+    tracing::trace!("VFS: {}", vfs);
+    vfs.starts_with("unix") || vfs.starts_with("win32")
+}
+
+macro_rules! block_on {
+    ($runtime:expr, $e:expr) => {
+        $runtime.block_on(async { $e.await })
+    };
+}
+
+fn is_local() -> bool {
+    std::env::var("LIBSQL_BOTTOMLESS_LOCAL").map_or(false, |local| {
+        local.eq_ignore_ascii_case("true")
+            || local.eq_ignore_ascii_case("t")
+            || local.eq_ignore_ascii_case("yes")
+            || local.eq_ignore_ascii_case("y")
+            || local == "1"
+    })
+}
+
+pub extern "C" fn xOpen(
+    vfs: *const sqlite3_vfs,
+    db_file: *mut sqlite3_file,
+    wal_name: *const i8,
+    no_shm_mode: i32,
+    max_size: i64,
+    methods: *mut libsql_wal_methods,
+    wal: *mut *mut Wal,
+) -> i32 {
+    tracing::debug!("Opening WAL {}", unsafe {
+        std::ffi::CStr::from_ptr(wal_name).to_str().unwrap()
+    });
+
+    let orig_methods = unsafe { &*(*methods).underlying_methods };
+    let rc = (orig_methods.xOpen)(vfs, db_file, wal_name, no_shm_mode, max_size, methods, wal);
+    if rc != ffi::SQLITE_OK {
+        return rc;
+    }
+
+    if !is_regular(vfs) {
+        tracing::error!("Bottomless WAL is currently only supported for regular VFS");
+        return ffi::SQLITE_CANTOPEN;
+    }
+
+    if is_local() {
+        tracing::info!("Running in local-mode only, without any replication");
+        return ffi::SQLITE_OK;
+    }
+
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            tracing::error!("Failed to initialize async runtime: {}", e);
+            return ffi::SQLITE_CANTOPEN;
+        }
+    };
+
+    let replicator = block_on!(runtime, replicator::Replicator::new());
+    let mut replicator = match replicator {
+        Ok(repl) => repl,
+        Err(e) => {
+            tracing::error!("Failed to initialize replicator: {}", e);
+            return ffi::SQLITE_CANTOPEN;
+        }
+    };
+
+    let path = unsafe {
+        match std::ffi::CStr::from_ptr(wal_name).to_str() {
+            Ok(path) if path.len() >= 4 => &path[..path.len() - 4],
+            Ok(path) => path,
+            Err(e) => {
+                tracing::error!("Failed to parse the main database path: {}", e);
+                return ffi::SQLITE_CANTOPEN;
+            }
+        }
+    };
+
+    replicator.register_db(path);
+    let rc = block_on!(runtime, try_restore(&mut replicator));
+    if rc != ffi::SQLITE_OK {
+        return rc;
+    }
+
+    let context = replicator::Context {
+        replicator,
+        runtime,
+    };
+    unsafe { (*(*wal)).replicator_context = Box::leak(Box::new(context)) };
+
+    ffi::SQLITE_OK
+}
+
+fn get_orig_methods(wal: *mut Wal) -> &'static libsql_wal_methods {
+    unsafe { &*((*(*wal).wal_methods).underlying_methods) }
+}
+
+fn get_replicator_context(wal: *mut Wal) -> &'static mut replicator::Context {
+    unsafe { &mut *((*wal).replicator_context) }
+}
+
+pub extern "C" fn xClose(
+    wal: *mut Wal,
+    db: *mut c_void,
+    sync_flags: i32,
+    n_buf: i32,
+    z_buf: *mut u8,
+) -> i32 {
+    tracing::debug!("Closing wal");
+    let orig_methods = get_orig_methods(wal);
+    if !is_local() {
+        let _replicator_box = unsafe { Box::from_raw((*wal).replicator_context) };
+    }
+
+    (orig_methods.xClose)(wal, db, sync_flags, n_buf, z_buf)
+}
+
+pub extern "C" fn xLimit(wal: *mut Wal, limit: i64) {
+    let orig_methods = get_orig_methods(wal);
+    (orig_methods.xLimit)(wal, limit)
+}
+
+pub extern "C" fn xBeginReadTransaction(wal: *mut Wal, changed: *mut i32) -> i32 {
+    let orig_methods = get_orig_methods(wal);
+    (orig_methods.xBeginReadTransaction)(wal, changed)
+}
+
+pub extern "C" fn xEndReadTransaction(wal: *mut Wal) -> i32 {
+    let orig_methods = get_orig_methods(wal);
+    (orig_methods.xEndReadTransaction)(wal)
+}
+
+pub extern "C" fn xFindFrame(wal: *mut Wal, pgno: i32, frame: *mut i32) -> i32 {
+    let orig_methods = get_orig_methods(wal);
+    (orig_methods.xFindFrame)(wal, pgno, frame)
+}
+
+pub extern "C" fn xReadFrame(wal: *mut Wal, frame: u32, n_out: i32, p_out: *mut u8) -> i32 {
+    let orig_methods = get_orig_methods(wal);
+    (orig_methods.xReadFrame)(wal, frame, n_out, p_out)
+}
+
+pub extern "C" fn xDbSize(wal: *mut Wal) -> i32 {
+    let orig_methods = get_orig_methods(wal);
+    (orig_methods.xDbSize)(wal)
+}
+
+pub extern "C" fn xBeginWriteTransaction(wal: *mut Wal) -> i32 {
+    let orig_methods = get_orig_methods(wal);
+    (orig_methods.xBeginWriteTransaction)(wal)
+}
+
+pub extern "C" fn xEndWriteTransaction(wal: *mut Wal) -> i32 {
+    let orig_methods = get_orig_methods(wal);
+    (orig_methods.xEndWriteTransaction)(wal)
+}
+
+pub extern "C" fn xUndo(
+    wal: *mut Wal,
+    func: extern "C" fn(*mut c_void, i32) -> i32,
+    ctx: *mut c_void,
+) -> i32 {
+    let orig_methods = get_orig_methods(wal);
+    let rc = (orig_methods.xUndo)(wal, func, ctx);
+    if is_local() || rc != ffi::SQLITE_OK {
+        return rc;
+    }
+
+    let last_valid_frame = unsafe { (*wal).hdr.last_valid_frame };
+    let ctx = get_replicator_context(wal);
+    tracing::trace!(
+        "Undo: rolling back from frame {} to {}",
+        ctx.replicator.peek_last_valid_frame(),
+        last_valid_frame
+    );
+    ctx.replicator.rollback_to_frame(last_valid_frame);
+
+    ffi::SQLITE_OK
+}
+
+pub extern "C" fn xSavepoint(wal: *mut Wal, wal_data: *mut u32) {
+    let orig_methods = get_orig_methods(wal);
+    (orig_methods.xSavepoint)(wal, wal_data)
+}
+
+pub extern "C" fn xSavepointUndo(wal: *mut Wal, wal_data: *mut u32) -> i32 {
+    let orig_methods = get_orig_methods(wal);
+    let rc = (orig_methods.xSavepointUndo)(wal, wal_data);
+    if is_local() || rc != ffi::SQLITE_OK {
+        return rc;
+    }
+
+    let last_valid_frame = unsafe { *wal_data };
+    let ctx = get_replicator_context(wal);
+    tracing::trace!(
+        "Savepoint: rolling back from frame {} to {}",
+        ctx.replicator.peek_last_valid_frame(),
+        last_valid_frame
+    );
+    ctx.replicator.rollback_to_frame(last_valid_frame);
+
+    ffi::SQLITE_OK
+}
+
+pub extern "C" fn xFrames(
+    wal: *mut Wal,
+    page_size: u32,
+    page_headers: *const PgHdr,
+    size_after: u32,
+    is_commit: i32,
+    sync_flags: i32,
+) -> i32 {
+    let mut last_consistent_frame = 0;
+    if !is_local() {
+        let ctx = get_replicator_context(wal);
+        let last_valid_frame = unsafe { (*wal).hdr.last_valid_frame };
+        ctx.replicator.register_last_valid_frame(last_valid_frame);
+        // In theory it's enough to set the page size only once, but in practice
+        // it's a very cheap operation anyway, and the page is not always known
+        // upfront and can change dynamically.
+        // FIXME: changing the page size in the middle of operation is *not*
+        // supported by bottomless storage.
+        if let Err(e) = ctx.replicator.set_page_size(page_size as usize) {
+            tracing::error!("{}", e);
+            return ffi::SQLITE_IOERR_WRITE;
+        }
+        for (pgno, data) in ffi::PageHdrIter::new(page_headers, page_size as usize) {
+            ctx.replicator.write(pgno, data);
+        }
+
+        // TODO: flushing can be done even if is_commit == 0, in order to drain
+        // the local cache and free its memory. However, that complicates rollbacks (xUndo),
+        // because the flushed-but-not-committed pages should be removed from the remote
+        // location. It's not complicated, but potentially costly in terms of latency,
+        // so for now it is not yet implemented.
+        if is_commit != 0 {
+            last_consistent_frame = match block_on!(ctx.runtime, ctx.replicator.flush()) {
+                Ok(frame) => frame,
+                Err(e) => {
+                    tracing::error!("Failed to replicate: {}", e);
+                    return ffi::SQLITE_IOERR_WRITE;
+                }
+            };
+        }
+    }
+
+    let orig_methods = get_orig_methods(wal);
+    let rc = (orig_methods.xFrames)(
+        wal,
+        page_size,
+        page_headers,
+        size_after,
+        is_commit,
+        sync_flags,
+    );
+    if is_local() || rc != ffi::SQLITE_OK {
+        return rc;
+    }
+
+    let ctx = get_replicator_context(wal);
+    if is_commit != 0 {
+        let frame_checksum = unsafe { (*wal).hdr.frame_checksum };
+
+        if let Err(e) = block_on!(
+            ctx.runtime,
+            ctx.replicator
+                .finalize_commit(last_consistent_frame, frame_checksum)
+        ) {
+            tracing::error!("Failed to finalize replication: {}", e);
+            return ffi::SQLITE_IOERR_WRITE;
+        }
+    }
+
+    ffi::SQLITE_OK
+}
+
+extern "C" fn always_wait(_busy_param: *mut c_void) -> i32 {
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    1
+}
+
+#[tracing::instrument(skip(wal, db, busy_handler, busy_arg))]
+pub extern "C" fn xCheckpoint(
+    wal: *mut Wal,
+    db: *mut c_void,
+    emode: i32,
+    busy_handler: extern "C" fn(busy_param: *mut c_void) -> i32,
+    busy_arg: *const c_void,
+    sync_flags: i32,
+    n_buf: i32,
+    z_buf: *mut u8,
+    frames_in_wal: *mut i32,
+    backfilled_frames: *mut i32,
+) -> i32 {
+    tracing::trace!("Checkpoint");
+
+    /* In order to avoid partial checkpoints, passive checkpoint
+     ** mode is not allowed. Only TRUNCATE checkpoints are accepted,
+     ** because these are guaranteed to block writes, copy all WAL pages
+     ** back into the main database file and reset the frame number.
+     ** In order to make this mechanism work smoothly with the final
+     ** checkpoint on WAL close as well as default autocheckpoints,
+     ** the mode is unconditionally upgraded to SQLITE_CHECKPOINT_TRUNCATE.
+     ** An alternative to consider is to just refuse weaker checkpoints.
+     */
+    let emode = if emode < ffi::SQLITE_CHECKPOINT_TRUNCATE {
+        tracing::trace!("Upgrading checkpoint to TRUNCATE mode");
+        ffi::SQLITE_CHECKPOINT_TRUNCATE
+    } else {
+        emode
+    };
+    /* If there's no busy handler, let's provide a default one,
+     ** since we auto-upgrade the passive checkpoint
+     */
+    let busy_handler = if (busy_handler as *const c_void).is_null() {
+        tracing::trace!("Falling back to the default busy handler - always wait");
+        always_wait
+    } else {
+        busy_handler
+    };
+
+    let orig_methods = get_orig_methods(wal);
+    let rc = (orig_methods.xCheckpoint)(
+        wal,
+        db,
+        emode,
+        busy_handler,
+        busy_arg,
+        sync_flags,
+        n_buf,
+        z_buf,
+        frames_in_wal,
+        backfilled_frames,
+    );
+
+    if is_local() || rc != ffi::SQLITE_OK {
+        return rc;
+    }
+
+    let ctx = get_replicator_context(wal);
+    if ctx.replicator.commits_in_current_generation == 0 {
+        tracing::debug!("No commits happened in this generation, not snapshotting");
+        return ffi::SQLITE_OK;
+    }
+
+    ctx.replicator.new_generation();
+    tracing::debug!("Snapshotting after checkpoint");
+    let result = block_on!(ctx.runtime, ctx.replicator.snapshot_main_db_file());
+    if let Err(e) = result {
+        tracing::error!(
+            "Failed to snapshot the main db file during checkpoint: {}",
+            e
+        );
+        return ffi::SQLITE_IOERR_WRITE;
+    }
+
+    ffi::SQLITE_OK
+}
+
+pub extern "C" fn xCallback(wal: *mut Wal) -> i32 {
+    let orig_methods = get_orig_methods(wal);
+    (orig_methods.xCallback)(wal)
+}
+
+pub extern "C" fn xExclusiveMode(wal: *mut Wal) -> i32 {
+    let orig_methods = get_orig_methods(wal);
+    (orig_methods.xExclusiveMode)(wal)
+}
+
+pub extern "C" fn xHeapMemory(wal: *mut Wal) -> i32 {
+    let orig_methods = get_orig_methods(wal);
+    (orig_methods.xHeapMemory)(wal)
+}
+
+pub extern "C" fn xFile(wal: *mut Wal) -> *const c_void {
+    let orig_methods = get_orig_methods(wal);
+    (orig_methods.xFile)(wal)
+}
+
+pub extern "C" fn xDb(wal: *mut Wal, db: *const c_void) {
+    let orig_methods = get_orig_methods(wal);
+    (orig_methods.xDb)(wal, db)
+}
+
+pub extern "C" fn xPathnameLen(orig_len: i32) -> i32 {
+    orig_len + 4
+}
+
+pub extern "C" fn xGetPathname(buf: *mut u8, orig: *const u8, orig_len: i32) {
+    unsafe { std::ptr::copy(orig, buf, orig_len as usize) }
+    unsafe { std::ptr::copy("-wal".as_ptr(), buf.offset(orig_len as isize), 4) }
+}
+
+async fn try_restore(replicator: &mut replicator::Replicator) -> i32 {
+    match replicator.restore().await {
+        Ok(replicator::RestoreAction::None) => (),
+        Ok(replicator::RestoreAction::SnapshotMainDbFile) => {
+            replicator.new_generation();
+            if let Err(e) = replicator.snapshot_main_db_file().await {
+                tracing::error!("Failed to snapshot the main db file: {}", e);
+                return ffi::SQLITE_CANTOPEN;
+            }
+            // Restoration process only leaves the local WAL file if it was
+            // detected to be newer than its remote counterpart.
+            if let Err(e) = replicator.maybe_replicate_wal().await {
+                tracing::error!("Failed to replicate local WAL: {}", e);
+                return ffi::SQLITE_CANTOPEN;
+            }
+        }
+        Ok(replicator::RestoreAction::ReuseGeneration(gen)) => {
+            replicator.set_generation(gen);
+        }
+        Err(e) => {
+            tracing::error!("Failed to restore the database: {}", e);
+            return ffi::SQLITE_CANTOPEN;
+        }
+    }
+
+    ffi::SQLITE_OK
+}
+
+pub extern "C" fn xPreMainDbOpen(_methods: *mut libsql_wal_methods, path: *const i8) -> i32 {
+    if is_local() {
+        tracing::info!("Running in local-mode only, without any replication");
+        return ffi::SQLITE_OK;
+    }
+
+    if path.is_null() {
+        return ffi::SQLITE_OK;
+    }
+    let path = unsafe {
+        match std::ffi::CStr::from_ptr(path).to_str() {
+            Ok(path) => path,
+            Err(e) => {
+                tracing::error!("Failed to parse the main database path: {}", e);
+                return ffi::SQLITE_CANTOPEN;
+            }
+        }
+    };
+    tracing::debug!("Main database file {} will be open soon", path);
+
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            tracing::error!("Failed to initialize async runtime: {}", e);
+            return ffi::SQLITE_CANTOPEN;
+        }
+    };
+
+    let replicator = block_on!(
+        runtime,
+        replicator::Replicator::create(replicator::Options {
+            create_bucket_if_not_exists: true,
+            verify_crc: true,
+        })
+    );
+    let mut replicator = match replicator {
+        Ok(repl) => repl,
+        Err(e) => {
+            tracing::error!("Failed to initialize replicator: {}", e);
+            return ffi::SQLITE_CANTOPEN;
+        }
+    };
+
+    replicator.register_db(path);
+    block_on!(runtime, try_restore(&mut replicator))
+}
+
+#[no_mangle]
+pub extern "C" fn bottomless_init() {
+    tracing::debug!("bottomless module initialized");
+}
+
+#[tracing::instrument]
+#[no_mangle]
+pub extern "C" fn bottomless_methods(
+    underlying_methods: *const libsql_wal_methods,
+) -> *const libsql_wal_methods {
+    let vwal_name: *const u8 = "bottomless\0".as_ptr();
+
+    Box::into_raw(Box::new(libsql_wal_methods {
+        iVersion: 1,
+        xOpen,
+        xClose,
+        xLimit,
+        xBeginReadTransaction,
+        xEndReadTransaction,
+        xFindFrame,
+        xReadFrame,
+        xDbSize,
+        xBeginWriteTransaction,
+        xEndWriteTransaction,
+        xUndo,
+        xSavepoint,
+        xSavepointUndo,
+        xFrames,
+        xCheckpoint,
+        xCallback,
+        xExclusiveMode,
+        xHeapMemory,
+        snapshot_get_stub: std::ptr::null(),
+        snapshot_open_stub: std::ptr::null(),
+        snapshot_recover_stub: std::ptr::null(),
+        snapshot_check_stub: std::ptr::null(),
+        snapshot_unlock_stub: std::ptr::null(),
+        framesize_stub: std::ptr::null(),
+        xFile,
+        write_lock_stub: std::ptr::null(),
+        xDb,
+        xPathnameLen,
+        xGetPathname,
+        xPreMainDbOpen,
+        name: vwal_name,
+        b_uses_shm: 0,
+        p_next: std::ptr::null(),
+        underlying_methods,
+    }))
+}
+
+#[cfg(feature = "libsql_linked_statically")]
+pub mod static_init {
+    use crate::libsql_wal_methods;
+
+    extern "C" {
+        fn libsql_wal_methods_find(name: *const std::ffi::c_char) -> *const libsql_wal_methods;
+        fn libsql_wal_methods_register(methods: *const libsql_wal_methods) -> i32;
+    }
+
+    pub fn register_bottomless_methods() {
+        static INIT: std::sync::Once = std::sync::Once::new();
+        INIT.call_once(|| {
+            crate::bottomless_init();
+            let orig_methods = unsafe { libsql_wal_methods_find(std::ptr::null()) };
+            if orig_methods.is_null() {}
+            let methods = crate::bottomless_methods(orig_methods);
+            let rc = unsafe { libsql_wal_methods_register(methods) };
+            if rc != crate::ffi::SQLITE_OK {
+                let _box = unsafe { Box::from_raw(methods as *mut libsql_wal_methods) };
+                tracing::warn!("Failed to instantiate bottomless WAL methods");
+            }
+        })
+    }
+}

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -1,0 +1,771 @@
+use aws_sdk_s3::types::ByteStream;
+use aws_sdk_s3::{Client, Endpoint};
+use bytes::{Bytes, BytesMut};
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+
+pub type Result<T> = anyhow::Result<T>;
+
+const CRC_64: crc::Crc<u64> = crc::Crc::<u64>::new(&crc::CRC_64_ECMA_182);
+
+#[derive(Debug)]
+struct Frame {
+    pgno: i32,
+    bytes: BytesMut,
+    crc: u64,
+}
+
+#[derive(Debug)]
+pub struct Replicator {
+    pub client: Client,
+    write_buffer: BTreeMap<u32, Frame>,
+
+    pub page_size: usize,
+    generation: uuid::Uuid,
+    pub commits_in_current_generation: u32,
+    next_frame: u32,
+    verify_crc: bool,
+    last_frame_crc: u64,
+    last_transaction_crc: u64,
+    pub bucket: String,
+    pub db_path: String,
+    pub db_name: String,
+}
+
+#[derive(Debug)]
+pub struct FetchedResults {
+    pub pages: Vec<(i32, Bytes)>,
+    pub next_marker: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum RestoreAction {
+    None,
+    SnapshotMainDbFile,
+    ReuseGeneration(uuid::Uuid),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Options {
+    pub create_bucket_if_not_exists: bool,
+    pub verify_crc: bool,
+}
+
+impl Replicator {
+    pub const UNSET_PAGE_SIZE: usize = usize::MAX;
+
+    pub async fn new() -> Result<Self> {
+        Self::create(Options {
+            create_bucket_if_not_exists: false,
+            verify_crc: true,
+        })
+        .await
+    }
+
+    pub async fn create(options: Options) -> Result<Self> {
+        let write_buffer = BTreeMap::new();
+        let mut loader = aws_config::from_env();
+        if let Ok(endpoint) = std::env::var("LIBSQL_BOTTOMLESS_ENDPOINT") {
+            loader = loader.endpoint_resolver(Endpoint::immutable(endpoint)?);
+        }
+        let bucket =
+            std::env::var("LIBSQL_BOTTOMLESS_BUCKET").unwrap_or_else(|_| "bottomless".to_string());
+        let client = Client::new(&loader.load().await);
+        let generation = Self::generate_generation();
+        tracing::debug!("Generation {}", generation);
+
+        match client.head_bucket().bucket(&bucket).send().await {
+            Ok(_) => tracing::info!("Bucket {} exists and is accessible", bucket),
+            Err(aws_sdk_s3::types::SdkError::ServiceError(err)) if err.err().is_not_found() => {
+                if options.create_bucket_if_not_exists {
+                    tracing::info!("Bucket {} not found, recreating", bucket);
+                    client.create_bucket().bucket(&bucket).send().await?;
+                } else {
+                    tracing::error!("Bucket {} does not exist", bucket);
+                    return Err(aws_sdk_s3::types::SdkError::ServiceError(err).into());
+                }
+            }
+            Err(e) => {
+                tracing::error!("Bucket checking error: {}", e);
+                return Err(e.into());
+            }
+        }
+
+        Ok(Self {
+            client,
+            write_buffer,
+            bucket,
+            page_size: Self::UNSET_PAGE_SIZE,
+            generation,
+            commits_in_current_generation: 0,
+            next_frame: 1,
+            verify_crc: options.verify_crc,
+            last_frame_crc: 0,
+            last_transaction_crc: 0,
+            db_path: String::new(),
+            db_name: String::new(),
+        })
+    }
+
+    // The database can use different page size - as soon as it's known,
+    // it should be communicated to the replicator via this call.
+    // NOTICE: in practice, WAL journaling mode does not allow changing page sizes,
+    // so verifying that it hasn't changed is a panic check. Perhaps in the future
+    // it will be useful, if WAL ever allows changing the page size.
+    pub fn set_page_size(&mut self, page_size: usize) -> Result<()> {
+        tracing::trace!("Setting page size from {} to {}", self.page_size, page_size);
+        if self.page_size != Self::UNSET_PAGE_SIZE && self.page_size != page_size {
+            return Err(anyhow::anyhow!(
+                "Cannot set page size to {}, it was already set to {}",
+                page_size,
+                self.page_size
+            ));
+        }
+        self.page_size = page_size;
+        Ok(())
+    }
+
+    // Gets an object from the current bucket
+    fn get_object(&self, key: String) -> aws_sdk_s3::client::fluent_builders::GetObject {
+        self.client.get_object().bucket(&self.bucket).key(key)
+    }
+
+    // Lists objects from the current bucket
+    fn list_objects(&self) -> aws_sdk_s3::client::fluent_builders::ListObjects {
+        self.client.list_objects().bucket(&self.bucket)
+    }
+
+    // Generates a new generation UUID v7, which contains a timestamp and is binary-sortable.
+    // This timestamp goes back in time - that allows us to list newest generations
+    // first in the S3-compatible bucket, under the assumption that fetching newest generations
+    // is the most common operation.
+    // NOTICE: at the time of writing, uuid v7 is an unstable feature of the uuid crate
+    fn generate_generation() -> uuid::Uuid {
+        let (seconds, nanos) = uuid::timestamp::Timestamp::now(uuid::NoContext).to_unix();
+        let (seconds, nanos) = (253370761200 - seconds, 999999999 - nanos);
+        let synthetic_ts = uuid::Timestamp::from_unix(uuid::NoContext, seconds, nanos);
+        uuid::Uuid::new_v7(synthetic_ts)
+    }
+
+    // Starts a new generation for this replicator instance
+    pub fn new_generation(&mut self) {
+        tracing::debug!("New generation started: {}", self.generation);
+        self.set_generation(Self::generate_generation());
+    }
+
+    // Sets a generation for this replicator instance. This function
+    // should be called if a generation number from S3-compatible storage
+    // is reused in this session.
+    pub fn set_generation(&mut self, generation: uuid::Uuid) {
+        self.generation = generation;
+        self.commits_in_current_generation = 0;
+        self.next_frame = 1; // New generation marks a new WAL
+        tracing::debug!("Generation set to {}", self.generation);
+    }
+
+    // Registers a database path for this replicator.
+    pub fn register_db(&mut self, db_path: impl Into<String>) {
+        let db_path = db_path.into();
+        // An optional prefix to differentiate between databases with the same filename
+        let db_id = std::env::var("LIBSQL_BOTTOMLESS_DATABASE_ID").unwrap_or_default();
+        let name = match db_path.rfind('/') {
+            Some(index) => &db_path[index + 1..],
+            None => &db_path,
+        };
+        self.db_name = db_id + name;
+        self.db_path = db_path;
+        tracing::trace!("Registered {} (full path: {})", self.db_name, self.db_path);
+    }
+
+    // Returns the next free frame number for the replicated log
+    fn next_frame(&mut self) -> u32 {
+        self.next_frame += 1;
+        self.next_frame - 1
+    }
+
+    // Returns the current last valid frame in the replicated log
+    pub fn peek_last_valid_frame(&self) -> u32 {
+        self.next_frame.saturating_sub(1)
+    }
+
+    // Sets the last valid frame in the replicated log.
+    pub fn register_last_valid_frame(&mut self, frame: u32) {
+        if frame != self.peek_last_valid_frame() {
+            if self.next_frame != 1 {
+                tracing::error!(
+                    "[BUG] Local max valid frame is {}, while replicator thinks it's {}",
+                    frame,
+                    self.peek_last_valid_frame()
+                );
+            }
+            self.next_frame = frame + 1
+        }
+    }
+
+    // Writes pages to a local in-memory buffer
+    pub fn write(&mut self, pgno: i32, data: &[u8]) {
+        let frame = self.next_frame();
+        let mut crc = CRC_64.digest_with_initial(self.last_frame_crc);
+        crc.update(data);
+        let crc = crc.finalize();
+        tracing::trace!(
+            "Writing page {}:{} at frame {}, crc: {}",
+            pgno,
+            data.len(),
+            frame,
+            crc
+        );
+        let mut bytes = BytesMut::new();
+        bytes.extend_from_slice(data);
+        self.write_buffer.insert(frame, Frame { pgno, bytes, crc });
+        self.last_frame_crc = crc;
+    }
+
+    // Sends pages participating in current transaction to S3.
+    // Returns the frame number holding the last flushed page.
+    pub async fn flush(&mut self) -> Result<u32> {
+        if self.write_buffer.is_empty() {
+            tracing::trace!("Attempting to flush an empty buffer");
+            return Ok(0);
+        }
+        tracing::trace!("Flushing {} frames", self.write_buffer.len());
+        self.commits_in_current_generation += 1;
+        let mut tasks = vec![];
+        // FIXME: instead of batches processed in bursts, better to allow X concurrent tasks with a semaphore
+        const CONCURRENCY: usize = 64;
+        let last_frame_in_transaction_crc = self.write_buffer.iter().last().unwrap().1.crc;
+        for (frame, Frame { pgno, bytes, crc }) in self.write_buffer.iter() {
+            let data: &[u8] = bytes;
+            if data.len() != self.page_size {
+                tracing::warn!("Unexpected truncated page of size {}", data.len())
+            }
+            let mut compressor = async_compression::tokio::bufread::GzipEncoder::new(data);
+            let mut compressed: Vec<u8> = Vec::with_capacity(self.page_size);
+            tokio::io::copy(&mut compressor, &mut compressed).await?;
+            let key = format!(
+                "{}-{}/{:012}-{:012}-{:016x}",
+                self.db_name, self.generation, frame, pgno, crc
+            );
+            tracing::trace!("Flushing {} (compressed size: {})", key, compressed.len());
+            tasks.push(
+                self.client
+                    .put_object()
+                    .bucket(&self.bucket)
+                    .key(key)
+                    .body(ByteStream::from(compressed))
+                    .send(),
+            );
+            if tasks.len() >= CONCURRENCY {
+                futures::future::try_join_all(std::mem::take(&mut tasks)).await?;
+                tasks.clear();
+            }
+        }
+        if !tasks.is_empty() {
+            futures::future::try_join_all(tasks).await?;
+        }
+        self.write_buffer.clear();
+        self.last_transaction_crc = last_frame_in_transaction_crc;
+        tracing::trace!("Last transaction crc: {}", self.last_transaction_crc);
+        Ok(self.next_frame - 1)
+    }
+
+    // Marks all recently flushed pages as committed and updates the frame number
+    // holding the newest consistent committed transaction.
+    pub async fn finalize_commit(&mut self, last_frame: u32, checksum: [u32; 2]) -> Result<()> {
+        // Last consistent frame is persisted in S3 in order to be able to recover
+        // from failured that happen in the middle of a commit, when only some
+        // of the pages that belong to a transaction are replicated.
+        let last_consistent_frame_key = format!("{}-{}/.consistent", self.db_name, self.generation);
+        tracing::trace!("Finalizing frame: {}, checksum: {:?}", last_frame, checksum);
+        // Information kept in this entry: [last consistent frame number: 4 bytes][last checksum: 8 bytes]
+        let mut consistent_info = BytesMut::with_capacity(12);
+        consistent_info.extend_from_slice(&last_frame.to_be_bytes());
+        consistent_info.extend_from_slice(&checksum[0].to_be_bytes());
+        consistent_info.extend_from_slice(&checksum[1].to_be_bytes());
+        self.client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(last_consistent_frame_key)
+            .body(ByteStream::from(Bytes::from(consistent_info)))
+            .send()
+            .await?;
+        tracing::trace!("Commit successful");
+        Ok(())
+    }
+
+    // Drops uncommitted frames newer than given last valid frame
+    pub fn rollback_to_frame(&mut self, last_valid_frame: u32) {
+        // NOTICE: O(size), can be optimized to O(removed) if ever needed
+        self.write_buffer.retain(|&k, _| k <= last_valid_frame);
+        self.next_frame = last_valid_frame + 1;
+        self.last_frame_crc = self
+            .write_buffer
+            .iter()
+            .next_back()
+            .map(|entry| entry.1.crc)
+            .unwrap_or(self.last_transaction_crc);
+        tracing::debug!(
+            "Rolled back to {}, crc {} (last transaction crc = {})",
+            self.next_frame - 1,
+            self.last_frame_crc,
+            self.last_transaction_crc,
+        );
+    }
+
+    // Tries to read the local change counter from the given database file
+    async fn read_change_counter(reader: &mut tokio::fs::File) -> Result<[u8; 4]> {
+        use tokio::io::{AsyncReadExt, AsyncSeekExt};
+        let mut counter = [0u8; 4];
+        reader.seek(std::io::SeekFrom::Start(24)).await?;
+        reader.read_exact(&mut counter).await?;
+        Ok(counter)
+    }
+
+    // Tries to read the local page size from the given database file
+    async fn read_page_size(reader: &mut tokio::fs::File) -> Result<usize> {
+        use tokio::io::{AsyncReadExt, AsyncSeekExt};
+        reader.seek(std::io::SeekFrom::Start(16)).await?;
+        let page_size = reader.read_u16().await?;
+        if page_size == 1 {
+            Ok(65536)
+        } else {
+            Ok(page_size as usize)
+        }
+    }
+
+    // Returns the compressed database file path and its change counter, extracted
+    // from the header of page1 at offset 24..27 (as per SQLite documentation).
+    pub async fn compress_main_db_file(&self) -> Result<(&'static str, [u8; 4])> {
+        use tokio::io::AsyncWriteExt;
+        let compressed_db = "db.gz";
+        let mut reader = tokio::fs::File::open(&self.db_path).await?;
+        let mut writer = async_compression::tokio::write::GzipEncoder::new(
+            tokio::fs::File::create(compressed_db).await?,
+        );
+        tokio::io::copy(&mut reader, &mut writer).await?;
+        writer.shutdown().await?;
+        let change_counter = Self::read_change_counter(&mut reader).await?;
+        Ok((compressed_db, change_counter))
+    }
+
+    // Replicates local WAL pages to S3, if local WAL is present.
+    // This function is called under the assumption that if local WAL
+    // file is present, it was already detected to be newer than its
+    // remote counterpart.
+    pub async fn maybe_replicate_wal(&mut self) -> Result<()> {
+        use tokio::io::{AsyncReadExt, AsyncSeekExt};
+        let mut wal_file = match tokio::fs::File::open(&format!("{}-wal", &self.db_path)).await {
+            Ok(file) => file,
+            Err(_) => {
+                tracing::info!("Local WAL not present - not replicating");
+                return Ok(());
+            }
+        };
+        let len = match wal_file.metadata().await {
+            Ok(metadata) => metadata.len(),
+            Err(_) => 0,
+        };
+        if len < 32 {
+            tracing::info!("Local WAL is empty, not replicating");
+            return Ok(());
+        }
+        if self.page_size == Self::UNSET_PAGE_SIZE {
+            tracing::trace!("Page size not detected yet, not replicated");
+            return Ok(());
+        }
+
+        tracing::trace!("Local WAL pages: {}", (len - 32) / self.page_size as u64);
+        wal_file.seek(tokio::io::SeekFrom::Start(24)).await?;
+        let checksum: [u32; 2] = [wal_file.read_u32().await?, wal_file.read_u32().await?];
+        tracing::trace!("Local WAL checksum: {:?}", checksum);
+        let mut last_written_frame = 0;
+        for offset in (32..len).step_by(self.page_size + 24) {
+            wal_file.seek(tokio::io::SeekFrom::Start(offset)).await?;
+            let pgno = wal_file.read_i32().await?;
+            let size_after = wal_file.read_u32().await?;
+            tracing::trace!("Size after transaction for {}: {}", pgno, size_after);
+            wal_file
+                .seek(tokio::io::SeekFrom::Start(offset + 24))
+                .await?;
+            let mut data = vec![0u8; self.page_size];
+            wal_file.read_exact(&mut data).await?;
+            self.write(pgno, &data);
+            // In multi-page transactions, only the last page in the transaction contains
+            // the size_after_transaction field. If it's zero, it means it's an uncommited
+            // page.
+            if size_after != 0 {
+                last_written_frame = self.flush().await?;
+            }
+        }
+        if last_written_frame > 0 {
+            self.finalize_commit(last_written_frame, checksum).await?;
+        }
+        if !self.write_buffer.is_empty() {
+            tracing::warn!("Uncommited WAL entries: {}", self.write_buffer.len());
+        }
+        self.write_buffer.clear();
+        tracing::info!("Local WAL replicated");
+        Ok(())
+    }
+
+    // Check if the local database file exists and contains data
+    async fn main_db_exists_and_not_empty(&self) -> bool {
+        let file = match tokio::fs::File::open(&self.db_path).await {
+            Ok(file) => file,
+            Err(_) => return false,
+        };
+        match file.metadata().await {
+            Ok(metadata) => metadata.len() > 0,
+            Err(_) => false,
+        }
+    }
+
+    // Sends the main database file to S3 - if -wal file is present, it's replicated
+    // too - it means that the local file was detected to be newer than its remote
+    // counterpart.
+    pub async fn snapshot_main_db_file(&mut self) -> Result<()> {
+        if !self.main_db_exists_and_not_empty().await {
+            tracing::debug!("Not snapshotting, the main db file does not exist or is empty");
+            return Ok(());
+        }
+        tracing::debug!("Snapshotting {}", self.db_path);
+
+        // TODO: find a way to compress ByteStream on the fly instead of creating
+        // an intermediary file.
+        let (compressed_db_path, change_counter) = self.compress_main_db_file().await?;
+        let key = format!("{}-{}/db.gz", self.db_name, self.generation);
+        self.client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .body(ByteStream::from_path(compressed_db_path).await?)
+            .send()
+            .await?;
+        /* FIXME: we can't rely on the change counter in WAL mode:
+         ** "In WAL mode, changes to the database are detected using the wal-index and
+         ** so the change counter is not needed. Hence, the change counter might not be
+         ** incremented on each transaction in WAL mode."
+         ** Instead, we need to consult WAL checksums.
+         */
+        let change_counter_key = format!("{}-{}/.changecounter", self.db_name, self.generation);
+        self.client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(change_counter_key)
+            .body(ByteStream::from(Bytes::copy_from_slice(&change_counter)))
+            .send()
+            .await?;
+        tracing::debug!("Main db snapshot complete");
+        Ok(())
+    }
+
+    // Returns newest replicated generation, or None, if one is not found.
+    // FIXME: assumes that this bucket stores *only* generations for databases,
+    // it should be more robust and continue looking if the first item does not
+    // match the <db-name>-<generation-uuid>/ pattern.
+    pub async fn find_newest_generation(&self) -> Option<uuid::Uuid> {
+        let prefix = format!("{}-", self.db_name);
+        let response = self
+            .list_objects()
+            .prefix(prefix)
+            .max_keys(1)
+            .send()
+            .await
+            .ok()?;
+        let objs = response.contents()?;
+        let key = objs.first()?.key()?;
+        let key = match key.find('/') {
+            Some(index) => &key[self.db_name.len() + 1..index],
+            None => key,
+        };
+        tracing::debug!("Generation candidate: {}", key);
+        uuid::Uuid::parse_str(key).ok()
+    }
+
+    // Tries to fetch the remote database change counter from given generation
+    pub async fn get_remote_change_counter(&self, generation: &uuid::Uuid) -> Result<[u8; 4]> {
+        use bytes::Buf;
+        let mut remote_change_counter = [0u8; 4];
+        if let Ok(response) = self
+            .get_object(format!("{}-{}/.changecounter", self.db_name, generation))
+            .send()
+            .await
+        {
+            response
+                .body
+                .collect()
+                .await?
+                .copy_to_slice(&mut remote_change_counter)
+        }
+        Ok(remote_change_counter)
+    }
+
+    // Tries to fetch the last consistent frame number stored in the remote generation
+    pub async fn get_last_consistent_frame(&self, generation: &uuid::Uuid) -> Result<(u32, u64)> {
+        use bytes::Buf;
+        Ok(
+            match self
+                .get_object(format!("{}-{}/.consistent", self.db_name, generation))
+                .send()
+                .await
+                .ok()
+            {
+                Some(response) => {
+                    let mut collected = response.body.collect().await?;
+                    (collected.get_u32(), collected.get_u64())
+                }
+                None => (0, 0),
+            },
+        )
+    }
+
+    // Returns the number of pages stored in the local WAL file, or 0, if there aren't any.
+    async fn get_local_wal_page_count(&mut self) -> u32 {
+        use tokio::io::{AsyncReadExt, AsyncSeekExt};
+        match tokio::fs::File::open(&format!("{}-wal", &self.db_path)).await {
+            Ok(mut file) => {
+                let metadata = match file.metadata().await {
+                    Ok(metadata) => metadata,
+                    Err(_) => return 0,
+                };
+                let len = metadata.len();
+                if len >= 32 {
+                    // Page size is stored in WAL file at offset [8-12)
+                    if file.seek(tokio::io::SeekFrom::Start(8)).await.is_err() {
+                        return 0;
+                    };
+                    let page_size = match file.read_u32().await {
+                        Ok(size) => size,
+                        Err(_) => return 0,
+                    };
+                    if self.set_page_size(page_size as usize).is_err() {
+                        return 0;
+                    }
+                    // Each WAL file consists of a 32-byte WAL header and N entries of size (page size + 24)
+                    (len / (self.page_size + 24) as u64) as u32
+                } else {
+                    0
+                }
+            }
+            Err(_) => 0,
+        }
+    }
+
+    // Parses the frame and page number from given key.
+    // Format: <db-name>-<generation>/<frame-number>-<page-number>-<crc64>
+    fn parse_frame_page_crc(key: &str) -> Option<(u32, i32, u64)> {
+        let checksum_delim = key.rfind('-')?;
+        let page_delim = key[0..checksum_delim].rfind('-')?;
+        let frame_delim = key[0..page_delim].rfind('/')?;
+        let frameno = key[frame_delim + 1..page_delim].parse::<u32>().ok()?;
+        let pgno = key[page_delim + 1..checksum_delim].parse::<i32>().ok()?;
+        let crc = u64::from_str_radix(&key[checksum_delim + 1..], 16).ok()?;
+        tracing::debug!(frameno, pgno, crc);
+        Some((frameno, pgno, crc))
+    }
+
+    // Restores the database state from given remote generation
+    pub async fn restore_from(&mut self, generation: uuid::Uuid) -> Result<RestoreAction> {
+        use tokio::io::{AsyncSeekExt, AsyncWriteExt};
+
+        // Check if the database needs to be restored by inspecting the database
+        // change counter and the WAL size.
+        let local_counter = match tokio::fs::File::open(&self.db_path).await {
+            Ok(mut db) => {
+                // While reading the main database file for the first time,
+                // page size from an existing database should be set.
+                if let Ok(page_size) = Self::read_page_size(&mut db).await {
+                    self.set_page_size(page_size)?;
+                }
+                Self::read_change_counter(&mut db).await.unwrap_or([0u8; 4])
+            }
+            Err(_) => [0u8; 4],
+        };
+
+        let remote_counter = self.get_remote_change_counter(&generation).await?;
+        tracing::debug!("Counters: l={:?}, r={:?}", local_counter, remote_counter);
+
+        let (last_consistent_frame, checksum) = self.get_last_consistent_frame(&generation).await?;
+        tracing::debug!(
+            "Last consistent remote frame: {}; checksum: {:x}",
+            last_consistent_frame,
+            checksum
+        );
+
+        let wal_pages = self.get_local_wal_page_count().await;
+        match local_counter.cmp(&remote_counter) {
+            Ordering::Equal => {
+                tracing::debug!(
+                    "Consistent: {}; wal pages: {}",
+                    last_consistent_frame,
+                    wal_pages
+                );
+                match wal_pages.cmp(&last_consistent_frame) {
+                    Ordering::Equal => {
+                        tracing::info!(
+                            "Remote generation is up-to-date, reusing it in this session"
+                        );
+                        self.next_frame = wal_pages + 1;
+                        return Ok(RestoreAction::ReuseGeneration(generation));
+                    }
+                    Ordering::Greater => {
+                        tracing::info!("Local change counter matches the remote one, but local WAL contains newer data, which needs to be replicated");
+                        return Ok(RestoreAction::SnapshotMainDbFile);
+                    }
+                    Ordering::Less => (),
+                }
+            }
+            Ordering::Greater => {
+                tracing::info!("Local change counter is larger than its remote counterpart - a new snapshot needs to be replicated");
+                return Ok(RestoreAction::SnapshotMainDbFile);
+            }
+            Ordering::Less => (),
+        }
+
+        tokio::fs::rename(&self.db_path, format!("{}.bottomless.backup", self.db_path))
+            .await
+            .ok(); // Best effort
+        let mut main_db_writer = tokio::fs::File::create(&self.db_path).await?;
+        // If the db file is not present, the database could have been empty
+        if let Ok(db_file) = self
+            .get_object(format!("{}-{}/db.gz", self.db_name, generation))
+            .send()
+            .await
+        {
+            let body_reader = db_file.body.into_async_read();
+            let mut decompress_reader = async_compression::tokio::bufread::GzipDecoder::new(
+                tokio::io::BufReader::new(body_reader),
+            );
+            tokio::io::copy(&mut decompress_reader, &mut main_db_writer).await?;
+            main_db_writer.flush().await?;
+        }
+        tracing::info!("Restored the main database file");
+
+        let mut next_marker = None;
+        let prefix = format!("{}-{}/", self.db_name, generation);
+        tracing::debug!("Overwriting any existing WAL file: {}-wal", &self.db_path);
+        tokio::fs::remove_file(&format!("{}-wal", &self.db_path))
+            .await
+            .ok();
+        tokio::fs::remove_file(&format!("{}-shm", &self.db_path))
+            .await
+            .ok();
+
+        let mut applied_wal_frame = false;
+        loop {
+            let mut list_request = self.list_objects().prefix(&prefix);
+            if let Some(marker) = next_marker {
+                list_request = list_request.marker(marker);
+            }
+            let response = list_request.send().await?;
+            let objs = match response.contents() {
+                Some(objs) => objs,
+                None => {
+                    tracing::debug!("No objects found in generation {}", generation);
+                    break;
+                }
+            };
+            let mut prev_crc = 0;
+            let mut page_buffer = Vec::with_capacity(65536); // best guess for the page size - it will certainly not be more than 64KiB
+            for obj in objs {
+                let key = obj
+                    .key()
+                    .ok_or_else(|| anyhow::anyhow!("Failed to get key for an object"))?;
+                tracing::debug!("Loading {}", key);
+                let frame = self.get_object(key.into()).send().await?;
+
+                let (frameno, pgno, crc) = match Self::parse_frame_page_crc(key) {
+                    Some(result) => result,
+                    None => {
+                        if !key.ends_with(".gz")
+                            && !key.ends_with(".consistent")
+                            && !key.ends_with(".changecounter")
+                        {
+                            tracing::warn!("Failed to parse frame/page from key {}", key);
+                        }
+                        continue;
+                    }
+                };
+                if frameno > last_consistent_frame {
+                    tracing::warn!("Remote log contains frame {} larger than last consistent frame ({}), stopping the restoration process",
+                                frameno, last_consistent_frame);
+                    break;
+                }
+                let body_reader = frame.body.into_async_read();
+                let mut decompress_reader = async_compression::tokio::bufread::GzipDecoder::new(
+                    tokio::io::BufReader::new(body_reader),
+                );
+                // If page size is unknown *or* crc verification is performed,
+                // a page needs to be loaded to memory first
+                if self.verify_crc || self.page_size == Self::UNSET_PAGE_SIZE {
+                    let page_size =
+                        tokio::io::copy(&mut decompress_reader, &mut page_buffer).await?;
+                    if self.verify_crc {
+                        let mut expected_crc = CRC_64.digest_with_initial(prev_crc);
+                        expected_crc.update(&page_buffer);
+                        let expected_crc = expected_crc.finalize();
+                        tracing::debug!(crc, expected_crc);
+                        if crc != expected_crc {
+                            tracing::warn!(
+                                "CRC check failed: {:016x} != {:016x} (expected)",
+                                crc,
+                                expected_crc
+                            );
+                        }
+                        prev_crc = crc;
+                    }
+                    self.set_page_size(page_size as usize)?;
+                    let offset = (pgno - 1) as u64 * page_size;
+                    main_db_writer
+                        .seek(tokio::io::SeekFrom::Start(offset))
+                        .await?;
+                    tokio::io::copy(&mut &page_buffer[..], &mut main_db_writer).await?;
+                    page_buffer.clear();
+                } else {
+                    let offset = (pgno - 1) as u64 * self.page_size as u64;
+                    main_db_writer
+                        .seek(tokio::io::SeekFrom::Start(offset))
+                        .await?;
+                    // FIXME: we only need to overwrite with the newest page,
+                    // no need to replay the whole WAL
+                    tokio::io::copy(&mut decompress_reader, &mut main_db_writer).await?;
+                }
+                main_db_writer.flush().await?;
+                tracing::debug!("Written frame {} as main db page {}", frameno, pgno);
+                applied_wal_frame = true;
+            }
+            next_marker = response
+                .is_truncated()
+                .then(|| objs.last().map(|elem| elem.key().unwrap().to_string()))
+                .flatten();
+            if next_marker.is_none() {
+                break;
+            }
+        }
+
+        if applied_wal_frame {
+            Ok::<_, anyhow::Error>(RestoreAction::SnapshotMainDbFile)
+        } else {
+            Ok::<_, anyhow::Error>(RestoreAction::None)
+        }
+    }
+
+    // Restores the database state from newest remote generation
+    pub async fn restore(&mut self) -> Result<RestoreAction> {
+        let newest_generation = match self.find_newest_generation().await {
+            Some(gen) => gen,
+            None => {
+                tracing::debug!("No generation found, nothing to restore");
+                return Ok(RestoreAction::SnapshotMainDbFile);
+            }
+        };
+
+        tracing::info!("Restoring from generation {}", newest_generation);
+        self.restore_from(newest_generation).await
+    }
+}
+
+pub struct Context {
+    pub replicator: Replicator,
+    pub runtime: tokio::runtime::Runtime,
+}

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -48,7 +48,7 @@ tower = { version = "0.4.13", features = ["make"] }
 tower-http = { version = "0.3.5", features = ["compression-full", "cors"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-uuid = { version = "1.2.2", features = ["v4"] }
+uuid = { version = "1.3", features = ["v4"] }
 
 [dev-dependencies]
 proptest = "1.0.0"


### PR DESCRIPTION
libSQL's bottomless S3 replication is going to live in the sqld/ tree, so the project is moved as is from https://github.com/libsql/bottomless/. After it's merged, I'll archive libsql/bottomless and redirect to sqld/

/cc @glommer 