### PR TITLE
improve syntax error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,8 +2362,7 @@ dependencies = [
 [[package]]
 name = "sqlite3-parser"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3e42304077fd98c51f96c5c2c55203eb9ba505e5539881cc935b83e77bbc7f"
+source = "git+https://github.com/MarinPostma/lemon-rs?rev=1ae885e#1ae885eca78ec3a658954daae55fb16095bd6420"
 dependencies = [
  "bitflags",
  "buf_redux",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ members = [
 [patch."https://github.com/psarna/mvsqlite"]
 mvfs = { git = "https://github.com/MarinPostma/mvsqlite", branch = "use-cchar" }
 mwal = { git = "https://github.com/MarinPostma/mvsqlite", branch = "use-cchar" }
+
+[patch.crates-io]
+sqlite3-parser = { git = "https://github.com/MarinPostma/lemon-rs", rev = "1ae885e" }


### PR DESCRIPTION
improve the error message when a syntax error is encountered.

The parser is a bit sloppy when it comes to reporting the error locations, sometimes pointing farther than he should. I'll see if this is fixable later, or if this is a feature of the lemon parser :smile:

the error message looks like:
```
>> echo '{"statements": ["selecct count(*) from test where x = 12"]}' | http post "127.0.0.1:8080"
{"error":"syntax error around L1:8: `selecct`"}
```
