### PR TITLE
db dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
  "bytes",
  "crc",
  "futures",
- "sqld",
+ "sqld-libsql-bindings",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3506,9 +3506,6 @@ dependencies = [
  "insta",
  "itertools",
  "jsonwebtoken",
- "libsql-wasmtime-bindings",
- "mvfs",
- "mwal",
  "once_cell",
  "parking_lot",
  "pgwire",
@@ -3523,6 +3520,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "sqld-libsql-bindings",
  "sqlite3-parser",
  "tempfile",
  "thiserror",
@@ -3538,6 +3536,18 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "vergen",
+]
+
+[[package]]
+name = "sqld-libsql-bindings"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "libsql-wasmtime-bindings",
+ "mvfs",
+ "mwal",
+ "rusqlite",
+ "tracing",
 ]
 
 [[package]]

--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -205,6 +205,7 @@ impl LibSqlDb {
         let (sender, receiver) = crossbeam::channel::unbounded::<Message>();
 
         tokio::task::spawn_blocking(move || {
+            let path = path.as_ref().join("data");
             let conn = open_db(
                 path,
                 #[cfg(feature = "mwal_backend")]

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -144,6 +144,11 @@ pub async fn run_server(config: Config) -> anyhow::Result<()> {
         ))
     });
 
+    // create database directory where all the files will go.
+    if !config.db_path.exists() {
+        std::fs::create_dir_all(&config.db_path)?;
+    }
+
     match config.writer_rpc_addr {
         Some(ref addr) => {
             let factory = WriteProxyDbFactory::new(
@@ -162,7 +167,7 @@ pub async fn run_server(config: Config) -> anyhow::Result<()> {
             run_service(service, config).await?;
         }
         None => {
-            let logger = Arc::new(WalLogger::open("wallog").context("failed to open WalLogger")?);
+            let logger = Arc::new(WalLogger::open(&config.db_path)?);
             let logger_clone = logger.clone();
             let path_clone = config.db_path.clone();
             let db_factory = move || {

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -9,7 +9,7 @@ use sqld::Config;
 #[command(name = "sqld")]
 #[command(about = "SQL daemon", long_about = None)]
 struct Cli {
-    #[clap(long, short, default_value = "iku.db", env = "SQLD_DB_PATH")]
+    #[clap(long, short, default_value = "data.sqld", env = "SQLD_DB_PATH")]
     db_path: PathBuf,
     /// The address and port the PostgreSQL server listens to.
     #[clap(long, short, env = "SQLD_PG_LISTEN_ADDR")]

--- a/sqld/src/wal_logger.rs
+++ b/sqld/src/wal_logger.rs
@@ -137,6 +137,7 @@ impl WalLogger {
     pub const HEADER_SIZE: usize = 4096;
 
     pub fn open(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let path = path.as_ref().join("wallog");
         let mut log_file = OpenOptions::new()
             .create(true)
             .write(true)
@@ -218,8 +219,8 @@ mod test {
 
     #[test]
     fn write_and_read_from_frame_log() {
-        let log_file = tempfile::NamedTempFile::new().unwrap();
-        let logger = WalLogger::open(log_file.path()).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let logger = WalLogger::open(dir.path()).unwrap();
 
         assert_eq!(*logger.current_offset.lock(), WalLogger::HEADER_SIZE);
 
@@ -246,16 +247,16 @@ mod test {
 
     #[test]
     fn index_out_of_bounds() {
-        let log_file = tempfile::NamedTempFile::new().unwrap();
-        let logger = WalLogger::open(log_file.path()).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let logger = WalLogger::open(dir.path()).unwrap();
         assert!(logger.get_entry(1).unwrap().is_none());
     }
 
     #[test]
     #[should_panic]
     fn incorrect_frame_size() {
-        let log_file = tempfile::NamedTempFile::new().unwrap();
-        let logger = WalLogger::open(log_file.path()).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let logger = WalLogger::open(dir.path()).unwrap();
         let entry = WalLogEntry::Frame {
             page_no: 0,
             data: vec![0; 3].into(),


### PR DESCRIPTION
This pr adds all the files created by sqld to a directory, instead of creating multiple standalone files.

It also renames the default db name from `iku.db` to `data.sqld`
