### PR TITLE
.gitignore: add more Ruby ignore paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 target
 testing/server/javascript/node_modules/
 testing/server/javascript/package-lock.json
-testing/server/ruby/Gemfile.lock
+testing/*/ruby/Gemfile.lock
+testing/*/ruby/vendor/
 iku.db
 iku.db-shm
 server/iku.db


### PR DESCRIPTION
The paths should be generic enough to hide all the intermediary test files.