### PR TITLE
Use sql.js to provide sqlite driver in browser.

### DIFF
--- a/packages/libsql-client/package-lock.json
+++ b/packages/libsql-client/package-lock.json
@@ -9,8 +9,11 @@
             "version": "0.0.5",
             "license": "MIT",
             "dependencies": {
+                "@types/sql.js": "^1.4.4",
                 "better-sqlite3": "^8.0.1",
-                "cross-fetch": "^3.1.5"
+                "browser-or-node": "^2.1.1",
+                "cross-fetch": "^3.1.5",
+                "sql.js": "^1.8.0"
             },
             "devDependencies": {
                 "@types/better-sqlite3": "^7.6.3",
@@ -1030,6 +1033,11 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/emscripten": {
+            "version": "1.39.6",
+            "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.6.tgz",
+            "integrity": "sha512-H90aoynNhhkQP6DRweEjJp5vfUVdIj7tdPLsu7pq89vODD/lcugKfZOsfgwpvM6XUewEp2N5dCg1Uf3Qe55Dcg=="
+        },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1076,14 +1084,22 @@
         "node_modules/@types/node": {
             "version": "18.11.18",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-            "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-            "dev": true
+            "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
         },
         "node_modules/@types/prettier": {
             "version": "2.7.2",
             "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
             "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
             "dev": true
+        },
+        "node_modules/@types/sql.js": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.4.tgz",
+            "integrity": "sha512-6EWU2wfiBtzgTy18WQoXZAGTreBjhZcBCfD8CDvyI1Nj0a4KNDDt41IYeAZ40cRUdfqWHb7VGx7t6nK0yBOI5A==",
+            "dependencies": {
+                "@types/emscripten": "*",
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/stack-utils": {
             "version": "2.0.1",
@@ -1332,6 +1348,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/browser-or-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-2.1.1.tgz",
+            "integrity": "sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg=="
         },
         "node_modules/browserslist": {
             "version": "4.21.4",
@@ -3580,6 +3601,11 @@
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true
         },
+        "node_modules/sql.js": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.8.0.tgz",
+            "integrity": "sha512-3HD8pSkZL+5YvYUI8nlvNILs61ALqq34xgmF+BHpqxe68yZIJ1H+sIVIODvni25+CcxHUxDyrTJUL0lE/m7afw=="
+        },
         "node_modules/stack-utils": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -4865,6 +4891,11 @@
                 "@types/node": "*"
             }
         },
+        "@types/emscripten": {
+            "version": "1.39.6",
+            "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.6.tgz",
+            "integrity": "sha512-H90aoynNhhkQP6DRweEjJp5vfUVdIj7tdPLsu7pq89vODD/lcugKfZOsfgwpvM6XUewEp2N5dCg1Uf3Qe55Dcg=="
+        },
         "@types/graceful-fs": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -4911,14 +4942,22 @@
         "@types/node": {
             "version": "18.11.18",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-            "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-            "dev": true
+            "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
         },
         "@types/prettier": {
             "version": "2.7.2",
             "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
             "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
             "dev": true
+        },
+        "@types/sql.js": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.4.tgz",
+            "integrity": "sha512-6EWU2wfiBtzgTy18WQoXZAGTreBjhZcBCfD8CDvyI1Nj0a4KNDDt41IYeAZ40cRUdfqWHb7VGx7t6nK0yBOI5A==",
+            "requires": {
+                "@types/emscripten": "*",
+                "@types/node": "*"
+            }
         },
         "@types/stack-utils": {
             "version": "2.0.1",
@@ -5110,6 +5149,11 @@
             "requires": {
                 "fill-range": "^7.0.1"
             }
+        },
+        "browser-or-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-2.1.1.tgz",
+            "integrity": "sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg=="
         },
         "browserslist": {
             "version": "4.21.4",
@@ -6739,6 +6783,11 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true
+        },
+        "sql.js": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.8.0.tgz",
+            "integrity": "sha512-3HD8pSkZL+5YvYUI8nlvNILs61ALqq34xgmF+BHpqxe68yZIJ1H+sIVIODvni25+CcxHUxDyrTJUL0lE/m7afw=="
         },
         "stack-utils": {
             "version": "2.0.6",

--- a/packages/libsql-client/package.json
+++ b/packages/libsql-client/package.json
@@ -37,7 +37,10 @@
         "typescript": "^4.9.4"
     },
     "dependencies": {
+        "@types/sql.js": "^1.4.4",
         "better-sqlite3": "^8.0.1",
-        "cross-fetch": "^3.1.5"
+        "browser-or-node": "^2.1.1",
+        "cross-fetch": "^3.1.5",
+        "sql.js": "^1.8.0"
     }
 }

--- a/packages/libsql-client/src/lib/driver/BrowserSqliteDriver.ts
+++ b/packages/libsql-client/src/lib/driver/BrowserSqliteDriver.ts
@@ -1,0 +1,82 @@
+import initSqlJs from "sql.js";
+import { BoundStatement, Params, ResultSet, SqlValue } from "../libsql-js";
+import { Driver } from "./Driver";
+
+export class BrowserSqliteDriver implements Driver {
+    private sql?: initSqlJs.SqlJsStatic;
+    private db?: initSqlJs.Database;
+
+    constructor(url: string) {
+        if (url !== "file::memory:" && url !== ":memory:") {
+            console.warn(
+                `BrowserSqliteDriver will ignore given db url '${url}' as in browser mode only the memory storage is available`
+            );
+        }
+    }
+
+    private async loadWasm() {
+        this.sql = await initSqlJs({
+            // Required to load the wasm binary asynchronously. Of course, you can host it wherever you want
+            // You can omit locateFile completely when running in node
+            locateFile: (file) => "https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/sql-wasm.js"
+        });
+        this.db = new this.sql.Database();
+    }
+
+    async execute(sql: string, params?: Params): Promise<ResultSet> {
+        if (this.sql === undefined) {
+            await this.loadWasm();
+        }
+
+        return await new Promise((resolve) => {
+            let columns: string[];
+            const rows: Record<string, any>[] = [];
+
+            try {
+                const stmt = this.db!.prepare(sql);
+                columns = stmt.getColumnNames();
+                stmt.bind(params as initSqlJs.BindParams);
+
+                while (stmt.step()) {
+                    rows.push(stmt.get());
+                }
+                stmt.free();
+            } catch (e: any) {
+                resolve({
+                    success: false,
+                    error: { message: e.message },
+                    meta: { duration: 0 }
+                });
+                return;
+            }
+
+            resolve({
+                success: true,
+                columns,
+                rows,
+                meta: { duration: 0 }
+            });
+        });
+    }
+
+    async transaction(stmts: (string | BoundStatement)[]): Promise<ResultSet[]> {
+        try {
+            const result = [];
+            await this.execute("BEGIN TRANSACTION");
+            for (const stmt of stmts) {
+                let rs;
+                if (typeof stmt === "string") {
+                    rs = await this.execute(stmt);
+                } else {
+                    rs = await this.execute(stmt.q, stmt.params);
+                }
+                result.push(rs);
+            }
+            await this.execute("COMMIT TRANSACTION");
+            return result;
+        } catch (e) {
+            await this.execute("ROLLBACK TRANSACTION");
+            throw e;
+        }
+    }
+}

--- a/packages/libsql-client/src/lib/libsql-js.ts
+++ b/packages/libsql-client/src/lib/libsql-js.ts
@@ -1,6 +1,9 @@
+import { isNode, isDeno } from "browser-or-node";
+
 import { Driver } from "./driver/Driver";
 import { HttpDriver } from "./driver/HttpDriver";
 import { SqliteDriver } from "./driver/SqliteDriver";
+import { BrowserSqliteDriver } from "./driver/BrowserSqliteDriver";
 
 export type Config = {
     url: string;
@@ -77,6 +80,10 @@ export function connect(config: Config): Connection {
     if (url.protocol == "http:" || url.protocol == "https:") {
         return new Connection(new HttpDriver(url));
     } else {
-        return new Connection(new SqliteDriver(rawUrl));
+        if (isNode || isDeno) {
+            return new Connection(new SqliteDriver(rawUrl));
+        } else {
+            return new Connection(new BrowserSqliteDriver(rawUrl));
+        }
     }
 }


### PR DESCRIPTION
It doesn't use webworkers as I can't imagine anyone using it in the browser for anything but testing. 
Fixes https://github.com/libsql/sqld/issues/145.