### PR TITLE
sqld: implement --with-bottomless-replication for S3-compatible replication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # install dependencies
 FROM rust:slim-bullseye AS compiler
 RUN apt update && apt install -y libclang-dev clang \
-    build-essential tcl protobuf-compiler file
+    build-essential tcl protobuf-compiler file \
+    ca-certificates
 RUN cargo install cargo-chef
 WORKDIR /sqld
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # install dependencies
 FROM rust:slim-bullseye AS compiler
-RUN apt update && apt install -y libclang-dev clang \
-    build-essential tcl protobuf-compiler file \
-    ca-certificates
+RUN apt-get update && apt-get install -y libclang-dev clang \
+    build-essential tcl protobuf-compiler file
 RUN cargo install cargo-chef
 WORKDIR /sqld
 
@@ -21,6 +20,7 @@ RUN cargo build -p sqld --release
 # runtime
 FROM debian:bullseye-slim
 COPY --from=builder /sqld/target/release/sqld /bin/sqld
+RUN apt-get update && apt-get install -y ca-certificates
 COPY docker-entrypoint.sh /usr/local/bin
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,34 @@ curl -s -d '{\"statements\": [\"SELECT * from sqlite_master;\"] }' http://127.0.
 
 You can also inspect the local foo.db file with the `sqlite3` shell
 
+### Integration with S3 bottomless replication
+
+`sqld` is integrated with [bottomless replication subproject](https://github.com/libsql/sqld/tree/main/bottomless). With bottomless replication, the database state is continuously backed up to S3-compatible storage. Each backup session is called a "generation" and consists of the main database file snapshot and replicates [WAL](https://www.sqlite.org/wal.html) pages.
+
+In order to enable automatic replication to S3 storage, run `sqld` with `--enable-bottomless-replication` parameter:
+```console
+sqld --http-listen-addr=127.0.0.1:8000 --enable-bottomless-replication
+```
+
+#### Configuration
+Replication needs to be able to access an S3-compatible bucket. The following environment variables can be used to configure the replication:
+```sh
+LIBSQL_BOTTOMLESS_BUCKET=my-bucket                 # Default bucket name: bottomless
+LIBSQL_BOTTOMLESS_ENDPOINT='http://localhost:9000' # address can be overridden for local testing, e.g. with Minio
+AWS_SECRET_ACCESS_KEY=                             # regular AWS variables are used
+AWS_ACCESS_KEY_ID=                                 # ... to set up auth, regions, etc.
+AWS_REGION=                                        # .
+```
+
+#### bottomless-cli
+Replicated snapshots can be inspected and managed with the official command-line interface.
+
+The tool can be installed via `cargo`:
+```console
+RUSTFLAGS='--cfg uuid_unstable' cargo install bottomless-cli
+```
+For usage examples and description, refer to the official bottomless-cli documentation: https://github.com/libsql/sqld/tree/main/bottomless#cli
+
 ## Homebrew
 
 You can install `sqld` through homebrew by doing:

--- a/bottomless/src/lib.rs
+++ b/bottomless/src/lib.rs
@@ -39,7 +39,7 @@ fn is_local() -> bool {
 pub extern "C" fn xOpen(
     vfs: *mut sqlite3_vfs,
     db_file: *mut sqlite3_file,
-    wal_name: *const i8,
+    wal_name: *const c_char,
     no_shm_mode: i32,
     max_size: i64,
     methods: *mut libsql_wal_methods,
@@ -456,7 +456,7 @@ async fn try_restore(replicator: &mut replicator::Replicator) -> i32 {
     ffi::SQLITE_OK
 }
 
-pub extern "C" fn xPreMainDbOpen(_methods: *mut libsql_wal_methods, path: *const i8) -> i32 {
+pub extern "C" fn xPreMainDbOpen(_methods: *mut libsql_wal_methods, path: *const c_char) -> i32 {
     if is_local() {
         tracing::info!("Running in local-mode only, without any replication");
         return ffi::SQLITE_OK;

--- a/docker-compose-with-bottomless.yml
+++ b/docker-compose-with-bottomless.yml
@@ -1,0 +1,37 @@
+version: "3.9"
+services:
+  writer:
+    build: .
+    environment: 
+      - SQLD_NODE=primary
+      - SQLD_ENABLE_BOTTOMLESS_REPLICATION=true
+      - LIBSQL_BOTTOMLESS_ENDPOINT=http://s3:9000
+      - AWS_ACCESS_KEY_ID=minioadmin
+      - AWS_SECRET_ACCESS_KEY=minioadmin
+      - AWS_DEFAULT_REGION=eu-central-2
+      - RUST_LOG=info,bottomless=trace
+    ports:
+      - "6000:5000"
+    depends_on:
+      - s3
+  reader:
+    build: .
+    environment:
+      - SQLD_NODE=replica
+      - SQLD_PRIMARY_URL=http://writer:5001
+      - SQLD_HTTP_LISTEN_ADDR=0.0.0.0:8080
+    depends_on:
+      - writer
+  nginx:
+    image: nginx:latest
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - reader
+    ports:
+      - "6001:6001"
+      - "8080:8080"
+  s3:
+    image: fclairamb/minio-github-actions
+    ports:
+      - "9000:9000"

--- a/sqld-libsql-bindings/src/lib.rs
+++ b/sqld-libsql-bindings/src/lib.rs
@@ -41,8 +41,9 @@ pub fn open_with_regular_wal(
 ) -> anyhow::Result<Connection> {
     let path = path.as_ref().join("data");
     unsafe {
-        let orig = get_orig_wal_methods(with_bottomless)?;
-        let wrapped = WalMethodsHook::wrap(orig, wal_hook);
+        let default_methods = get_orig_wal_methods(false)?;
+        let maybe_bottomless_methods = get_orig_wal_methods(with_bottomless)?;
+        let wrapped = WalMethodsHook::wrap(default_methods, maybe_bottomless_methods, wal_hook);
         let res = libsql_wal_methods_register(wrapped);
         ensure!(res == 0, "failed to register WAL methods");
     }

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -9,6 +9,7 @@ async-lock = "2.6.0"
 async-trait = "0.1.58"
 base64 = "0.21.0"
 bincode = "1.3.3"
+bottomless = { version = "0", path = "../bottomless", features = ["libsql_linked_statically"] }
 byteorder = "1.4.3"
 bytes = { version = "1.2.1", features = ["serde"] }
 clap = { version = "4.0.23", features = [ "derive", "env"] }

--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -136,6 +136,7 @@ fn open_db(
         Arc<Mutex<sqld_libsql_bindings::mwal::ffi::libsql_wal_methods>>,
     >,
     wal_hook: impl WalHook + Send + Clone + 'static,
+    with_bottomless: bool,
 ) -> anyhow::Result<rusqlite::Connection> {
     let mut retries = 0;
     loop {
@@ -156,6 +157,7 @@ fn open_db(
                     | OpenFlags::SQLITE_OPEN_URI
                     | OpenFlags::SQLITE_OPEN_NO_MUTEX,
                 wal_hook.clone(),
+                with_bottomless,
             ),
         };
         #[cfg(not(feature = "mwal_backend"))]
@@ -166,6 +168,7 @@ fn open_db(
                 | OpenFlags::SQLITE_OPEN_URI
                 | OpenFlags::SQLITE_OPEN_NO_MUTEX,
             wal_hook.clone(),
+            with_bottomless,
         );
 
         match conn_result {
@@ -201,6 +204,7 @@ impl LibSqlDb {
             Arc<Mutex<sqld_libsql_bindings::mwal::ffi::libsql_wal_methods>>,
         >,
         wal_hook: impl WalHook + Send + Clone + 'static,
+        with_bottomless: bool,
     ) -> crate::Result<Self> {
         let (sender, receiver) = crossbeam::channel::unbounded::<Message>();
 
@@ -210,6 +214,7 @@ impl LibSqlDb {
                 #[cfg(feature = "mwal_backend")]
                 vwal_methods,
                 wal_hook,
+                with_bottomless,
             )
             .unwrap();
 

--- a/sqld/src/database/write_proxy/mod.rs
+++ b/sqld/src/database/write_proxy/mod.rs
@@ -124,6 +124,7 @@ impl WriteProxyDatabase {
             #[cfg(feature = "mwal_backend")]
             vwal_methods,
             (),
+            false, // no bottomless replication for replicas
         )?;
         Ok(Self {
             read_db,

--- a/sqld/src/database/write_proxy/replication.rs
+++ b/sqld/src/database/write_proxy/replication.rs
@@ -60,6 +60,7 @@ impl PeriodicDbUpdater {
                     | OpenFlags::SQLITE_OPEN_URI
                     | OpenFlags::SQLITE_OPEN_NO_MUTEX,
                 hook,
+                false, // bottomless replication is not enabled for replicas
             )
         })
         .await??;

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -63,6 +63,7 @@ pub struct Config {
     pub rpc_server_cert: Option<PathBuf>,
     pub rpc_server_key: Option<PathBuf>,
     pub rpc_server_ca_cert: Option<PathBuf>,
+    pub enable_bottomless_replication: bool,
 }
 
 async fn run_service<S>(service: S, config: Config) -> anyhow::Result<()>
@@ -149,6 +150,10 @@ pub async fn run_server(config: Config) -> anyhow::Result<()> {
         std::fs::create_dir_all(&config.db_path)?;
     }
 
+    if config.enable_bottomless_replication {
+        bottomless::static_init::register_bottomless_methods();
+    }
+
     match config.writer_rpc_addr {
         Some(ref addr) => {
             let factory = WriteProxyDbFactory::new(
@@ -181,6 +186,7 @@ pub async fn run_server(config: Config) -> anyhow::Result<()> {
                         #[cfg(feature = "mwal_backend")]
                         vwal_methods,
                         hook,
+                        config.enable_bottomless_replication,
                     )
                 }
             };

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -78,6 +78,8 @@ struct Cli {
     /// Don't display welcome message
     #[clap(long)]
     no_welcome: bool,
+    #[clap(long)]
+    enable_bottomless_replication: bool,
 }
 
 impl Cli {
@@ -147,6 +149,7 @@ impl From<Cli> for Config {
             rpc_server_ca_cert: cli.grpc_ca_cert_file,
             #[cfg(feature = "mwal_backend")]
             mwal_addr: cli.mwal_addr,
+            enable_bottomless_replication: cli.enable_bottomless_replication,
         }
     }
 }

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -78,7 +78,7 @@ struct Cli {
     /// Don't display welcome message
     #[clap(long)]
     no_welcome: bool,
-    #[clap(long)]
+    #[clap(long, env = "SQLD_ENABLE_BOTTOMLESS_REPLICATION")]
     enable_bottomless_replication: bool,
 }
 


### PR DESCRIPTION
This series adds `--enable-bottomless-replication` option to `sqld`. If enabled, bottomless S3 replication is hooked into the virtual WAL.

This series is still a draft, because bottomless replication needs a few things set up via environment variables (e.g. `LIBSQL_BOTTOMLESS_BUCKET`, `LIBSQL_BOTTOMLESS_ENDPOINT`, AWS credentials), and they should also be configurable as command-line params.

I also need to document it thoroughly, so that people actually know how to set everything up.