### PR TITLE
Node client for the Hrana protocol

### DIFF
--- a/docs/HRANA_SPEC.md
+++ b/docs/HRANA_SPEC.md
@@ -158,8 +158,7 @@ type ResponseErrorMsg = {
 When the server receives a `request` message, it must eventually send either a
 `response_ok` with the response or a `response_error` that describes a failure.
 The response from the server includes the same `request_id` that was provided by
-the client in the request. The server can process the requests asynchronously
-and send the responses in arbitrary order.
+the client in the request. The server can send the responses in arbitrary order.
 
 The request ids are arbitrary 32-bit signed integers, the server does not
 interpret them in any way.
@@ -333,3 +332,13 @@ precision, because some JSON implementations treat all numbers as 64-bit floats
 
 These types exactly correspond to SQLite types. In the future, the protocol
 might be extended with more types for compatibility with Postgres.
+
+### Ordering
+
+The protocol allows the server to reorder the responses: it is not necessary to
+send the responses in the same order as the requests. However, the server must
+process requests related to a single stream id in order.
+
+For example, this means that a client can send an `open_stream` request
+immediately followed by a batch of `execute` requests on that stream and the
+server will always process them in correct order.

--- a/packages/hrana-client/.gitignore
+++ b/packages/hrana-client/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+/lib
+package-lock.json

--- a/packages/hrana-client/.gitignore
+++ b/packages/hrana-client/.gitignore
@@ -1,3 +1,5 @@
 node_modules
-/lib
+/lib-esm
+/lib-cjs
 package-lock.json
+*.tsbuildinfo

--- a/packages/hrana-client/jest.config.js
+++ b/packages/hrana-client/jest.config.js
@@ -1,0 +1,4 @@
+// https://jestjs.io/docs/configuration
+module.exports = {
+    preset: "ts-jest/presets/default",
+}

--- a/packages/hrana-client/jest.config.js
+++ b/packages/hrana-client/jest.config.js
@@ -1,4 +1,7 @@
 // https://jestjs.io/docs/configuration
-module.exports = {
-    preset: "ts-jest/presets/default",
+export default {
+    preset: "ts-jest/presets/default-esm",
+    moduleNameMapper: {
+        '^(\\.{1,2}/.*)\\.js$': '$1',
+    },
 }

--- a/packages/hrana-client/package-cjs.json
+++ b/packages/hrana-client/package-cjs.json
@@ -1,0 +1,3 @@
+{
+    "type": "commonjs"
+}

--- a/packages/hrana-client/package.json
+++ b/packages/hrana-client/package.json
@@ -1,18 +1,26 @@
 {
   "name": "@libsql/hrana-client",
-  "type": "commonjs",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+
+  "type": "module",
+  "main": "lib-cjs/index.js",
+  "types": "lib-esm/index.d.ts",
   "exports": {
     ".": {
-      "types": "./lib/index.d.ts",
-      "default": "./lib/index.js"
+      "types": "./lib-esm/index.d.ts",
+      "require": "./lib-cjs/index.js",
+      "default": "./lib-esm/index.js"
     }
   },
+
   "scripts": {
-    "build": "tsc",
+    "prebuild": "rm -rf ./lib-cjs ./lib-esm",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "tsc -p tsconfig.build-cjs.json",
+    "build:esm": "tsc -p tsconfig.build-esm.json",
+    "postbuild": "cp package-cjs.json ./lib-cjs/package.json",
     "test": "jest"
   },
+
   "dependencies": {
     "isomorphic-ws": "^5.0.0"
   },

--- a/packages/hrana-client/package.json
+++ b/packages/hrana-client/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@libsql/hrana-client",
+  "type": "commonjs",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
+  "dependencies": {
+    "isomorphic-ws": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.4.0",
+    "@types/ws": "^8.5.4",
+    "jest": "^29.4.0",
+    "ts-jest": "^29.0.5",
+    "typescript": "^4.9.4"
+  }
+}

--- a/packages/hrana-client/src/__tests__/index.ts
+++ b/packages/hrana-client/src/__tests__/index.ts
@@ -1,0 +1,12 @@
+import * as hrana from "..";
+
+function openClient(): hrana.Client {
+    return hrana.open("ws://localhost:2023");
+}
+
+test("simple query", async () => {
+    const c = openClient();
+    const s = c.openStream();
+    expect(await s.queryValue("SELECT 1")).toStrictEqual(1);
+    c.close();
+})

--- a/packages/hrana-client/src/__tests__/index.ts
+++ b/packages/hrana-client/src/__tests__/index.ts
@@ -1,12 +1,99 @@
 import * as hrana from "..";
 
-function openClient(): hrana.Client {
-    return hrana.open("ws://localhost:2023");
+function withClient(f: (c: hrana.Client) => Promise<void>): () => Promise<void> {
+    return async () => {
+        const c = hrana.open("ws://localhost:2023");
+        try {
+            await f(c);
+        } finally {
+            c.close();
+        }
+    };
 }
 
-test("simple query", async () => {
-    const c = openClient();
+test("Stream.queryValue()", withClient(async (c) => {
     const s = c.openStream();
     expect(await s.queryValue("SELECT 1")).toStrictEqual(1);
-    c.close();
-})
+    expect(await s.queryValue("SELECT 'elephant'")).toStrictEqual("elephant");
+    expect(await s.queryValue("SELECT 42.5")).toStrictEqual(42.5);
+    expect(await s.queryValue("SELECT NULL")).toStrictEqual(null);
+}));
+
+test("Stream.queryRow()", withClient(async (c) => {
+    const s = c.openStream();
+    
+    const row = await s.queryRow(
+        "SELECT 1 AS one, 'elephant' AS two, 42.5 AS three, NULL as four");
+    expect(row[0]).toStrictEqual(1);
+    expect(row[1]).toStrictEqual("elephant");
+    expect(row[2]).toStrictEqual(42.5);
+    expect(row[3]).toStrictEqual(null);
+
+    expect(row[0]).toStrictEqual(row.one);
+    expect(row[1]).toStrictEqual(row.two);
+    expect(row[2]).toStrictEqual(row.three);
+    expect(row[3]).toStrictEqual(row.four);
+}));
+
+test("Stream.query()", withClient(async (c) => {
+    const s = c.openStream();
+
+    await s.execute("BEGIN");
+    await s.execute("CREATE TABLE t (one, two, three, four)");
+    await s.execute(
+        `INSERT INTO t VALUES
+            (1, 'elephant', 42.5, NULL),
+            (2, 'hippopotamus', '123', 0.0)`
+    );
+
+    const rows = await s.query("SELECT * FROM t ORDER BY one");
+    expect(rows.length).toStrictEqual(2);
+    expect(rows.rowsAffected).toStrictEqual(-1);
+
+    const row0 = rows[0];
+    expect(row0[0]).toStrictEqual(1);
+    expect(row0[1]).toStrictEqual("elephant");
+    expect(row0["three"]).toStrictEqual(42.5);
+    expect(row0["four"]).toStrictEqual(null);
+
+    const row1 = rows[1];
+    expect(row1["one"]).toStrictEqual(2);
+    expect(row1["two"]).toStrictEqual("hippopotamus");
+    expect(row1[2]).toStrictEqual("123");
+    expect(row1[3]).toStrictEqual(0.0);
+}));
+
+test("Stream.execute()", withClient(async (c) => {
+    const s = c.openStream();
+
+    let res = await s.execute("BEGIN");
+    expect(res.rowsAffected).toStrictEqual(-1);
+
+    res = await s.execute("CREATE TABLE t (num, word)");
+    expect(res.rowsAffected).toStrictEqual(-1);
+
+    res = await s.execute("INSERT INTO t VALUES (1, 'one'), (2, 'two'), (3, 'three')");
+    expect(res.rowsAffected).toStrictEqual(3);
+
+    res = await s.execute("DELETE FROM t WHERE num >= 2");
+    expect(res.rowsAffected).toStrictEqual(2);
+
+    res = await s.execute("UPDATE t SET num = 4, word = 'four'");
+    expect(res.rowsAffected).toStrictEqual(1);
+}));
+
+test("concurrent streams", withClient(async (c) => {
+    const s1 = c.openStream();
+    await s1.execute("CREATE TABLE t (number)");
+    await s1.execute("INSERT INTO t VALUES (1)");
+
+    const s2 = c.openStream();
+
+    await s1.execute("BEGIN");
+
+    await s2.execute("BEGIN");
+    await s2.execute("INSERT INTO t VALUES (10)");
+
+    expect(await s1.queryValue("SELECT SUM(number) FROM t")).toStrictEqual(1);
+    expect(await s2.queryValue("SELECT SUM(number) FROM t")).toStrictEqual(11);
+}));

--- a/packages/hrana-client/src/convert.ts
+++ b/packages/hrana-client/src/convert.ts
@@ -1,0 +1,95 @@
+import type * as proto from "./proto";
+
+/** A statement that you can send to the database. Either a plain SQL string, or an SQL string together with
+ * values for the `?` parameters.
+ */
+export type Stmt =
+    | string
+    | [string, Array<Value>];
+
+export function stmtToProto(stmtLike: Stmt, wantRows: boolean): proto.Stmt {
+    let sql;
+    let args: Array<proto.Value> = [];
+    if (typeof stmtLike === "string") {
+        sql = stmtLike;
+    } else {
+        sql = stmtLike[0];
+        args = stmtLike[1].map(valueToProto);
+    }
+
+    return {"sql": sql, "args": args, "want_rows": wantRows};
+}
+
+/** JavaScript values that you can get from the database. */
+export type Value =
+    | null
+    | string
+    | number
+    | ArrayBuffer;
+
+export function valueToProto(value: Value): proto.Value {
+    if (value === null) {
+        return {"type": "null"};
+    } else if (typeof value === "number") {
+        return {"type": "float", "value": +value};
+    } else if (value instanceof ArrayBuffer) {
+        throw new Error("ArrayBuffer is not yet supported");
+    } else {
+        return {"type": "text", "value": ""+value};
+    }
+}
+
+export function valueFromProto(value: proto.Value): Value {
+    if (value["type"] === "null") {
+        return null;
+    } else if (value["type"] === "integer") {
+        return parseInt(value["value"], 10);
+    } else if (value["type"] === "float") {
+        return value["value"];
+    } else if (value["type"] === "text") {
+        return value["value"];
+    } else if (value["type"] === "blob") {
+        throw new Error("blob is not yet supported");
+    } else {
+        throw new Error("Unexpected value type");
+    }
+}
+
+export function rowArrayFromProto(result: proto.StmtResult): RowArray {
+    const array = new RowArray();
+    for (const row of result["rows"]) {
+        array.push(rowFromProto(result, row));
+    }
+    return array;
+}
+
+export function rowFromProto(result: proto.StmtResult, row: Array<proto.Value>): Row {
+    const array = row.map((value) => valueFromProto(value));
+    Object.setPrototypeOf(array, Row.prototype);
+
+    for (let i = 0; i < result["cols"].length; ++i) {
+        const colName = result["cols"][i]["name"];
+        if (colName && !Object.hasOwn(array, colName)) {
+            Object.defineProperty(array, colName, {
+                value: array[i],
+                enumerable: true,
+            });
+        }
+    }
+
+    return array;
+}
+
+export function errorFromProto(error: proto.Error): Error {
+    return new Error(`Server returned error ${JSON.stringify(error["message"])}`);
+}
+
+export class RowArray extends Array<Row> {
+    constructor() {
+        super();
+        Object.setPrototypeOf(this, RowArray.prototype);
+    }
+}
+
+export class Row extends Array<Value> {
+}

--- a/packages/hrana-client/src/convert.ts
+++ b/packages/hrana-client/src/convert.ts
@@ -1,4 +1,4 @@
-import type * as proto from "./proto";
+import type * as proto from "./proto.js";
 
 /** A statement that you can send to the database. Either a plain SQL string, or an SQL string together with
  * values for the `?` parameters.

--- a/packages/hrana-client/src/id_alloc.ts
+++ b/packages/hrana-client/src/id_alloc.ts
@@ -1,0 +1,53 @@
+// An allocator of non-negative integer ids.
+//
+// This clever data structure has these "ideal" properties:
+// - It consumes memory proportional to the number of used ids (which is optimal).
+// - All operations are O(1) time.
+// - The allocated ids are small (with a slight modification, we could always provide the smallest possible
+// id).
+export default class IdAlloc {
+    // Set of all allocated ids
+    #usedIds: Set<number>;
+    // Set of all free ids lower than `#usedIds.size`
+    #freeIds: Set<number>;
+
+    constructor() {
+        this.#usedIds = new Set();
+        this.#freeIds = new Set();
+    }
+
+    // Returns an id that was free, and marks it as used.
+    alloc(): number {
+        // this "loop" is just a way to pick an arbitrary element from the `#freeIds` set
+        for (const freeId of this.#freeIds) {
+            this.#freeIds.delete(freeId);
+            this.#usedIds.add(freeId);
+
+            // maintain the invariant of `#freeIds`
+            if (!this.#usedIds.has(this.#usedIds.size - 1)) {
+                this.#freeIds.add(this.#usedIds.size - 1);
+            }
+            return freeId;
+        }
+
+        // the `#freeIds` set is empty, so there are no free ids lower than `#usedIds.size`
+        // this means that `#usedIds` is a set that contains all numbers from 0 to `#usedIds.size - 1`,
+        // so `#usedIds.size` is free
+        const freeId = this.#usedIds.size;
+        this.#usedIds.add(freeId);
+        return freeId;
+    }
+
+    free(id: number) {
+        if (!this.#usedIds.delete(id)) {
+            throw new Error("Internal error: freeing an id that is not allocated");
+        }
+
+        // maintain the invariant of `#freeIds`
+        this.#freeIds.delete(this.#usedIds.size);
+        if (id < this.#usedIds.size) {
+            this.#freeIds.add(id);
+        }
+    }
+}
+

--- a/packages/hrana-client/src/index.ts
+++ b/packages/hrana-client/src/index.ts
@@ -1,0 +1,348 @@
+import WebSocket from "isomorphic-ws";
+
+import type { Stmt, Value, Row, RowArray } from "./convert";
+import { rowArrayFromProto, stmtToProto, rowFromProto, valueFromProto, errorFromProto } from "./convert";
+import IdAlloc from "./id_alloc";
+import type * as proto from "./proto";
+
+export type { Stmt, Value, Row, RowArray } from "./convert";
+
+/** Open a Hrana client connected to the given `url`. */
+export function open(url: string, jwt?: string): Client {
+    const socket = new WebSocket(url, ["hrana1"]);
+    return new Client(socket, jwt ?? null);
+}
+
+/** A client that talks to a SQL server using the Hrana protocol over a WebSocket. */
+export class Client {
+    #socket: WebSocket;
+    // List of messages that we queue until the socket transitions from the CONNECTING to the OPEN state.
+    #msgsWaitingToOpen: proto.ClientMsg[];
+    // Stores the error that caused us to close the client (and the socket). If we are not closed, this is
+    // `undefined`.
+    #closed: Error | undefined;
+
+    // Have we received a response to our "hello" from the server?
+    #recvdHello: boolean;
+    // A map from request id to the responses that we expect to receive from the server.
+    #responseMap: Map<number, ResponseState>;
+    // An allocator of request ids.
+    #requestIdAlloc: IdAlloc;
+    // An allocator of stream ids.
+    #streamIdAlloc: IdAlloc;
+
+    /** @private */
+    constructor(socket: WebSocket, jwt: string | null) {
+        this.#socket = socket;
+        this.#socket.binaryType = "arraybuffer";
+        this.#msgsWaitingToOpen = [];
+        this.#closed = undefined;
+
+        this.#recvdHello = false;
+        this.#responseMap = new Map();
+        this.#requestIdAlloc = new IdAlloc();
+        this.#streamIdAlloc = new IdAlloc();
+
+        this.#socket.onopen = () => this.#onSocketOpen();
+        this.#socket.onclose = (event) => this.#onSocketClose(event);
+        this.#socket.onerror = (event) => this.#onSocketError(event);
+        this.#socket.onmessage = (event) => this.#onSocketMessage(event);
+
+        this.#send({"type": "hello", "jwt": jwt});
+    }
+
+    // Send (or enqueue to send) a message to the server.
+    #send(msg: proto.ClientMsg): void {
+        if (this.#closed !== undefined) {
+            throw new Error("Internal error: trying to send a message on a closed client");
+        }
+
+        if (this.#socket.readyState >= WebSocket.OPEN) {
+            this.#sendToSocket(msg);
+        } else {
+            this.#msgsWaitingToOpen.push(msg);
+        }
+    }
+
+    // The socket transitioned from CONNECTING to OPEN
+    #onSocketOpen(): void {
+        for (const msg of this.#msgsWaitingToOpen) {
+            this.#sendToSocket(msg);
+        }
+        this.#msgsWaitingToOpen.length = 0;
+    }
+
+    #sendToSocket(msg: proto.ClientMsg): void {
+        this.#socket.send(JSON.stringify(msg));
+    }
+
+    // Send a request to the server and invoke a callback when we get the response.
+    #sendRequest(request: proto.Request, callbacks: ResponseCallbacks) {
+        const requestId = this.#requestIdAlloc.alloc();
+        this.#responseMap.set(requestId, {...callbacks, type: request.type});
+        this.#send({"type": "request", "request_id": requestId, request});
+    }
+
+    // The socket encountered an error.
+    #onSocketError(event: Event | WebSocket.ErrorEvent): void {
+        const eventMessage = (event as {message?: string}).message;
+        const message = eventMessage ?? "Connection was closed due to an error";
+        this.#setClosed(new Error(message));
+    }
+
+    // The socket was closed.
+    #onSocketClose(event: WebSocket.CloseEvent): void {
+        this.#setClosed(new Error(`WebSocket was closed with code ${event.code}: ${event.reason}`));
+    }
+
+    // Close the client with the given error.
+    #setClosed(error: Error): void {
+        if (this.#closed !== undefined) {
+            return;
+        }
+        this.#closed = error;
+
+        for (const [requestId, responseState] of this.#responseMap.entries()) {
+            responseState.errorCallback(error);
+            this.#requestIdAlloc.free(requestId);
+        }
+        this.#responseMap.clear();
+
+        this.#socket.close();
+    }
+
+    // We received a message from the socket.
+    #onSocketMessage(event: WebSocket.MessageEvent): void {
+        if (typeof event.data !== "string") {
+            this.#socket.close(3003, "Only string messages are accepted");
+            this.#setClosed(new Error("Received non-string message from server"))
+            return;
+        }
+
+        try {
+            this.#handleMsg(event.data);
+        } catch (e) {
+            this.#socket.close(3007, "Could not handle message");
+            this.#setClosed(new Error("Error while handling message from server", {cause: e}));
+        }
+    }
+
+    // Handle a message from the server.
+    #handleMsg(msgText: string): void {
+        const msg = JSON.parse(msgText) as proto.ServerMsg;
+
+        if (msg["type"] === "hello_ok" || msg["type"] === "hello_error") {
+            if (this.#recvdHello) {
+                throw new Error("Received a duplicated hello response");
+            }
+            this.#recvdHello = true;
+
+            if (msg["type"] === "hello_error") {
+                throw errorFromProto(msg["error"]);
+            }
+            return;
+        } else if (!this.#recvdHello) {
+            throw new Error("Received a non-hello message before a hello response");
+        }
+
+        if (msg["type"] === "response_ok") {
+            const requestId = msg["request_id"];
+            const responseState = this.#responseMap.get(requestId);
+            this.#responseMap.delete(requestId);
+
+            if (responseState === undefined) {
+                throw new Error("Received unexpected OK response");
+            } else if (responseState.type !== msg["response"]["type"]) {
+                throw new Error("Received unexpected type of response");
+            }
+
+            try {
+                responseState.responseCallback(msg["response"]);
+            } catch (e) {
+                responseState.errorCallback(e as Error);
+                throw e;
+            }
+        } else if (msg["type"] === "response_error") {
+            const requestId = msg["request_id"];
+            const responseState = this.#responseMap.get(requestId);
+            this.#responseMap.delete(requestId);
+
+            if (responseState === undefined) {
+                throw new Error("Received unexpected error response");
+            }
+            responseState.errorCallback(errorFromProto(msg["error"]));
+        } else {
+            throw new Error("Received unexpected message type");
+        }
+    }
+
+    /** Open a {@link Stream}, a stream for executing SQL statements. */
+    openStream(): Stream {
+        if (this.#closed !== undefined) {
+            throw new Error("Client is closed", {cause: this.#closed});
+        }
+
+        const streamId = this.#streamIdAlloc.alloc();
+        const streamState = {
+            streamId,
+            closed: undefined,
+        };
+
+        const responseCallback = () => undefined;
+        const errorCallback = (e: Error) => this._closeStream(streamState, e);
+
+        const request: proto.OpenStreamReq = {
+            "type": "open_stream",
+            "stream_id": streamId,
+        };
+        this.#sendRequest(request, {responseCallback, errorCallback});
+
+        return new Stream(this, streamState);
+    }
+
+    // Make sure that the stream is closed.
+    /** @private */
+    _closeStream(streamState: StreamState, error: Error): void {
+        if (streamState.closed !== undefined || this.#closed !== undefined) {
+            return;
+        }
+        streamState.closed = error;
+
+        const callback = () => {
+            this.#streamIdAlloc.free(streamState.streamId);
+        };
+        const request: proto.CloseStreamReq = {
+            "type": "close_stream",
+            "stream_id": streamState.streamId,
+        };
+        this.#sendRequest(request, {responseCallback: callback, errorCallback: callback});
+    }
+
+    // Execute a statement on a stream and invoke callbacks in `stmtState` when we get the results (or an
+    // error).
+    /** @private */
+    _execute(streamState: StreamState, stmtState: StmtState): void {
+        const responseCallback = (response: proto.Response) => {
+            stmtState.resultCallback((response as proto.ExecuteResp)["result"]);
+        };
+        const errorCallback = (error: Error) => {
+            stmtState.errorCallback(error);
+        }
+
+        if (streamState.closed !== undefined) {
+            errorCallback(new Error("Stream was closed", {cause: streamState.closed}));
+            return;
+        } else if (this.#closed !== undefined) {
+            errorCallback(new Error("Client was closed", {cause: this.#closed}));
+            return;
+        }
+
+        const request: proto.ExecuteReq = {
+            "type": "execute",
+            "stream_id": streamState.streamId,
+            "stmt": stmtState.stmt,
+        };
+        this.#sendRequest(request, {responseCallback, errorCallback});
+    }
+
+    /** Close the client and the WebSocket. */
+    close() {
+        this.#setClosed(new Error("Client was manually closed"));
+    }
+}
+
+interface ResponseCallbacks {
+    responseCallback: (_: proto.Response) => void;
+    errorCallback: (_: Error) => void;
+}
+
+interface ResponseState extends ResponseCallbacks {
+    type: string;
+}
+
+interface StmtState {
+    stmt: proto.Stmt;
+    resultCallback: (_: proto.StmtResult) => void;
+    errorCallback: (_: Error) => void;
+}
+
+interface StreamState {
+    streamId: number;
+    closed: Error | undefined;
+}
+
+/** A stream for executing SQL statements (a "database connection"). */
+export class Stream {
+    #client: Client;
+    #state: StreamState;
+
+    /** @private */
+    constructor(client: Client, state: StreamState) {
+        this.#client = client;
+        this.#state = state;
+    }
+
+    /** Execute a statement that returns rows. */
+    query(stmt: Stmt): Promise<RowArray> {
+        return new Promise((rowsCallback, errorCallback) => {
+            this.#client._execute(this.#state, {
+                stmt: stmtToProto(stmt, true),
+                resultCallback(result) {
+                    rowsCallback(rowArrayFromProto(result))
+                },
+                errorCallback,
+            });
+        });
+    }
+
+    /** Execute a statement that returns at most a single row. */
+    queryRow(stmt: Stmt): Promise<Row | undefined> {
+        return new Promise((rowCallback, errorCallback) => {
+            this.#client._execute(this.#state, {
+                stmt: stmtToProto(stmt, true),
+                resultCallback(result) {
+                    if (result.rows.length >= 1) {
+                        rowCallback(rowFromProto(result, result.rows[0]));
+                    } else {
+                        rowCallback(undefined);
+                    }
+                },
+                errorCallback,
+            });
+        });
+    }
+
+    /** Execute a statement that returns at most single value. */
+    queryValue(stmt: Stmt): Promise<Value | undefined> {
+        return new Promise((valueCallback, errorCallback) => {
+            this.#client._execute(this.#state, {
+                stmt: stmtToProto(stmt, true),
+                resultCallback(result) {
+                    if (result.rows.length >= 1 && result.rows[0].length >= 1) {
+                        valueCallback(valueFromProto(result.rows[0][0]));
+                    } else {
+                        valueCallback(undefined);
+                    }
+                },
+                errorCallback,
+            });
+        });
+    }
+
+    /** Execute a statement that does not return rows. */
+    execute(stmt: Stmt): Promise<void> {
+        return new Promise((doneCallback, errorCallback) => {
+            this.#client._execute(this.#state, {
+                stmt: stmtToProto(stmt, false),
+                resultCallback() { doneCallback(); },
+                errorCallback,
+            });
+        });
+    }
+
+    /** Close the stream. */
+    close(): void {
+        this.#client._closeStream(this.#state, new Error("Stream was manually closed"));
+    }
+}
+

--- a/packages/hrana-client/src/index.ts
+++ b/packages/hrana-client/src/index.ts
@@ -1,11 +1,14 @@
 import WebSocket from "isomorphic-ws";
 
-import type { Stmt, Value, Row, RowArray } from "./convert";
-import { rowArrayFromProto, stmtToProto, rowFromProto, valueFromProto, errorFromProto } from "./convert";
+import type { Stmt, Value, StmtResult, RowArray, Row } from "./convert";
+import {
+    stmtToProto, rowArrayFromProto, rowFromProto,
+    stmtResultFromProto, valueFromProto, errorFromProto,
+} from "./convert";
 import IdAlloc from "./id_alloc";
 import type * as proto from "./proto";
 
-export type { Stmt, Value, Row, RowArray } from "./convert";
+export type { Stmt, Value, StmtResult, RowArray, Row } from "./convert";
 
 /** Open a Hrana client connected to the given `url`. */
 export function open(url: string, jwt?: string): Client {
@@ -330,11 +333,11 @@ export class Stream {
     }
 
     /** Execute a statement that does not return rows. */
-    execute(stmt: Stmt): Promise<void> {
+    execute(stmt: Stmt): Promise<StmtResult> {
         return new Promise((doneCallback, errorCallback) => {
             this.#client._execute(this.#state, {
                 stmt: stmtToProto(stmt, false),
-                resultCallback() { doneCallback(); },
+                resultCallback(result) { doneCallback(stmtResultFromProto(result)); },
                 errorCallback,
             });
         });

--- a/packages/hrana-client/src/index.ts
+++ b/packages/hrana-client/src/index.ts
@@ -1,12 +1,12 @@
 import WebSocket from "isomorphic-ws";
 
-import type { Stmt, Value, StmtResult, RowArray, Row } from "./convert";
+import type { Stmt, Value, StmtResult, RowArray, Row } from "./convert.js";
 import {
     stmtToProto, rowArrayFromProto, rowFromProto,
     stmtResultFromProto, valueFromProto, errorFromProto,
-} from "./convert";
-import IdAlloc from "./id_alloc";
-import type * as proto from "./proto";
+} from "./convert.js";
+import IdAlloc from "./id_alloc.js";
+import type * as proto from "./proto.js";
 
 export type { Stmt, Value, StmtResult, RowArray, Row } from "./convert";
 

--- a/packages/hrana-client/src/proto.ts
+++ b/packages/hrana-client/src/proto.ts
@@ -1,0 +1,129 @@
+// TypeScript types for the messages in the Hrana protocol
+//
+// The structure of this file follows the specification in HRANA_SPEC.md
+
+export type int32 = number
+
+// ## Messages
+
+export type ClientMsg =
+    | HelloMsg
+    | RequestMsg
+
+export type ServerMsg =
+    | HelloOkMsg
+    | HelloErrorMsg
+    | ResponseOkMsg
+    | ResponseErrorMsg
+
+// ### Hello
+
+export type HelloMsg = {
+    "type": "hello",
+    "jwt": string | null,
+}
+
+export type HelloOkMsg = {
+    "type": "hello_ok",
+}
+
+export type HelloErrorMsg = {
+    "type": "hello_error",
+    "error": Error,
+}
+
+// ### Request/response
+
+export type RequestMsg = {
+    "type": "request",
+    "request_id": int32,
+    "request": Request,
+}
+
+export type ResponseOkMsg = {
+    "type": "response_ok",
+    "request_id": int32,
+    "response": Response,
+}
+
+export type ResponseErrorMsg = {
+    "type": "response_error",
+    "request_id": int32,
+    "error": Error,
+}
+
+// ### Errors
+
+export type Error = {
+    "message": string,
+}
+
+// ## Requests
+
+export type Request =
+    | OpenStreamReq
+    | CloseStreamReq
+    | ExecuteReq
+
+export type Response =
+    | OpenStreamResp
+    | CloseStreamResp
+    | ExecuteResp
+
+// ### Open stream
+
+export type OpenStreamReq = {
+    "type": "open_stream",
+    "stream_id": int32,
+}
+
+export type OpenStreamResp = {
+    "type": "open_stream",
+}
+
+// ### Close stream
+
+export type CloseStreamReq = {
+    "type": "close_stream",
+    "stream_id": int32,
+}
+
+export type CloseStreamResp = {
+    "type": "close_stream",
+}
+
+// ### Execute a statement
+
+export type ExecuteReq = {
+    "type": "execute",
+    "stream_id": int32,
+    "stmt": Stmt,
+}
+
+export type ExecuteResp = {
+    "type": "execute",
+    "result": StmtResult,
+}
+
+export type Stmt = {
+    "sql": string,
+    "args": Array<Value>,
+    "want_rows": boolean,
+}
+
+export type StmtResult = {
+    "cols": Array<Col>,
+    "rows": Array<Array<Value>>,
+    "affected_row_count": number,
+}
+
+export type Col = {
+    "name": string | null,
+}
+
+export type Value =
+    | { "type": "null" }
+    | { "type": "integer", "value": string }
+    | { "type": "float", "value": number }
+    | { "type": "text", "value": string }
+    | { "type": "blob", "base64": string }

--- a/packages/hrana-client/test_server.py
+++ b/packages/hrana-client/test_server.py
@@ -2,11 +2,12 @@ import asyncio
 import base64
 import collections
 import json
+import os
 import sqlite3
 import sys
-import websockets
+import tempfile
 
-db_file = sys.argv[1]
+import websockets
 
 async def main():
     server = await websockets.serve(handle_socket, "localhost", 2023, subprotocols=["hrana1"])
@@ -15,7 +16,6 @@ async def main():
     await server.wait_closed()
 
 async def handle_socket(websocket):
-    print(f"Accepted connection from {websocket.remote_address}")
     async def recv_msg():
         try:
             msg_str = await websocket.recv()
@@ -29,24 +29,27 @@ async def handle_socket(websocket):
         msg_str = json.dumps(msg)
         await websocket.send(msg_str)
 
-    Stream = collections.namedtuple("Stream", ["conn", "lock"])
+    db_fd, db_file = tempfile.mkstemp(suffix=".db", prefix="hrana_client_test_")
+    os.close(db_fd)
+    print(f"Accepted connection from {websocket.remote_address}, using db {db_file!r}")
+
+    Stream = collections.namedtuple("Stream", ["conn"])
     streams = {}
 
     async def handle_request(req):
         if req["type"] == "open_stream":
-            conn = await asyncio.to_thread(lambda: sqlite3.connect(db_file))
-            streams[int(req["stream_id"])] = Stream(conn, asyncio.Lock())
+            conn = await asyncio.to_thread(lambda: sqlite3.connect(db_file,
+                check_same_thread=False, isolation_level=None))
+            streams[int(req["stream_id"])] = Stream(conn)
             return {"type": "open_stream"}
         elif req["type"] == "close_stream":
             stream = streams.pop(int(req["stream_id"]), None)
             if stream is not None:
-                async with stream.lock:
-                    await asyncio.to_thread(lambda: stream.conn.close())
+                await asyncio.to_thread(lambda: stream.conn.close())
             return {"type": "close_stream"}
         elif req["type"] == "execute":
             stream = streams[int(req["stream_id"])]
-            async with stream.lock:
-                result = await asyncio.to_thread(lambda: execute_stmt(stream.conn, req["stmt"]))
+            result = await asyncio.to_thread(lambda: execute_stmt(stream.conn, req["stmt"]))
             return {"type": "execute", "result": result}
         else:
             raise RuntimeError(f"Unknown req: {req!r}")
@@ -54,7 +57,7 @@ async def handle_socket(websocket):
     def execute_stmt(conn, stmt):
         params = [value_to_sqlite(arg) for arg in stmt["args"]]
         cursor = conn.execute(stmt["sql"], params)
-        cols = [{"name": name} for name, *_ in cursor.description]
+        cols = [{"name": name} for name, *_ in cursor.description or []]
 
         rows = []
         for row in cursor:
@@ -91,16 +94,8 @@ async def handle_socket(websocket):
         else:
             raise RuntimeError(f"Unknown SQLite value: {value!r}")
 
-    hello_msg = await recv_msg()
-    assert hello_msg.get("type") == "hello"
-    await send_msg({"type": "hello_ok"})
-
-    request_tasks = set()
-    while True:
-        msg = await recv_msg()
-        if msg is None:
-            break
-        elif msg["type"] == "request":
+    async def handle_msg(msg):
+        if msg["type"] == "request":
             response = await handle_request(msg["request"])
             await send_msg({
                 "type": "response_ok",
@@ -110,4 +105,23 @@ async def handle_socket(websocket):
         else:
             raise RuntimeError(f"Unknown msg: {msg!r}")
 
-asyncio.run(main())
+
+    hello_msg = await recv_msg()
+    assert hello_msg.get("type") == "hello"
+    await send_msg({"type": "hello_ok"})
+
+    try:
+        while True:
+            msg = await recv_msg()
+            if msg is None:
+                break
+            await handle_msg(msg)
+    finally:
+        for stream in streams.values():
+            stream.conn.close()
+        os.unlink(db_file)
+
+try:
+    asyncio.run(main())
+except KeyboardInterrupt:
+    print()

--- a/packages/hrana-client/tsconfig.base.json
+++ b/packages/hrana-client/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "moduleResolution": "node",
+        "lib": ["esnext"],
+        "target": "esnext",
+
+        "esModuleInterop": true,
+        "isolatedModules": true,
+
+        "rootDir": "src/",
+
+        "strict": true
+    },
+    "include": ["src/"],
+    "exclude": ["**/__tests__"]
+}

--- a/packages/hrana-client/tsconfig.build-cjs.json
+++ b/packages/hrana-client/tsconfig.build-cjs.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "module": "commonjs",
+        "declaration": false,
+        "outDir": "./lib-cjs/"
+    }
+}
+

--- a/packages/hrana-client/tsconfig.build-esm.json
+++ b/packages/hrana-client/tsconfig.build-esm.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "module": "esnext",
+        "declaration": true,
+        "outDir": "./lib-esm/"
+    }
+}
+

--- a/packages/hrana-client/tsconfig.json
+++ b/packages/hrana-client/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "moduleResolution": "node",
+        "lib": ["esnext"],
+        "target": "esnext",
+        "module": "commonjs",
+
+        "rootDir": "src/",
+        "outDir": "lib/",
+        "declaration": true,
+
+        "esModuleInterop": true,
+        "isolatedModules": true,
+
+        "strict": true
+    },
+    "include": ["src/"],
+    "exclude": ["**/__tests__"]
+}

--- a/packages/hrana-client/tsconfig.json
+++ b/packages/hrana-client/tsconfig.json
@@ -1,19 +1,7 @@
 {
+    "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "moduleResolution": "node",
-        "lib": ["esnext"],
-        "target": "esnext",
-        "module": "commonjs",
-
-        "rootDir": "src/",
-        "outDir": "lib/",
-        "declaration": true,
-
-        "esModuleInterop": true,
-        "isolatedModules": true,
-
-        "strict": true
-    },
-    "include": ["src/"],
-    "exclude": ["**/__tests__"]
+        "noEmit": true,
+        "incremental": true
+    }
 }

--- a/scripts/hrana_server.py
+++ b/scripts/hrana_server.py
@@ -1,0 +1,113 @@
+import asyncio
+import base64
+import collections
+import json
+import sqlite3
+import sys
+import websockets
+
+db_file = sys.argv[1]
+
+async def main():
+    server = await websockets.serve(handle_socket, "localhost", 2023, subprotocols=["hrana1"])
+    for sock in server.sockets:
+        print(f"Listening on {sock.getsockname()!r}")
+    await server.wait_closed()
+
+async def handle_socket(websocket):
+    print(f"Accepted connection from {websocket.remote_address}")
+    async def recv_msg():
+        try:
+            msg_str = await websocket.recv()
+        except websockets.exceptions.ConnectionClosed:
+            return None
+        assert isinstance(msg_str, str)
+        msg = json.loads(msg_str)
+        return msg
+
+    async def send_msg(msg):
+        msg_str = json.dumps(msg)
+        await websocket.send(msg_str)
+
+    Stream = collections.namedtuple("Stream", ["conn", "lock"])
+    streams = {}
+
+    async def handle_request(req):
+        if req["type"] == "open_stream":
+            conn = await asyncio.to_thread(lambda: sqlite3.connect(db_file))
+            streams[int(req["stream_id"])] = Stream(conn, asyncio.Lock())
+            return {"type": "open_stream"}
+        elif req["type"] == "close_stream":
+            stream = streams.pop(int(req["stream_id"]), None)
+            if stream is not None:
+                async with stream.lock:
+                    await asyncio.to_thread(lambda: stream.conn.close())
+            return {"type": "close_stream"}
+        elif req["type"] == "execute":
+            stream = streams[int(req["stream_id"])]
+            async with stream.lock:
+                result = await asyncio.to_thread(lambda: execute_stmt(stream.conn, req["stmt"]))
+            return {"type": "execute", "result": result}
+        else:
+            raise RuntimeError(f"Unknown req: {req!r}")
+
+    def execute_stmt(conn, stmt):
+        params = [value_to_sqlite(arg) for arg in stmt["args"]]
+        cursor = conn.execute(stmt["sql"], params)
+        cols = [{"name": name} for name, *_ in cursor.description]
+
+        rows = []
+        for row in cursor:
+            if stmt["want_rows"]:
+                rows.append([value_from_sqlite(val) for val in row])
+
+        return {"cols": cols, "rows": rows, "affected_row_count": cursor.rowcount}
+
+    def value_to_sqlite(value):
+        if value["type"] == "null":
+            return None
+        elif value["type"] == "integer":
+            return int(value["value"])
+        elif value["type"] == "float":
+            return float(value["value"])
+        elif value["type"] == "text":
+            return str(value["value"])
+        elif value["type"] == "blob":
+            return base64.b64decode(value["base64"])
+        else:
+            raise RuntimeError(f"Unknown value: {value!r}")
+
+    def value_from_sqlite(value):
+        if value is None:
+            return {"type": "null"}
+        elif isinstance(value, int):
+            return {"type": "integer", "value": str(value)}
+        elif isinstance(value, float):
+            return {"type": "float", "value": value}
+        elif isinstance(value, str):
+            return {"type": "text", "value": value}
+        elif isinstance(value, bytes):
+            return {"type": "blob", "value": base64.b64encode(value)}
+        else:
+            raise RuntimeError(f"Unknown SQLite value: {value!r}")
+
+    hello_msg = await recv_msg()
+    assert hello_msg.get("type") == "hello"
+    await send_msg({"type": "hello_ok"})
+
+    request_tasks = set()
+    while True:
+        msg = await recv_msg()
+        if msg is None:
+            break
+        elif msg["type"] == "request":
+            response = await handle_request(msg["request"])
+            await send_msg({
+                "type": "response_ok",
+                "request_id": msg["request_id"],
+                "response": response,
+            })
+        else:
+            raise RuntimeError(f"Unknown msg: {msg!r}")
+
+asyncio.run(main())


### PR DESCRIPTION
Introduce the package `@libsql/hrana-client` with a JavaScript client for the Hrana protocol, which should be soon implemented by `sqld`. This will be used to talk to `sqld` from edge functions and other JavaScript environments.

Developers can use this library directly, but it is mainly intended to power adapters for higher-level libraries (Kysely, Knex.js).