### PR TITLE
Improve Error handling and error propagation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,10 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "libsql-client"
-version = "0.3.2"
+version = "0.2.0"
 dependencies = [
  "base64 0.21.0",
- "num-traits",
  "serde_json",
  "worker",
 ]
@@ -3016,6 +3015,7 @@ dependencies = [
  "smallvec",
  "sqlite3-parser",
  "tempfile",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -41,6 +41,7 @@ smallvec = "1.10.0"
 sqlite3-parser = { git = "https://github.com/gwenn/lemon-rs.git", rev = "be6d0a96c4424fada2e068b51c25d1fdc9f983f4", default-features = false, features = [
     "YYNOERRORRECOVERY"
 ] }
+thiserror = "1.0.38"
 tokio = { version = "1.21.2", features = ["full"] }
 tokio-stream = "0.1.11"
 tokio-tungstenite = "0.17.2"

--- a/sqld/src/database/mod.rs
+++ b/sqld/src/database/mod.rs
@@ -1,5 +1,6 @@
 use crate::query::{Queries, QueryResult};
 use crate::query_analysis::State;
+use crate::Result;
 
 pub mod libsql;
 pub mod service;
@@ -11,5 +12,5 @@ const TXN_TIMEOUT_SECS: u64 = 5;
 pub trait Database {
     /// Executes a batch of queries, and return the a vec of results corresponding to the queries,
     /// and the state the database is in after the call to execute.
-    async fn execute(&self, queries: Queries) -> anyhow::Result<(Vec<QueryResult>, State)>;
+    async fn execute(&self, queries: Queries) -> Result<(Vec<QueryResult>, State)>;
 }

--- a/sqld/src/error.rs
+++ b/sqld/src/error.rs
@@ -1,0 +1,38 @@
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("LibSQL failed to bind provided query parameters: `{0}`")]
+    LibSqlInvalidQueryParams(anyhow::Error),
+    #[error("Transaction timed-out when evaluating query no. `{0}`")]
+    LibSqlTxTimeout(usize),
+    #[error("Server can't handle additional transactions")]
+    LibSqlTxBusy,
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+    #[error(transparent)]
+    RusqliteError(#[from] rusqlite::Error),
+    #[error("Failed to execute query via RPC. Error code: {}, message: {}", .0.code, .0.message)]
+    RpcQueryError(crate::rpc::proxy::proxy_rpc::Error),
+    #[error("Failed to execute queries via RPC protocol: `{0}`")]
+    RpcQueryExecutionError(tonic::Status),
+    #[error("Database value error: `{0}`")]
+    DbValueError(String),
+    // Dedicated for most generic internal errors. Please use it sparingly.
+    // Consider creating a dedicate enum value for your error.
+    #[error("Internal Error: `{0}`")]
+    Internal(String),
+}
+
+impl From<tokio::sync::oneshot::error::RecvError> for Error {
+    fn from(inner: tokio::sync::oneshot::error::RecvError) -> Self {
+        Self::Internal(format!(
+            "Failed to receive response via oneshot channel: {inner}"
+        ))
+    }
+}
+
+impl From<bincode::Error> for Error {
+    fn from(other: bincode::Error) -> Self {
+        Self::Internal(other.to_string())
+    }
+}

--- a/sqld/src/postgres/proto.rs
+++ b/sqld/src/postgres/proto.rs
@@ -16,6 +16,7 @@ use tokio::sync::Mutex;
 use tokio_util::codec::Framed;
 use tower::Service;
 
+use crate::error::Error;
 use crate::query::{Params, Queries, Query, QueryResponse, QueryResult, Value};
 use crate::query_analysis::Statement;
 use crate::server::AsyncPeekable;
@@ -30,7 +31,7 @@ impl<'a, S> QueryHandler<'a, S> {
 
     async fn handle_queries(&self, queries: Queries) -> PgWireResult<Vec<Response>>
     where
-        S: Service<Queries, Response = Vec<QueryResult>, Error = anyhow::Error> + Sync + Send,
+        S: Service<Queries, Response = Vec<QueryResult>, Error = Error> + Sync + Send,
         S::Future: Send,
     {
         let mut s = self.0.lock().await;
@@ -55,7 +56,7 @@ impl<'a, S> QueryHandler<'a, S> {
 #[async_trait::async_trait]
 impl<'a, S> SimpleQueryHandler for QueryHandler<'a, S>
 where
-    S: Service<Queries, Response = Vec<QueryResult>, Error = anyhow::Error> + Sync + Send,
+    S: Service<Queries, Response = Vec<QueryResult>, Error = Error> + Sync + Send,
     S::Future: Send,
 {
     async fn do_query<C>(&self, _client: &C, query: &str) -> PgWireResult<Vec<Response>>
@@ -83,7 +84,7 @@ where
 #[async_trait::async_trait]
 impl<'a, S> ExtendedQueryHandler for QueryHandler<'a, S>
 where
-    S: Service<Queries, Response = Vec<QueryResult>, Error = anyhow::Error> + Sync + Send,
+    S: Service<Queries, Response = Vec<QueryResult>, Error = Error> + Sync + Send,
     S::Future: Send,
 {
     async fn do_query<C>(

--- a/sqld/src/postgres/service.rs
+++ b/sqld/src/postgres/service.rs
@@ -15,6 +15,7 @@ use tokio_util::codec::{Decoder, Framed};
 use tower::MakeService;
 use tower::Service;
 
+use crate::error::Error;
 use crate::postgres::authenticator::PgAuthenticator;
 use crate::query::{Queries, QueryResult};
 use crate::server::AsyncPeekable;
@@ -30,7 +31,7 @@ pub struct PgWireConnection<T, S> {
 
 impl<T, S> PgWireConnection<T, S>
 where
-    S: Service<Queries, Response = Vec<QueryResult>, Error = anyhow::Error> + Sync + Send,
+    S: Service<Queries, Response = Vec<QueryResult>, Error = Error> + Sync + Send,
     T: AsyncRead + AsyncWrite + Unpin + Send + Sync,
     S::Future: Send,
 {
@@ -122,13 +123,13 @@ impl<S> PgConnectionFactory<S> {
 impl<T, F> Service<(T, SocketAddr)> for PgConnectionFactory<F>
 where
     T: AsyncRead + AsyncWrite + AsyncPeekable + Unpin + Send + Sync + 'static,
-    F: MakeService<(), Queries, MakeError = anyhow::Error> + Sync,
+    F: MakeService<(), Queries, MakeError = Error> + Sync,
     F::Future: 'static + Send + Sync,
-    F::Service: Service<Queries, Response = Vec<QueryResult>, Error = anyhow::Error> + Sync + Send,
+    F::Service: Service<Queries, Response = Vec<QueryResult>, Error = Error> + Sync + Send,
     <F::Service as Service<Queries>>::Future: Send,
 {
     type Response = ();
-    type Error = anyhow::Error;
+    type Error = Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(

--- a/sqld/src/query.rs
+++ b/sqld/src/query.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
-use std::fmt;
 use std::str::FromStr;
 
 use anyhow::{ensure, Context};
@@ -12,12 +11,13 @@ use rusqlite::types::ToSqlOutput;
 use rusqlite::ToSql;
 use serde::{Deserialize, Serialize};
 
+use crate::error::Error;
 use crate::query_analysis::Statement;
 use crate::rpc::proxy::proxy_rpc::{
     Column as RpcColumn, ResultRows, Row as RpcRow, Type as RpcType, Value as RpcValue,
 };
 
-pub type QueryResult = Result<QueryResponse, QueryError>;
+pub type QueryResult = Result<QueryResponse, Error>;
 
 #[derive(Debug, Clone)]
 pub struct Column {
@@ -351,43 +351,6 @@ impl Params {
 }
 
 pub type Queries = Vec<Query>;
-
-#[derive(Debug, Clone)]
-pub struct QueryError {
-    pub code: ErrorCode,
-    pub msg: String,
-}
-
-impl std::error::Error for QueryError {}
-
-impl fmt::Display for QueryError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.msg)
-    }
-}
-
-impl QueryError {
-    pub fn new(code: ErrorCode, msg: impl ToString) -> Self {
-        Self {
-            code,
-            msg: msg.to_string(),
-        }
-    }
-}
-
-impl From<rusqlite::Error> for QueryError {
-    fn from(other: rusqlite::Error) -> Self {
-        Self::new(ErrorCode::SQLError, other)
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum ErrorCode {
-    SQLError,
-    TxBusy,
-    TxTimeout,
-    Internal,
-}
 
 #[cfg(test)]
 mod test {

--- a/sqld/src/rpc/mod.rs
+++ b/sqld/src/rpc/mod.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -43,7 +44,9 @@ where
         let tls_config = tonic::transport::ServerTlsConfig::new()
             .identity(identity)
             .client_ca_root(ca_cert);
-        builder = builder.tls_config(tls_config)?;
+        builder = builder
+            .tls_config(tls_config)
+            .context("Failed to read the TSL config of RPC server")?;
     }
     builder
         .add_service(ProxyServer::new(proxy_service))


### PR DESCRIPTION
Rename QueryError to SqldError.
Use SqldError wherever possible to better propagate errors.