### PR TITLE
Changed client interface to support parameter binding

### DIFF
--- a/packages/libsql-client/src/lib/driver/Driver.ts
+++ b/packages/libsql-client/src/lib/driver/Driver.ts
@@ -1,5 +1,6 @@
-import { ResultSet } from "../libsql-js"
+import { BoundStatement, Params, ResultSet } from "../libsql-js"
 
 export interface Driver {
-    transaction(sql: string[]): Promise<ResultSet[]>;
+    execute(stmt: string, params?: Params): Promise<ResultSet>;
+    transaction(stmts: (string | BoundStatement)[]): Promise<ResultSet[]>;
 }

--- a/packages/libsql-client/src/lib/driver/HttpDriver.ts
+++ b/packages/libsql-client/src/lib/driver/HttpDriver.ts
@@ -1,45 +1,73 @@
 import fetch from 'cross-fetch';
-import { Row, ResultSet } from "../libsql-js";
+import { ResultSet, BoundStatement, Params } from "../libsql-js";
 import { Driver } from "./Driver";
 
 export class HttpDriver implements Driver {
-    url: URL;
+    private url: URL;
 
     constructor(url: URL) {
         this.url = url;
     }
 
-    async transaction(sql: string[]): Promise<ResultSet[]> {
-        const query = {
-            statements: sql
-        };
+    async execute(stmt: string, params?: Params): Promise<ResultSet> {
+        let rs;
+        if (params === undefined) {
+            rs = (await this.transaction([stmt]))[0];
+        } else {
+            rs = (await this.transaction([{sql: stmt, params: params}]))[0];
+        }
+        return rs
+    }
+
+    async transaction(stmts: (string | BoundStatement)[]): Promise<ResultSet[]> {
+        if (stmts.length === 0) {
+            return [];
+        }
+
+        const statements = buildStatements(stmts);
 
         const response = await fetch(this.url, {
             method: 'POST',
-            body: JSON.stringify(query),
+            body: JSON.stringify(statements),
         });
 
         if (response.status === 200) {
             const results = await response.json();
-            validateTopLevelResults(results, sql.length);
+            validateTopLevelResults(results, stmts.length);
             const resultSets: ResultSet[] = [];
             for (var rsIdx = 0; rsIdx < results.length; rsIdx++) {
                 const result = results[rsIdx];
-                const rs = parseResultSet(result, rsIdx)
+                const rs = parseResultSet(result, rsIdx);
                 // TODO duration needs to be provided by sqld
                 rs.meta = { duration: 0 };
-                resultSets.push(rs as ResultSet)
+                resultSets.push(rs as ResultSet);
             }
             return resultSets;
         } else {
             const errorObj = await response.json();
             if (typeof errorObj === "object" && "error" in errorObj) {
-                throw new Error(errorObj.error)
+                throw new Error(errorObj.error);
             } else {
-                throw new Error(`${response.status} ${response.statusText}`)
+                throw new Error(`${response.status} ${response.statusText}`);
             }
         }
     }
+}
+
+
+function buildStatements(stmts: (string | BoundStatement)[]) {
+    let statements;
+    if (typeof stmts[0] === "string") {
+        statements = { statements: stmts }
+    } else {
+        const s = stmts as BoundStatement[];
+        statements = {
+            statements: s.map(st => {
+                return { q: st.sql, params: st.params };
+            })
+        }
+    }
+    return statements
 }
 
 function validateTopLevelResults(results: any, numResults: number) {
@@ -47,7 +75,7 @@ function validateTopLevelResults(results: any, numResults: number) {
         throw new Error("Response JSON was not an array");
     }
     if (results.length !== numResults) {
-        throw new Error(`Response array did not contain expected ${numResults} results`)
+        throw new Error(`Response array did not contain expected ${numResults} results`);
     }
 }
 
@@ -69,7 +97,7 @@ function parseResultSet(result: any, rsIdx: number): ResultSet {
         rs.success = false;
     }
     else {
-        throw new Error(`Result ${rsIdx} did not contain results or error`)
+        throw new Error(`Result ${rsIdx} did not contain results or error`);
     }
     return rs;
 }
@@ -94,7 +122,7 @@ function validateRowsAndCols(r: ResultSet, rsIdx: number) {
     const rows = r.rows!;
     for (var i = 0; i < rows.length; i++) {
         if (rows[i].length !== numCols) {
-            throw new Error(`Result ${rsIdx} row ${i} number of values != ${numCols}`)
+            throw new Error(`Result ${rsIdx} row ${i} number of values != ${numCols}`);
         }
     }
 }
@@ -104,6 +132,6 @@ function validateErrorResult(result: any, rsIdx: number) {
         throw new Error(`Result ${rsIdx} results was not an object`);
     }
     if (typeof result.error.message !== "string") {
-        throw new Error(`Result ${rsIdx} error message was not a string`)
+        throw new Error(`Result ${rsIdx} error message was not a string`);
     }
 }

--- a/packages/libsql-client/src/lib/driver/SqliteDriver.ts
+++ b/packages/libsql-client/src/lib/driver/SqliteDriver.ts
@@ -1,55 +1,77 @@
 import DatabaseConstructor, {Database, SqliteError, Statement} from "better-sqlite3";
-import { ResultSet } from "../libsql-js";
+import { BoundStatement, Params, ResultSet, SqlValue } from "../libsql-js";
 import { Driver } from "./Driver";
 
 export class SqliteDriver implements Driver {
-    db: Database;
+    private db: Database;
+
     constructor(url: string) {
         this.db = new DatabaseConstructor(url.substring(5))
     }
-    async transaction(sqls: string[]): Promise<ResultSet[]> {
-        const result = [];
-        for (let sql of sqls) {
-            const rs = await this.execute(sql);
-            result.push(rs);
-        }
-        return result;
-    }
-    async execute(sql: string): Promise<ResultSet> {
+
+    async execute(sql: string, params?: Params): Promise<ResultSet> {
         return await new Promise(resolve => {
-            let stmt: Statement
+            let columns: string[];
+            let rows: any[];
+
             try {
-                stmt = this.db.prepare(sql);
+                const stmt = this.db.prepare(sql);
+                if (stmt.reader) {
+                    columns = stmt.columns().map(c => c.name);
+                    if (params === undefined) {
+                        rows = stmt.all()
+                    } else {
+                        rows = stmt.all(params)
+                    }
+                    rows = rows.map(row => {
+                        return columns.map(column => row[column]);
+                    });
+                } else {
+                    columns = [];
+                    rows = [];
+                    if (params === undefined) {
+                        stmt.run();
+                    } else {
+                        stmt.run(params);
+                    }
+                }
             } catch (e: any) {
                 resolve({
                     success: false,
                     error: { message: e.message },
                     meta: { duration: 0 },
-                })
-                return
-            }
-            var columns: string[];
-            var rows: any[];
-            if (stmt.reader) {
-                columns = stmt.columns().map(c => c.name);
-                rows = stmt.all().map(row => {
-                    return columns.map(column => row[column]);
                 });
-            } else {
-                columns = [];
-                rows = [];
-                stmt.run();
+                return;
             }
-            // FIXME: error handling
-            const rs = {
+
+            resolve({
+                success: true,
                 columns,
                 rows,
-                success: true,
-                meta: {
-                    duration: 0,
-                },
-            };
-            resolve(rs);
+                meta: { duration: 0 },
+            });
         });
+    }
+
+    async transaction(stmts: (string | BoundStatement)[]): Promise<ResultSet[]> {
+        // TODO this is not really a "transaction", however, the better-sqlite3
+        // transaction API blocks the event loop and does not work with async
+        // functions. We need to investigate working the transaction manually
+        // with begin/commit, however, that likely does not support concurrent
+        // overlapping invocations from multiple procedures in the same process.
+        //
+        // https://github.com/WiseLibs/better-sqlite3/blob/HEAD/docs/api.md#transactionfunction---function
+
+        const result = [];
+        for (const stmt of stmts) {
+            let rs;
+            if (typeof stmt === "string") {
+                rs = await this.execute(stmt);
+            } else {
+                rs = await this.execute(stmt.sql, stmt.params);
+            }
+            result.push(rs);
+        }
+        return result;
     }
 }

--- a/packages/libsql-client/src/lib/libsql-js.ts
+++ b/packages/libsql-client/src/lib/libsql-js.ts
@@ -3,75 +3,80 @@ import { HttpDriver } from "./driver/HttpDriver";
 import { SqliteDriver } from "./driver/SqliteDriver";
 
 export type Config = {
-  url: string,
+    url: string,
 };
 
 /**
  * A SQL query result set row.
  */
-export type Row = Record<string, string | number | boolean | null>;
+export type Row = Record<string, SqlValue>;
+export type SqlValue = string | number | boolean | null;
+export type Params = SqlValue[] | Record<string, SqlValue>;
+export type BoundStatement = { sql: string, params: Params };
 
 /**
  * A SQL query result set.
  */
 export type ResultSet = {
-  /**
-   * Was the query successful?
-   * If true, rows and columns are provided.
-   * If false, error is provided
-   */
-  success: boolean;
-  /**
-   * Query result columns.
-   */
-  columns?: string[];
-  /**
-   * Query results.
-   */
-  rows?: Row[];
-  error?: {
-    message: string
-  }
-  /**
-   * Extra information about the query results.
-   */
-  meta: {
-    duration: number;
-  };
+    /**
+     * Was the query successful?
+     * If true, rows and columns are provided.
+     * If false, error is provided
+     */
+    success: boolean;
+    /**
+     * Query result columns.
+     */
+    columns?: string[];
+    /**
+     * Query results.
+     */
+    rows?: Row[];
+    /**
+     * Error information, if not successful.
+     */
+    error?: {
+        message: string;
+    };
+    /**
+     * Extra information about the query results.
+     */
+    meta: {
+        duration: number;
+    };
 };
 
 /**
  * A libSQL database connection.
  */
 export class Connection {
-  driver: Driver;
+    private driver: Driver;
 
-  constructor(driver: Driver) {
-    this.driver = driver;
-  }
+    constructor(driver: Driver) {
+        this.driver = driver;
+    }
 
-  /**
-   * Execute a SQL statement in a transaction.
-   */
-  async execute(sql: string): Promise<ResultSet> {
-    const results = await this.transaction([sql]) 
-    return results[0];
-  }
+    /**
+     * Execute a SQL statement in a transaction.
+     */
+    async execute(sql: string, params?: Params): Promise<ResultSet> {
+        return this.driver.execute(sql, params);
+    }
 
-  /**
-   * Execute a batch of SQL statements in a transaction.
-   */
-  async transaction(stmts: string[]): Promise<ResultSet[]> {
-    return await this.driver.transaction(stmts);
-  }
+    /**
+     * Execute a batch of SQL statements in a transaction.
+     */
+    async transaction(stmts: string[] | BoundStatement[]): Promise<ResultSet[]> {
+        return await this.driver.transaction(stmts);
+    }
 }
 
 export function connect(config: Config): Connection {
-  const rawUrl = config.url;
-  const url = new URL(rawUrl);
-  if (url.protocol == "http:" || url.protocol == "https:") {
-    return new Connection(new HttpDriver(url))
-  } else {
-    return new Connection(new SqliteDriver(rawUrl));
-  }
+    const rawUrl = config.url;
+    const url = new URL(rawUrl);
+    if (url.protocol == "http:" || url.protocol == "https:") {
+        return new Connection(new HttpDriver(url));
+    } else {
+        return new Connection(new SqliteDriver(rawUrl));
+    }
 }


### PR DESCRIPTION
This adds the ability to bind parameters to statements in the client library as was introduced to sqld in #45.  So you can now do queries like these using positional or named parameters:

```ts
db.execute(`INSERT INTO table (email) VALUES (?)`, [value]);

db.execute(`SELECT * FROM table WHERE email = :email`, { email: value });
```