### PR TITLE
auth: add Bearer authentication based on JWT RS256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,6 +1435,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
+dependencies = [
+ "base64 0.13.1",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,6 +1833,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,6 +2025,15 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2848,6 +2882,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time 0.3.17",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2948,6 +2994,7 @@ dependencies = [
  "futures",
  "hex",
  "hyper",
+ "jsonwebtoken",
  "libsql-wasmtime-bindings",
  "mvfs",
  "mwal",
@@ -3138,8 +3185,10 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
+ "itoa",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -3147,6 +3196,15 @@ name = "time-core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tinyvec"

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -17,6 +17,7 @@ fallible-iterator = "0.2.0"
 futures = "0.3.25"
 hex = "0.4.3"
 hyper = { version = "0.14.23", features = ["http2"] }
+jsonwebtoken = "8.2.0"
 libsql-wasmtime-bindings = "0"
 # Regular mvfs prevents users from enabling WAL mode
 mvfs = { git = "https://github.com/psarna/mvsqlite", branch = "mwal", optional = true }

--- a/sqld/src/http/auth.rs
+++ b/sqld/src/http/auth.rs
@@ -1,10 +1,32 @@
 use anyhow::{anyhow, Result};
 use hyper::{Body, Request};
+use jsonwebtoken::{DecodingKey, Validation};
+use serde_json::Value as JsonValue;
 use std::sync::Arc;
 
 /// HTTP request authorizer.
 pub trait Authorizer {
     fn is_authorized(&self, req: &Request<Body>) -> bool;
+}
+
+/// Takes a string representing a RSA PEM with its header and footer trimmed, and all line breaks
+/// removed, and created a decoding key for decoding a JWT.
+fn decoding_key_from_pem(key: &str) -> Result<DecodingKey> {
+    let header = String::from("-----BEGIN PUBLIC KEY-----\n");
+    let mut key = key
+        .as_bytes()
+        .chunks(64)
+        .try_fold(header, |mut buf, s| -> Result<String> {
+            let line = std::str::from_utf8(s)?;
+            buf.push_str(line);
+            buf.push('\n');
+            Ok(buf)
+        })?;
+    key.push_str("-----END PUBLIC KEY-----");
+    tracing::warn!("Public: {}", key);
+
+    let dkey = DecodingKey::from_rsa_pem(key.as_bytes())?;
+    Ok(dkey)
 }
 
 pub fn parse_auth(auth: Option<String>) -> Result<Arc<dyn Authorizer + Sync + Send>> {
@@ -13,6 +35,9 @@ pub fn parse_auth(auth: Option<String>) -> Result<Arc<dyn Authorizer + Sync + Se
             Some((scheme, param)) => match scheme {
                 "basic" => Ok(Arc::new(BasicAuthAuthorizer {
                     expected_auth: format!("Basic {}", param).to_lowercase(),
+                })),
+                "jwt" => Ok(Arc::new(BearerAuthAuthorizer {
+                    decoding_key: decoding_key_from_pem(param)?,
                 })),
                 _ => Err(anyhow!("unsupported HTTP auth scheme: {}", scheme)),
             },
@@ -47,6 +72,40 @@ impl Authorizer for BasicAuthAuthorizer {
                 .to_str()
                 .map(|actual_auth| actual_auth.to_lowercase() == self.expected_auth)
                 .unwrap_or(false)
+        } else {
+            false
+        }
+    }
+}
+
+/// Bearer token authentication authorizer.
+pub struct BearerAuthAuthorizer {
+    decoding_key: DecodingKey,
+}
+
+impl BearerAuthAuthorizer {
+    fn validate_token(&self, token: &str) -> Result<bool> {
+        // Once we start verifying claims, token will become useful
+        let _token = jsonwebtoken::decode::<JsonValue>(
+            token,
+            &self.decoding_key,
+            &Validation::new(jsonwebtoken::Algorithm::RS256),
+        )?;
+
+        Ok(true)
+    }
+}
+
+impl Authorizer for BearerAuthAuthorizer {
+    fn is_authorized(&self, req: &Request<Body>) -> bool {
+        let headers = req.headers();
+        let actual_auth = headers.get(hyper::header::AUTHORIZATION);
+        if let Some(Ok(actual_auth)) = actual_auth.map(|a| a.to_str()) {
+            if !actual_auth.starts_with("Bearer ") {
+                return false;
+            }
+            let token = &actual_auth[7..];
+            self.validate_token(token).unwrap_or(false)
         } else {
             false
         }


### PR DESCRIPTION
The Bearer token auth can now be verified, with the only supported algorithm at the moment being rsa-256.

Tested with:
```
cargo run -- --http-auth "jwt:MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA1lKV8RjGQkgUPs9P7OgxWIVAgTTKazm2C464SUVRt5rfcsf/JFA7r6SZAiGRB4BHC41NfKGWLeHz+uayqQDy1c14ly9lS3gQPzBTtk1SuX2WpaO7szXDwXHsjZ2fICkFo3QCuW7VhAC1bvHU5nodXr2TaYtLGoTARZSGgpwZO0/nedGsS90V6BPTHFtebzDWCsF8SIdiHXrO9oAYpmegWC97ydvbN2bFHD+03yPWK9qVZ0gj9rcLScpp/o6db2B/7VMQALKet2m3Vcee7fC+LrOV9XX+OOv4833+p4SG17v2r0rkn64OymTb03LPcOBH2LE+mA6PYCDQy5Qr5q/V7f6YLuVuUczEPxd094mTG8HwZLKetJFC0gttYD1fBpC1PL7p2lz4i56OE4Nn5p46J9hEw5gGwyEp8BBlcMIoKboKJCIpogwYhzKGJgVeP43M6WGdOIwy532L3H9G/v7skBjsy4nFmb+9mE+40JfZ0ikFhy15x+3isFmxWBHfO74khtYcebbQj8P3mT6tACEp0EiI8lobFRkwd5s501ZYxF8iFpLQznBMWGlRoLtRNY0RDjxW5AkNjwn3a+Zi3GFjp7VvdxCWkNf+KzS5ilN2gEh5ZWJuWoc1cvrbDZYTAkN/+QmG5+mhT62pklAm3stxRXU9sO4gGV+wgmKq8lldO18CAwEAAQ=="
```

and
```
curl -v -H "Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImV4cCI6MTIzfQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjoxMjMxMjMxMjMxMjMxMjN9.n3fwdgh1AGL05tR9ItPPxdPHMGhfPOWRHs2-18glGqDYnDE1lKqmkp9JCyVdTog2ToZ3RvNf7sJRBwdmVVPmjSjWYipRki_8dSa6EhaOICEVcRYdjB3-v4JSdKEF4jo2O1R_rsf09G1LWF-RBVwfflZfwMK7GSTd4kUEcm95jdlyIzQXDGaNbG7Ev6r1gsqn0r_Mll28opOXnFrUwpcVQRtkZcjwG0az6Ei875Keo4iDMzh4c-b9olwzZzvG-Axr3SXAUC_rq5s71Iu50T-yplLAcK1KIdIC5Dx7hRL-vw6CMl9lh015PlRFH1y-BgGi8nDbC7Cgstm_wALTFz36c6KXXHzF19SaIyKtZcCxe835YE_OkBWzKOGPgds8lXIUs8d01tbSxKOL791vb-3f4XYnuhe8dGhq64PHNeI0EFCF4IH_rJ1VjfNKDE9yGaFIxETL7hS2aFLKB4VDkYj0iQ0G4m9mIOvciUKargE750NgEtvMuTZWe1B7t-Qz-ozqBMUNBWVKHjvKSn5JpMEupE_z3uELCMv0vdEecXlTNMWMJqC2B1Mjni8SSbeBEW8KAOd3bAtVVRUwskkSeuf5wwjlP-MAXJSnnMGZ0PZkCuNSuHReooGpdWI58Pv2gtEfQBsz7Rd2kJDt7DbMQQ3dNuV5WvC5ZOLaAMOK0SDLrfY" -X POST -d '{"statements": ["explain select* from sqlite_master;"]}' localhost:8080
```

... both generated via https://jwt.io.

Thanks @MarinPostma for the reference impl and guidance!