### PR TITLE
fix HTTP blob encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,7 @@ dependencies = [
  "futures",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/packages/libsql-client/src/lib/libsql-js.ts
+++ b/packages/libsql-client/src/lib/libsql-js.ts
@@ -10,7 +10,7 @@ export type Config = {
  * A SQL query result set row.
  */
 export type Row = Record<string, SqlValue>;
-export type SqlValue = string | number | boolean | null;
+export type SqlValue = string | number | boolean | { base64: string } | null;
 export type Params = SqlValue[] | Record<string, SqlValue>;
 export type BoundStatement = { q: string; params: Params };
 

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -43,7 +43,9 @@ impl TryFrom<query::Value> for serde_json::Value {
                 })?)
             }
             query::Value::Text(s) => serde_json::Value::String(s),
-            query::Value::Blob(v) => serde_json::Value::String(BASE64_STANDARD_NO_PAD.encode(v)),
+            query::Value::Blob(v) => serde_json::json!({
+                "base64": BASE64_STANDARD_NO_PAD.encode(v),
+            }),
         };
 
         Ok(value)

--- a/sqld/src/http/types.rs
+++ b/sqld/src/http/types.rs
@@ -92,7 +92,7 @@ impl<'de> Deserialize<'de> for ValueDeserializer {
             {
                 match map.next_entry::<&str, &str>()? {
                     Some((k, v)) => {
-                        if k == "blob" {
+                        if k == "base64" {
                             // FIXME: If the blog payload is too big, it may block the main thread
                             // for too long in an async context. In this case, it may be necessary
                             // to offload deserialization to a separate thread.

--- a/sqld/src/http/types.rs
+++ b/sqld/src/http/types.rs
@@ -233,14 +233,14 @@ mod test {
 
     #[test]
     fn parse_positional_params() {
-        let json = r#"[1, "hello", 12.1, { "blob": "aGVsbG8K"}, null]"#; // blob: hello\n
+        let json = r#"[1, "hello", 12.1, { "base64": "aGVsbG8K"}, null]"#; // blob: hello\n
         let found: QueryParams = serde_json::from_str(json).unwrap();
         insta::assert_json_snapshot!(found);
     }
 
     #[test]
     fn parse_named_params() {
-        let json = r#"{":int": 1, "$real": 1.23, ":str": "hello", ":blob": { "blob": "aGVsbG8K"}, ":null": null, ":bool": false}"#;
+        let json = r#"{":int": 1, "$real": 1.23, ":str": "hello", ":blob": { "base64": "aGVsbG8K"}, ":null": null, ":bool": false}"#;
         let found: QueryParams = serde_json::from_str(json).unwrap();
         insta::with_settings!({sort_maps => true}, {
             insta::assert_json_snapshot!(found);


### PR DESCRIPTION
This PR fixes and unify blob encoding in http payloads as

```json
{ "base64": "PAYLOAD" }
```

@penberg I'm wondering if we shouldn't parse the blob into an ArrayBuffer?
