### PR TITLE
libsql-client: add reqwest backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,13 +1991,17 @@ dependencies = [
 
 [[package]]
 name = "libsql-client"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.0",
+ "libsql-client",
  "num-traits",
+ "rand",
+ "reqwest",
  "serde_json",
+ "tokio",
  "url",
  "worker",
 ]

--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -16,6 +16,17 @@ serde_json = "1.0.91"
 worker = { version = "0.0.12", optional = true }
 anyhow = "1.0.69"
 async-trait = "0.1.64"
+reqwest = { version = "0.11.14", optional = true }
 
 [features]
 workers_backend = ["worker"]
+reqwest_backend = ["reqwest"]
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+libsql-client = { path = ".", features = ["reqwest_backend"] }
+rand = "0.8.5"
+
+[[example]]
+name = "select"
+path = "examples/select.rs"

--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0.91"
 worker = { version = "0.0.12", optional = true }
 anyhow = "1.0.69"
 async-trait = "0.1.64"
-reqwest = { version = "0.11.14", optional = true }
+reqwest = { version = "0.11.14", optional = true, default-features = false, features = ["rustls-tls"] }
 
 [features]
 workers_backend = ["worker"]

--- a/libsql-client/README.md
+++ b/libsql-client/README.md
@@ -2,7 +2,33 @@
 
 libSQL Rust client library can be used to communicate with [sqld](https://github.com/libsql/sqld/) over HTTP protocol with native Rust interface.
 
-At the moment the library works exclusively in Cloudflare Workers environment, but it is expected to gain additional backends very soon.
+At the moment the library works with the following backends:
+ - reqwest
+ - Cloudflare Workers environment
+
+## Reqwest
+In order to connect to the database, set up the following env variables:
+```
+export LIBSQL_CLIENT_URL = "your-db-url.example.com"
+export LIBSQL_CLIENT_USER = "me"
+export LIBSQL_CLIENT_PASS = "my-password"
+```
+
+Add it as dependency with `reqwest_backend` backend enabled:
+```
+cargo add libsql-client -F reqwest_backend
+```
+
+Example for how to connect to the database and perform a query from a GET handler:
+```rust
+    let db = libsql_client::reqwest::Connection::connect_from_env()?;
+    let response = db
+        .execute("SELECT * FROM table WHERE key = 'key1'")
+        .await?;
+    (...)
+```
+
+## Cloudflare Workers
 
 In order to connect to the database, set up the following variables in `.dev.vars`, or register them as secrets:
 ```

--- a/libsql-client/examples/select.rs
+++ b/libsql-client/examples/select.rs
@@ -21,13 +21,13 @@ fn result_to_string(result: QueryResult) -> String {
     ret
 }
 
-// Serve a request to load the page
-async fn serve(db: impl Connection) -> String {
+// Bumps a counter for one of the geographic locations picked at random.
+async fn bump_counter(db: impl Connection) -> String {
     // Recreate the tables if they do not exist yet
-    db.execute("CREATE TABLE IF NOT EXISTS counter(country TEXT, city TEXT, value, PRIMARY KEY(country, city)) WITHOUT ROWID").await.ok();
-    db.execute(
-        "CREATE TABLE IF NOT EXISTS coordinates(lat INT, long INT, airport TEXT, PRIMARY KEY (lat, long))",
-    ).await.ok();
+    db.batch([
+        "CREATE TABLE IF NOT EXISTS counter(country TEXT, city TEXT, value, PRIMARY KEY(country, city)) WITHOUT ROWID",
+        "CREATE TABLE IF NOT EXISTS coordinates(lat INT, long INT, airport TEXT, PRIMARY KEY (lat, long))"
+    ]).await.ok();
 
     // For demo purposes, let's pick a pseudorandom location
     const FAKE_LOCATIONS: &[(&str, &str, &str, f64, f64)] = &[
@@ -71,6 +71,6 @@ async fn serve(db: impl Connection) -> String {
 #[tokio::main]
 async fn main() {
     let db = libsql_client::reqwest::Connection::connect_from_ctx().unwrap();
-    let response = serve(db).await;
+    let response = bump_counter(db).await;
     println!("{response}")
 }

--- a/libsql-client/examples/select.rs
+++ b/libsql-client/examples/select.rs
@@ -1,0 +1,76 @@
+use libsql_client::{Connection, QueryResult, Statement, Value};
+use rand::prelude::SliceRandom;
+
+fn result_to_string(result: QueryResult) -> String {
+    let mut ret = String::new();
+    match result {
+        QueryResult::Error((msg, _)) => return format!("Error: {msg}"),
+        QueryResult::Success((result, _)) => {
+            for column in &result.columns {
+                ret += &format!("| {column:16} |");
+            }
+            ret += "\n| -------------------------------------------------------- |\n";
+            for row in result.rows {
+                for column in &result.columns {
+                    ret += &format!("| {:16} |", row.cells[column].to_string());
+                }
+                ret += "\n";
+            }
+        }
+    };
+    ret
+}
+
+// Serve a request to load the page
+async fn serve(db: impl Connection) -> String {
+    // Recreate the tables if they do not exist yet
+    db.execute("CREATE TABLE IF NOT EXISTS counter(country TEXT, city TEXT, value, PRIMARY KEY(country, city)) WITHOUT ROWID").await.ok();
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS coordinates(lat INT, long INT, airport TEXT, PRIMARY KEY (lat, long))",
+    ).await.ok();
+
+    // For demo purposes, let's pick a pseudorandom location
+    const FAKE_LOCATIONS: &[(&str, &str, &str, f64, f64)] = &[
+        ("WAW", "PL", "Warsaw", 52.22959, 21.0067),
+        ("EWR", "US", "Newark", 42.99259, -81.3321),
+        ("HAM", "DE", "Hamburg", 50.118801, 7.684300),
+        ("HEL", "FI", "Helsinki", 60.3183, 24.9497),
+        ("NSW", "AU", "Sydney", -33.9500, 151.1819),
+    ];
+
+    let (airport, country, city, latitude, longitude) =
+        *FAKE_LOCATIONS.choose(&mut rand::thread_rng()).unwrap();
+
+    db.transaction([
+        Statement::with_params("INSERT INTO counter VALUES (?, ?, 0)", &[country, city]),
+        Statement::with_params(
+            "UPDATE counter SET value = value + 1 WHERE country = ? AND city = ?",
+            &[country, city],
+        ),
+        Statement::with_params(
+            "INSERT INTO coordinates VALUES (?, ?, ?)",
+            &[
+                Value::Float(latitude),
+                Value::Float(longitude),
+                airport.into(),
+            ],
+        ),
+    ])
+    .await
+    .ok();
+
+    let counter_response = match db.execute("SELECT * FROM counter").await {
+        Ok(resp) => resp,
+        Err(e) => return format!("Error: {e}"),
+    };
+    let scoreboard = result_to_string(counter_response);
+    let html = format!("Scoreboard:\n{scoreboard}");
+    html
+}
+
+#[tokio::main]
+async fn main() {
+    let db = libsql_client::reqwest::Connection::connect_from_ctx().unwrap();
+    let response = serve(db).await;
+    println!("{response}")
+}

--- a/libsql-client/examples/select.rs
+++ b/libsql-client/examples/select.rs
@@ -70,7 +70,7 @@ async fn bump_counter(db: impl Connection) -> String {
 
 #[tokio::main]
 async fn main() {
-    let db = libsql_client::reqwest::Connection::connect_from_ctx().unwrap();
+    let db = libsql_client::reqwest::Connection::connect_from_env().unwrap();
     let response = bump_counter(db).await;
     println!("{response}")
 }

--- a/libsql-client/src/lib.rs
+++ b/libsql-client/src/lib.rs
@@ -26,6 +26,9 @@ pub use connection::Connection;
 #[cfg(feature = "workers_backend")]
 pub mod workers;
 
+#[cfg(feature = "reqwest_backend")]
+pub mod reqwest;
+
 /// Metadata of a database request
 #[derive(Clone, Debug, Default)]
 pub struct Meta {

--- a/libsql-client/src/reqwest.rs
+++ b/libsql-client/src/reqwest.rs
@@ -66,7 +66,7 @@ impl Connection {
         Ok(Connection::connect(url.as_str(), username, password))
     }
 
-    pub fn connect_from_ctx() -> anyhow::Result<Connection> {
+    pub fn connect_from_env() -> anyhow::Result<Connection> {
         let url = std::env::var("LIBSQL_CLIENT_URL").map_err(|_| {
             anyhow::anyhow!("LIBSQL_CLIENT_URL variable should point to your sqld database")
         })?;

--- a/libsql-client/src/reqwest.rs
+++ b/libsql-client/src/reqwest.rs
@@ -1,0 +1,129 @@
+use async_trait::async_trait;
+use base64::Engine;
+
+use super::{parse_query_result, QueryResult, Statement};
+
+/// Database connection. This is the main structure used to
+/// communicate with the database.
+#[derive(Clone, Debug)]
+pub struct Connection {
+    url: String,
+    auth: String,
+}
+
+impl Connection {
+    /// Establishes a database connection.
+    ///
+    /// # Arguments
+    /// * `url` - URL of the database endpoint
+    /// * `username` - database username
+    /// * `pass` - user's password
+    pub fn connect(
+        url: impl Into<String>,
+        username: impl Into<String>,
+        pass: impl Into<String>,
+    ) -> Self {
+        let username = username.into();
+        let pass = pass.into();
+        let url = url.into();
+        // Auto-update the URL to start with https:// if no protocol was specified
+        let url = if !url.contains("://") {
+            "https://".to_owned() + &url
+        } else {
+            url
+        };
+        Self {
+            url,
+            auth: format!(
+                "Basic {}",
+                base64::engine::general_purpose::STANDARD.encode(format!("{username}:{pass}"))
+            ),
+        }
+    }
+
+    /// Establishes a database connection, given a [`Url`]
+    ///
+    /// # Arguments
+    /// * `url` - [`Url`] object of the database endpoint. This cannot be a relative URL;
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use libsql_client::reqwest::Connection;
+    /// use url::Url;
+    ///
+    /// let url  = Url::parse("https://foo:bar@localhost:8080").unwrap();
+    /// let db = Connection::connect_from_url(&url).unwrap();
+    /// ```
+    pub fn connect_from_url(url: &url::Url) -> anyhow::Result<Connection> {
+        let username = url.username();
+        let password = url.password().unwrap_or_default();
+        let mut url = url.clone();
+        url.set_username("")
+            .map_err(|_| anyhow::anyhow!("Could not extract username from URL. Invalid URL?"))?;
+        url.set_password(None)
+            .map_err(|_| anyhow::anyhow!("Could not extract password from URL. Invalid URL?"))?;
+        Ok(Connection::connect(url.as_str(), username, password))
+    }
+
+    pub fn connect_from_ctx() -> anyhow::Result<Connection> {
+        let url = std::env::var("LIBSQL_CLIENT_URL").map_err(|_| {
+            anyhow::anyhow!("LIBSQL_CLIENT_URL variable should point to your sqld database")
+        })?;
+        let user = std::env::var("LIBSQL_CLIENT_USER").map_err(|_| {
+            anyhow::anyhow!("LIBSQL_CLIENT_USER variable should be set to your sqld username")
+        })?;
+        let pass = std::env::var("LIBSQL_CLIENT_PASS").map_err(|_| {
+            anyhow::anyhow!("LIBSQL_CLIENT_PASS variable should be set to your sqld password")
+        })?;
+        Ok(Connection::connect(url, user, pass))
+    }
+}
+
+#[async_trait(?Send)]
+impl super::Connection for Connection {
+    async fn batch(
+        &self,
+        stmts: impl IntoIterator<Item = impl Into<Statement>>,
+    ) -> anyhow::Result<Vec<QueryResult>> {
+        // FIXME: serialize and deserialize with existing routines from sqld
+        let mut body = "{\"statements\": [".to_string();
+        let mut stmts_count = 0;
+        for stmt in stmts {
+            body += &format!("{},", stmt.into());
+            stmts_count += 1;
+        }
+        if stmts_count > 0 {
+            body.pop();
+        }
+        body += "]}";
+        let client = reqwest::Client::new();
+        let response = client
+            .post(&self.url)
+            .body(body)
+            .header("Authorization", &self.auth)
+            .send()
+            .await?;
+        let resp: String = response.text().await?;
+        let response_json: serde_json::Value = serde_json::from_str(&resp)?;
+        match response_json {
+            serde_json::Value::Array(results) => {
+                if results.len() != stmts_count {
+                    Err(anyhow::anyhow!(
+                        "Response array did not contain expected {stmts_count} results"
+                    ))
+                } else {
+                    let mut query_results: Vec<QueryResult> = Vec::with_capacity(stmts_count);
+                    for (idx, result) in results.into_iter().enumerate() {
+                        query_results.push(
+                            parse_query_result(result, idx).map_err(|e| anyhow::anyhow!("{e}"))?,
+                        );
+                    }
+
+                    Ok(query_results)
+                }
+            }
+            e => Err(anyhow::anyhow!("Error: {}", e)),
+        }
+    }
+}

--- a/libsql-client/src/statement.rs
+++ b/libsql-client/src/statement.rs
@@ -51,6 +51,12 @@ impl From<&str> for Statement {
     }
 }
 
+impl From<&&str> for Statement {
+    fn from(val: &&str) -> Self {
+        val.to_string().into()
+    }
+}
+
 impl std::fmt::Display for Statement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.params.is_empty() {


### PR DESCRIPTION
### WARNING: depends on #167 , unmerged at the time of writing this message

The backend communicates with sqld via the reqwest crate.

This patch comes with an example, runnable with
$ cargo run --example select

Note that the example is going to rightfully scream at you
if you do not provide authentication context in env variables:
```
 - LIBSQL_CLIENT_URL
 - LIBSQL_CLIENT_USER
 - LIBSQL_CLIENT_PASS
```

With reqwest backend, regular Rust apps can connect to sqld, as shown in the example