### PR TITLE
add a new method to connect from URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,6 +1996,7 @@ dependencies = [
  "base64 0.21.0",
  "num-traits",
  "serde_json",
+ "url",
  "worker",
 ]
 

--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["libsql", "sqld", "database", "driver", "http"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+url = "2.3.1"
 base64 = "0.21.0"
 num-traits = "0.2.15"
 serde_json = "1.0.91"


### PR DESCRIPTION
I feel this is needed, because often times the server will inform the user the full URL, with all the username information inside it. Forcing the user to extract it is tedious.

In addition to that, also add example usage for the base connect() method.