### PR TITLE
libsql-client: add rudimentary documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "libsql-client"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64 0.21.0",
  "serde_json",

--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-client"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "Apache-2.0"
 description = "HTTP-based client for libSQL and sqld"


### PR DESCRIPTION
Public structures and functions got documented.
Examples should be added, but it's left for a follow-up™