### PR TITLE
Include content-type header for query response.

### DIFF
--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -177,7 +177,9 @@ async fn handle_query(
     match result {
         Ok(Ok(rows)) => {
             let json = query_response_to_json(rows)?;
-            Ok(Response::new(Body::from(json)))
+            Ok(Response::builder()
+                .header("Content-Type", "application/json")
+                .body(Body::from(json))?)
         }
         Err(_) | Ok(Err(_)) => Ok(error("internal error", StatusCode::INTERNAL_SERVER_ERROR)),
     }


### PR DESCRIPTION
One thing I'm not sure about is whether it's necessary to include the encoding in the header as well :thinking: 