### PR TITLE
libsql-client: update to 0.3.x

### DIFF
--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-client"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "Apache-2.0"
 description = "HTTP-based client for libSQL and sqld"

--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-client"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "HTTP-based client for libSQL and sqld"
@@ -10,5 +10,6 @@ keywords = ["libsql", "sqld", "database", "driver", "http"]
 
 [dependencies]
 base64 = "0.21.0"
+num-traits = "0.2.15"
 serde_json = "1.0.91"
 worker = "0.0.12"

--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-client"
-version = "0.3.1"
+version = "0.3.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "HTTP-based client for libSQL and sqld"

--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-client"
-version = "0.3.5"
+version = "0.3.7"
 edition = "2021"
 license = "Apache-2.0"
 description = "HTTP-based client for libSQL and sqld"

--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-client"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "HTTP-based client for libSQL and sqld"

--- a/libsql-client/src/cell_value.rs
+++ b/libsql-client/src/cell_value.rs
@@ -1,0 +1,54 @@
+/// Value of a single database cell
+#[derive(Clone, Debug)]
+pub enum CellValue {
+    Text(String),
+    Float(f64),
+    Number(i64),
+    Bool(bool),
+    Null,
+}
+
+impl std::fmt::Display for CellValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CellValue::Text(s) => write!(f, "\"{s}\""),
+            CellValue::Float(d) => write!(f, "{d}"),
+            CellValue::Number(n) => write!(f, "{n}"),
+            CellValue::Bool(b) => write!(f, "{}", if *b { "1" } else { "0" }),
+            CellValue::Null => write!(f, "null"),
+        }
+    }
+}
+
+impl From<()> for CellValue {
+    fn from(_: ()) -> CellValue {
+        CellValue::Null
+    }
+}
+
+macro_rules! impl_from_cell_value {
+    ($typename: ty, $variant: ident) => {
+        impl From<$typename> for CellValue {
+            fn from(t: $typename) -> CellValue {
+                CellValue::$variant(t.into())
+            }
+        }
+    };
+}
+
+impl_from_cell_value!(String, Text);
+impl_from_cell_value!(&str, Text);
+
+impl_from_cell_value!(i8, Number);
+impl_from_cell_value!(i16, Number);
+impl_from_cell_value!(i32, Number);
+impl_from_cell_value!(i64, Number);
+
+impl_from_cell_value!(u8, Number);
+impl_from_cell_value!(u16, Number);
+impl_from_cell_value!(u32, Number);
+
+impl_from_cell_value!(f32, Float);
+impl_from_cell_value!(f64, Float);
+
+impl_from_cell_value!(bool, Bool);

--- a/libsql-client/src/cell_value.rs
+++ b/libsql-client/src/cell_value.rs
@@ -1,3 +1,6 @@
+//! `CellValue` represents libSQL values and types.
+//! Each database row consists of one or more cell values.
+
 /// Value of a single database cell
 #[derive(Clone, Debug)]
 pub enum CellValue {

--- a/libsql-client/src/lib.rs
+++ b/libsql-client/src/lib.rs
@@ -225,6 +225,19 @@ impl Connection {
     ///
     /// # Arguments
     /// * `stmt` - the SQL statement
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let db = Connection::connect("http://example.com", "admin", "s3cr3tp4ss");
+    /// let result = db.execute("SELECT * FROM sqlite_master").await?;
+    /// let result_params = db
+    ///     .execute(Statement::with_params(
+    ///         "UPDATE t SET v = ? WHERE key = ?",
+    ///         &[CellValue::Number(5), CellValue::Text("five".to_string())],
+    ///     ))
+    ///     .await?;
+    /// ```
     pub async fn execute(&self, stmt: impl Into<Statement>) -> Result<QueryResult> {
         let mut results = self.batch(std::iter::once(stmt)).await?;
         Ok(results.remove(0))
@@ -236,6 +249,15 @@ impl Connection {
     ///
     /// # Arguments
     /// * `stmts` - SQL statements
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let db = Connection::connect("http://example.com", "admin", "s3cr3tp4ss");
+    /// let result = db
+    ///     .batch(["CREATE TABLE t(id)", "INSERT INTO t VALUES (42)"])
+    ///     .await;
+    /// ```
     pub async fn batch(
         &self,
         stmts: impl IntoIterator<Item = impl Into<Statement>>,
@@ -292,6 +314,15 @@ impl Connection {
     ///
     /// # Arguments
     /// * `stmts` - SQL statements
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let db = Connection::connect("http://example.com", "admin", "s3cr3tp4ss");
+    /// let result = db
+    ///     .transaction(["CREATE TABLE t(id)", "INSERT INTO t VALUES (42)"])
+    ///     .await;
+    /// ```
     pub async fn transaction(
         &self,
         stmts: impl IntoIterator<Item = impl Into<Statement>>,

--- a/libsql-client/src/lib.rs
+++ b/libsql-client/src/lib.rs
@@ -188,8 +188,17 @@ impl Connection {
     ) -> Self {
         let username = username.into();
         let pass = pass.into();
+        let url = url.into();
+        // Auto-update the URL to start with https://
+        let url = if url.starts_with("https://") {
+            url
+        } else if let Some(stripped) = url.strip_prefix("http://") {
+            "https://".to_owned() + stripped
+        } else {
+            "https://".to_owned() + &url
+        };
         Self {
-            url: url.into(),
+            url,
             auth: format!(
                 "Basic {}",
                 base64::engine::general_purpose::STANDARD.encode(format!("{username}:{pass}"))

--- a/libsql-client/src/lib.rs
+++ b/libsql-client/src/lib.rs
@@ -200,13 +200,11 @@ impl Connection {
         let username = username.into();
         let pass = pass.into();
         let url = url.into();
-        // Auto-update the URL to start with https://
-        let url = if url.starts_with("https://") {
-            url
-        } else if let Some(stripped) = url.strip_prefix("http://") {
-            "https://".to_owned() + stripped
-        } else {
+        // Auto-update the URL to start with https:// if no protocol was specified
+        let url = if !url.contains("://") {
             "https://".to_owned() + &url
+        } else {
+            url
         };
         Self {
             url,
@@ -241,7 +239,7 @@ impl Connection {
     ///
     /// ```
     /// # async fn f() {
-    /// let db = libsql_client::Connection::connect("http://example.com", "admin", "s3cr3tp4ss");
+    /// let db = libsql_client::Connection::connect("https://example.com", "admin", "s3cr3tp4ss");
     /// let result = db.execute("SELECT * FROM sqlite_master").await;
     /// let result_params = db
     ///     .execute(libsql_client::Statement::with_params(
@@ -267,7 +265,7 @@ impl Connection {
     ///
     /// ```
     /// # async fn f() {
-    /// let db = libsql_client::Connection::connect("http://example.com", "admin", "s3cr3tp4ss");
+    /// let db = libsql_client::Connection::connect("https://example.com", "admin", "s3cr3tp4ss");
     /// let result = db
     ///     .batch(["CREATE TABLE t(id)", "INSERT INTO t VALUES (42)"])
     ///     .await;
@@ -334,7 +332,7 @@ impl Connection {
     ///
     /// ```
     /// # async fn f() {
-    /// let db = libsql_client::Connection::connect("http://example.com", "admin", "s3cr3tp4ss");
+    /// let db = libsql_client::Connection::connect("https://example.com", "admin", "s3cr3tp4ss");
     /// let result = db
     ///     .transaction(["CREATE TABLE t(id)", "INSERT INTO t VALUES (42)"])
     ///     .await;

--- a/libsql-client/src/lib.rs
+++ b/libsql-client/src/lib.rs
@@ -218,7 +218,7 @@ impl Connection {
     }
 
     /// Establishes a database connection from Cloudflare Workers context.
-    /// Expects the context to contain the following variables defined:
+    /// Expects the context to contain the following secrets defined:
     /// * `LIBSQL_CLIENT_URL`
     /// * `LIBSQL_CLIENT_USER`
     /// * `LIBSQL_CLIENT_PASS`
@@ -226,9 +226,9 @@ impl Connection {
     /// * `ctx` - Cloudflare Workers route context
     pub fn connect_from_ctx<D>(ctx: &worker::RouteContext<D>) -> Result<Self> {
         Ok(Self::connect(
-            ctx.var("LIBSQL_CLIENT_URL")?.to_string(),
-            ctx.var("LIBSQL_CLIENT_USER")?.to_string(),
-            ctx.var("LIBSQL_CLIENT_PASS")?.to_string(),
+            ctx.secret("LIBSQL_CLIENT_URL")?.to_string(),
+            ctx.secret("LIBSQL_CLIENT_USER")?.to_string(),
+            ctx.secret("LIBSQL_CLIENT_PASS")?.to_string(),
         ))
     }
 

--- a/libsql-client/src/lib.rs
+++ b/libsql-client/src/lib.rs
@@ -1,3 +1,14 @@
+//! A library for communicating with a libSQL database over HTTP.
+//!
+//! libsql-client is a lightweight HTTP-based driver for sqld,
+//! which is a server mode for libSQL, which is an open-contribution fork of SQLite.
+//!
+//! libsql-client compiles to wasm32-unknown-unknown target, which makes it a great
+//! driver for environments that run on WebAssembly.
+//!
+//! It is expected to become a general-purpose driver for communicating with sqld/libSQL,
+//! but the only backend implemented at the moment is for Cloudflare Workers environment.
+
 use std::collections::HashMap;
 use std::iter::IntoIterator;
 
@@ -10,7 +21,7 @@ pub use statement::Statement;
 pub mod cell_value;
 pub use cell_value::CellValue;
 
-/// Metadata of a request
+/// Metadata of a database request
 #[derive(Clone, Debug, Default)]
 pub struct Meta {
     pub duration: u64,
@@ -30,7 +41,7 @@ pub struct ResultSet {
     pub rows: Vec<Row>,
 }
 
-/// Result of a request - a set of rows or an error
+/// Result of a database request - a set of rows or an error
 #[derive(Clone, Debug)]
 pub enum QueryResult {
     Error((String, Meta)),
@@ -229,14 +240,16 @@ impl Connection {
     /// # Examples
     ///
     /// ```
-    /// let db = Connection::connect("http://example.com", "admin", "s3cr3tp4ss");
-    /// let result = db.execute("SELECT * FROM sqlite_master").await?;
+    /// # async fn f() {
+    /// let db = libsql_client::Connection::connect("http://example.com", "admin", "s3cr3tp4ss");
+    /// let result = db.execute("SELECT * FROM sqlite_master").await;
     /// let result_params = db
-    ///     .execute(Statement::with_params(
+    ///     .execute(libsql_client::Statement::with_params(
     ///         "UPDATE t SET v = ? WHERE key = ?",
-    ///         &[CellValue::Number(5), CellValue::Text("five".to_string())],
+    ///         &[libsql_client::CellValue::Number(5), libsql_client::CellValue::Text("five".to_string())],
     ///     ))
-    ///     .await?;
+    ///     .await;
+    /// # }
     /// ```
     pub async fn execute(&self, stmt: impl Into<Statement>) -> Result<QueryResult> {
         let mut results = self.batch(std::iter::once(stmt)).await?;
@@ -253,10 +266,12 @@ impl Connection {
     /// # Examples
     ///
     /// ```
-    /// let db = Connection::connect("http://example.com", "admin", "s3cr3tp4ss");
+    /// # async fn f() {
+    /// let db = libsql_client::Connection::connect("http://example.com", "admin", "s3cr3tp4ss");
     /// let result = db
     ///     .batch(["CREATE TABLE t(id)", "INSERT INTO t VALUES (42)"])
     ///     .await;
+    /// # }
     /// ```
     pub async fn batch(
         &self,
@@ -318,10 +333,12 @@ impl Connection {
     /// # Examples
     ///
     /// ```
-    /// let db = Connection::connect("http://example.com", "admin", "s3cr3tp4ss");
+    /// # async fn f() {
+    /// let db = libsql_client::Connection::connect("http://example.com", "admin", "s3cr3tp4ss");
     /// let result = db
     ///     .transaction(["CREATE TABLE t(id)", "INSERT INTO t VALUES (42)"])
     ///     .await;
+    /// # }
     /// ```
     pub async fn transaction(
         &self,

--- a/libsql-client/src/statement.rs
+++ b/libsql-client/src/statement.rs
@@ -1,0 +1,65 @@
+use super::CellValue;
+
+/// SQL statement, possibly with bound parameters
+pub struct Statement {
+    q: String,
+    params: Vec<CellValue>,
+}
+
+impl Statement {
+    /// Creates a new simple statement without bound parameters
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let stmt = Statement::new("SELECT * FROM sqlite_master");
+    /// ```
+    pub fn new(q: impl Into<String>) -> Statement {
+        Self {
+            q: q.into(),
+            params: vec![],
+        }
+    }
+
+    /// Creates a statement with bound parameters
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let stmt = Statement::with_params("UPDATE t SET x = ? WHERE key = ?", &[3, 8]);
+    /// ```
+    pub fn with_params(q: impl Into<String>, params: &[impl Into<CellValue> + Clone]) -> Statement {
+        Self {
+            q: q.into(),
+            params: params.iter().map(|p| p.clone().into()).collect(),
+        }
+    }
+}
+
+impl From<String> for Statement {
+    fn from(q: String) -> Statement {
+        Statement { q, params: vec![] }
+    }
+}
+
+impl From<&str> for Statement {
+    fn from(val: &str) -> Self {
+        val.to_string().into()
+    }
+}
+
+impl std::fmt::Display for Statement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.params.is_empty() {
+            write!(f, "\"{}\"", self.q)
+        } else {
+            let params: Vec<String> = self.params.iter().map(|p| p.to_string()).collect();
+            write!(
+                f,
+                "{{\"q\": \"{}\", \"params\": [{}]}}",
+                self.q,
+                params.join(",")
+            )
+        }
+    }
+}

--- a/libsql-client/src/statement.rs
+++ b/libsql-client/src/statement.rs
@@ -1,3 +1,6 @@
+//! `Statement` represents an SQL statement,
+//! which can be later sent to a database.
+
 use super::CellValue;
 
 /// SQL statement, possibly with bound parameters
@@ -12,7 +15,7 @@ impl Statement {
     /// # Examples
     ///
     /// ```
-    /// let stmt = Statement::new("SELECT * FROM sqlite_master");
+    /// let stmt = libsql_client::Statement::new("SELECT * FROM sqlite_master");
     /// ```
     pub fn new(q: impl Into<String>) -> Statement {
         Self {
@@ -26,7 +29,7 @@ impl Statement {
     /// # Examples
     ///
     /// ```
-    /// let stmt = Statement::with_params("UPDATE t SET x = ? WHERE key = ?", &[3, 8]);
+    /// let stmt = libsql_client::Statement::with_params("UPDATE t SET x = ? WHERE key = ?", &[3, 8]);
     /// ```
     pub fn with_params(q: impl Into<String>, params: &[impl Into<CellValue> + Clone]) -> Statement {
         Self {


### PR DESCRIPTION
The new code revamps the existing interface a little bit:
 - Renames `Rows` to `QueryResult`, because the structure contains both columns and rows now, and the name became misleading
 - Added explicit `Null` type, to map directly into libSQL's `NULL` type
 - Added auto-upgrade to `https://` of the database url, if somebody doesn't add it or uses plain `http://`
 - Added support for parameter binding
 - Added more documentation
 - Updated from using var envs to secrets
 
Fixes #132
Fixes #140
