### PR TITLE
add http api spec

### DIFF
--- a/docs/http_api.md
+++ b/docs/http_api.md
@@ -124,3 +124,11 @@ GET /health
 ```
 
 The health route return an `HTTP 200 (OK)` if the server is up and running.
+
+#### Load dump
+
+```
+POST /load-dump
+```
+
+The load dump allows the user to load a SQLite dump. A dump is created with the `.dump` command in SQLite. This dump can then be sent to sqld with the `POST /load-dump` route, where the body is set to the bytes of the dump file.

--- a/docs/http_api.md
+++ b/docs/http_api.md
@@ -14,9 +14,7 @@ The `Value` type represents an SQLite value. It has 4 variants:
 - Blob: some binary data, encoded in base64
 - Null: the null value.
 
-All these types map to JSON straightforwardly, with two exceptions:
-- Blob: they are represented as an object with { "type": "blob", "base64": /* base64 encoded blob */}
-- Integers: they are represented as string since some languages are not able to represent them in full fidelity.
+All these types map to JSON straightforwardly, except for blobs, that are represented as an object with { "type": "blob", "base64": /* base64 encoded blob */}
 
 ### Response format
 

--- a/docs/http_api.md
+++ b/docs/http_api.md
@@ -46,7 +46,7 @@ Where `T` is the type of the payload in case of success.
 #### Queries
 
 ```
-POST /query
+POST /queries
 ```
 
 This endpoint supports sending batches of queries to the database. All of the statements in the batch are executed as part of a transaction. If any statement in the batch fails, an error is returned and the transaction is aborted, resulting in no change to the database.

--- a/docs/http_api.md
+++ b/docs/http_api.md
@@ -14,7 +14,7 @@ The `Value` type represents an SQLite value. It has 4 variants:
 - Blob: some binary data, encoded in base64
 - Null: the null value.
 
-All these types map to JSON straightforwardly, except for blobs, that are represented as an object with { "type": "blob", "base64": /* base64 encoded blob */}
+All these types map to JSON straightforwardly, except for blobs, that are represented as an object with { "base64": /* base64 encoded blob */}
 
 ### Response format
 
@@ -63,7 +63,7 @@ type QueryBody = {
 }
 
 type Query = string | ParamQuery;
-type ParamQuery = { q: string, params: null | Record<string, Value> | Array<Value> }
+type ParamQuery = { q: string, params: undefined | Record<string, Value> | Array<Value> }
 ```
 
 Queries are either simple strings or `ParamQuery` that accept parameter bindings. The `statements` arrays can contain a mix of the two types.

--- a/docs/http_api.md
+++ b/docs/http_api.md
@@ -116,3 +116,11 @@ The prefix of the parameter must be specified in the `params` field (i.e, `:name
     "params": ["adhoc"]
 }
 ```
+
+#### Health
+
+```
+GET /health
+```
+
+The health route return an `HTTP 200 (OK)` if the server is up and running.

--- a/docs/http_api.md
+++ b/docs/http_api.md
@@ -1,0 +1,114 @@
+# SQLD HTTP API
+
+This is the documentation for the sqld HTTP API.
+
+## Usage
+
+### The `Value` type
+
+The `Value` type represents a SQLite value. It has 4 variants:
+
+- Text: an UTF-8 encoded string
+- Integer: a 64-bits signed integer
+- Real: a 64-bits floating number
+- Blob: some binary data, encoded in base64
+- Null: the null value.
+
+All these types map to JSON straightforwardly, with two exceptions:
+- Blob: they are represented as an object with { "type": "blob", "base64": /* base64 encoded blob */}
+- Integers: they are represented as string, since some languages are not able to represent them in full fidelity.
+
+### Routes
+
+#### Queries
+
+```
+POST /query
+```
+
+This endpoint supports sending batches of queries to the database. All of the statements in the batch are executed as part of a transaction. If any statement in the batch fails, an error is returned and the transaction is aborted, resulting in no changed to the database.
+
+The HTTP API is stateless, this means that interactive transactions are not possible. Since all batches are executed as part of a transactions, any transaction statements (e.g `BEGIN`, `END`, `ROLLBACK`...) are forbidden and will yield an error.
+
+##### Body
+
+The body for the query request has the following format:
+
+```
+type QueryBody = {
+    statements: Array<Query>
+}
+
+type Query = string | ParamQuery;
+type ParamQuery = { q: string, params: null | Record<string, Value> | Array<Value> }
+```
+
+Queries are either simple strings, or `ParamQuery` that accept parameter bindings. The `statements` arrays can contain a mix of the two types.
+
+##### Response Format
+
+On success, a request to `POST /query` returns a response with a HTTP 200 code, and a JSON body with the following structure:
+```
+type BatchResponse = {
+    results: Array<QueryResult> | undefined,
+}
+
+type QueryResult = {
+    columns: Array<string>,
+    rows: Array<Array<Value>>,
+}
+
+```
+
+On success, `BatchResponse` `error` is undefined, and `results` is populated. This is accompanied by a HTTP 200 code.
+On error, `results` is undefined, and `error` is populated. This is accompanied by the relevant HTTP error code.
+
+Each entry in the `results` array of the `BatchResponse` corresponds to a query in the request.
+The `QueryResult` is either an error, or a set of results.
+
+The `Query` can either be a plain query string, such as `SELECT * FROM users` or `INSERT INTO users VALUES ("adhoc")`, or objects for queries with bound parameters.
+
+##### Parameter binding
+
+Queries with bound parameters come in two types:
+
+1. Named bound parameters, where the parameter is referred to by a name, and is prefixed with a `:` or a `$`. If the query uses named parameters, then the `params` field of the query should be an object mapping parameters to their value.
+
+- Example: a query with named bound parameters
+
+```json
+{
+    "q": "SELECT * FROM users WHERE name = :name",
+    "params": {
+        ":name": "adhoc",
+    }
+}
+```
+The prefix of the parameter must be specified in the `params` field (i.e, `:name` instead of `name`), since libSQL threat the two as different parameters.
+
+2. Positional query parameters, bound by their position in the parameter list, and prefixed `?`. If the query uses positional parameters, the values should be provided as an array to the `params` field.
+
+- Example: a query with positional bound parameters
+
+```json
+{
+    "q": "SELECT * FROM users WHERE name = ?",
+    "params": ["adhoc"]
+}
+```
+
+### Error handling
+
+On error, the sqld API returns an unified error payload, with a relevant HTTP status code.
+The error response payload has the following format:
+
+```
+type Error = {
+    error: {
+        message: string,
+        error_code: string,
+   }
+}
+```
+
+The error code can later be used to link to the relevant documentation.

--- a/docs/http_api.md
+++ b/docs/http_api.md
@@ -132,3 +132,11 @@ POST /load-dump
 ```
 
 The load dump allows the user to load a SQLite dump. A dump is created with the `.dump` command in SQLite. This dump can then be sent to sqld with the `POST /load-dump` route, where the body is set to the bytes of the dump file.
+
+#### Version
+
+```
+GET /version
+```
+
+returns the server's version.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.66.1"
+channel = "1.67.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.66.0"
+channel = "1.66.1"


### PR DESCRIPTION
This attempts to specify the HTTP API. This is not a documentation for the current state of the HTTP API, but rather a specification for now, and eventually a documentation.

It brings some strutural changes to the current API, namely:
- top-level errors: since the failure of a statement in a batch should cause the whole batch to rollback, error are move to the top-level. Ultimately this should yield much niecer errors, and a more straighforward behaviour.
- Some changes in the response structure, to leave place for non-backward breaking changes
- Some changes in the encoding of the values, more specifically of integers that Javascript handles badly.
