### PR TITLE
Make SQLite node driver take params with prefix.

### DIFF
--- a/packages/libsql-client/src/__tests__/libsql-js.test.ts
+++ b/packages/libsql-client/src/__tests__/libsql-js.test.ts
@@ -58,7 +58,7 @@ test("execute-params", async () => {
     rs = await db.execute(`INSERT INTO ${table} (email) VALUES (?)`, [value]);
     assertEmptySuccessResult(rs);
 
-    rs = await db.execute(`SELECT * FROM ${table} WHERE email = :email`, { email: value });
+    rs = await db.execute(`SELECT * FROM ${table} WHERE email = :email`, { ":email": value });
     expect(rs.columns).toEqual(["email"]);
     expect(rs.rows).toEqual([[value]]);
 

--- a/packages/libsql-client/src/lib/driver/SqliteDriver.ts
+++ b/packages/libsql-client/src/lib/driver/SqliteDriver.ts
@@ -10,6 +10,21 @@ export class SqliteDriver implements Driver {
     }
 
     async execute(sql: string, params?: Params): Promise<ResultSet> {
+        if (params !== undefined && !Array.isArray(params)) {
+            const modifiedParams: Record<string, SqlValue> = {};
+            for (const paramName in params) {
+                const prefix = paramName.charAt(0);
+                if (prefix === "?" || prefix === ":" || prefix === "@" || prefix === "$") {
+                    const param = paramName.substring(1);
+                    modifiedParams[param] = params[paramName];
+                } else {
+                    throw new Error(
+                        `given sqlite parameter '${paramName}' doesn't start with a prefix character (?, $, : or @)`
+                    );
+                }
+            }
+            params = modifiedParams;
+        }
         return await new Promise((resolve) => {
             let columns: string[];
             let rows: any[];


### PR DESCRIPTION
It's a bit of a hack, but it should work reasonably well and we can still enjoy the benefits of better-sqlite speed.