### PR TITLE
libsql-client: add a local backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@
 members = [
     "bottomless",
     "bottomless-cli",
-    "libsql-client",
     "sqlc",
     "sqld",
     "sqld-libsql-bindings",

--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-client"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "HTTP-based client for libSQL and sqld"

--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-client"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "HTTP-based client for libSQL and sqld"

--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -17,14 +17,21 @@ worker = { version = "0.0.12", optional = true }
 anyhow = "1.0.69"
 async-trait = "0.1.64"
 reqwest = { version = "0.11.14", optional = true, default-features = false, features = ["rustls-tls"] }
+sqld-libsql-bindings = { version = "0", path = "../sqld-libsql-bindings", optional = true }
+rusqlite = { version = "0.28.0", optional = true, git = "https://github.com/psarna/rusqlite", rev = "4df75df0b0f5ecea2714a8b21bf9f2a0fcfd5905", default-features = false, features = [
+    "buildtime_bindgen",
+    "bundled-libsql",
+    "column_decltype"
+] }
 
 [features]
 workers_backend = ["worker"]
 reqwest_backend = ["reqwest"]
+local_backend = ["rusqlite", "sqld-libsql-bindings"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-libsql-client = { path = ".", features = ["reqwest_backend"] }
+libsql-client = { path = ".", features = ["reqwest_backend", "local_backend"] }
 rand = "0.8.5"
 
 [[example]]

--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -37,3 +37,7 @@ rand = "0.8.5"
 [[example]]
 name = "select"
 path = "examples/select.rs"
+
+[[example]]
+name = "connect_from_env"
+path = "examples/connect_from_env.rs"

--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-client"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "HTTP-based client for libSQL and sqld"
@@ -25,6 +25,7 @@ rusqlite = { version = "0.28.0", optional = true, git = "https://github.com/psar
 ] }
 
 [features]
+default = ["local_backend", "reqwest_backend"]
 workers_backend = ["worker"]
 reqwest_backend = ["reqwest"]
 local_backend = ["rusqlite", "sqld-libsql-bindings"]

--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -17,10 +17,8 @@ worker = { version = "0.0.12", optional = true }
 anyhow = "1.0.69"
 async-trait = "0.1.64"
 reqwest = { version = "0.11.14", optional = true, default-features = false, features = ["rustls-tls"] }
-sqld-libsql-bindings = { version = "0", path = "../sqld-libsql-bindings", optional = true }
-rusqlite = { version = "0.28.0", optional = true, git = "https://github.com/psarna/rusqlite", rev = "4df75df0b0f5ecea2714a8b21bf9f2a0fcfd5905", default-features = false, features = [
+rusqlite = { version = "0.28.0", optional = true, default-features = false, features = [
     "buildtime_bindgen",
-    "bundled-libsql",
     "column_decltype"
 ] }
 
@@ -28,7 +26,7 @@ rusqlite = { version = "0.28.0", optional = true, git = "https://github.com/psar
 default = ["local_backend", "reqwest_backend"]
 workers_backend = ["worker"]
 reqwest_backend = ["reqwest"]
-local_backend = ["rusqlite", "sqld-libsql-bindings"]
+local_backend = ["rusqlite"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
@@ -42,3 +40,5 @@ path = "examples/select.rs"
 [[example]]
 name = "connect_from_env"
 path = "examples/connect_from_env.rs"
+
+[workspace]

--- a/libsql-client/README.md
+++ b/libsql-client/README.md
@@ -1,22 +1,68 @@
 # Rust libSQL client library
 
-libSQL Rust client library can be used to communicate with [sqld](https://github.com/libsql/sqld/) over HTTP protocol with native Rust interface.
+libSQL Rust client library can be used to communicate with [sqld](https://github.com/libsql/sqld/) natively over HTTP protocol with native Rust interface.
 
 At the moment the library works with the following backends:
+ - local
  - reqwest
- - Cloudflare Workers environment
+ - Cloudflare Workers environment (optional)
 
-## Reqwest
+## Quickstart
+
+In order to use the database in your project, just call `libsql_client::connect()`:
+```rust
+    let db = libsql_client::connect()?;
+```
+
+The only thing you need to provide is an env variable with the database URL, e.g.
+```
+export LIBSQL_CLIENT_URL="file:////tmp/example.db"
+```
+for a local database stored in a file, or
+```
+export LIBSQL_CLIENT_URL="https://user:pass@example.turso.io"
+```
+for a remote database connection.
+
+You can also explicitly use a specific backend. Examples of that are covered in the next paragraphs.
+
+### Local
+
+In order to connect to the database, set up the URL to point to a local path:
+```
+export LIBSQL_CLIENT_URL = "/tmp/example.db"
+```
+
+`local_backend` feature is enabled by default, so add the dependency like this:
+```
+cargo add libsql-client
+```
+
+Example for how to connect to the database and perform a query:
+```rust
+    let db = libsql_client::local::Connection::connect_from_env()?;
+    let response = db
+        .execute("SELECT * FROM table WHERE key = 'key1'")
+        .await?;
+    (...)
+```
+
+
+### Reqwest
 In order to connect to the database, set up the following env variables:
 ```
-export LIBSQL_CLIENT_URL = "your-db-url.example.com"
+export LIBSQL_CLIENT_URL = "https://your-db-url.example.com"
 export LIBSQL_CLIENT_USER = "me"
 export LIBSQL_CLIENT_PASS = "my-password"
 ```
-
-Add it as dependency with `reqwest_backend` backend enabled:
+... or just the URL, if it contains the required auth information:
 ```
-cargo add libsql-client -F reqwest_backend
+export LIBSQL_CLIENT_URL = "https://user@pass:your-db-url.example.com"
+```
+
+`reqwest_backend` feature is enabled by default, so add the dependency like this:
+```
+cargo add libsql-client
 ```
 
 Example for how to connect to the database and perform a query from a GET handler:
@@ -28,18 +74,19 @@ Example for how to connect to the database and perform a query from a GET handle
     (...)
 ```
 
-## Cloudflare Workers
+### Cloudflare Workers
 
 In order to connect to the database, set up the following variables in `.dev.vars`, or register them as secrets:
 ```
-LIBSQL_CLIENT_URL = "your-db-url.example.com"
+LIBSQL_CLIENT_URL = "https://your-db-url.example.com"
 LIBSQL_CLIENT_USER = "me"
 LIBSQL_CLIENT_PASS = "my-password"
 ```
 
-Add it as dependency with `workers_backend` backend enabled:
+Add it as dependency with `workers_backend` backend enabled. Turn off default features, as they are not guaranteed to compile to `wasm32-unknown-unknown`,
+which is required in this environment:
 ```
-cargo add libsql-client -F workers_backend
+cargo add libsql-client --no-default-features -F workers_backend
 ```
 
 Example for how to connect to the database and perform a query from a GET handler:

--- a/libsql-client/examples/connect_from_env.rs
+++ b/libsql-client/examples/connect_from_env.rs
@@ -1,0 +1,83 @@
+use libsql_client::{connect, Connection, QueryResult, Statement, Value};
+use rand::prelude::SliceRandom;
+
+fn result_to_string(result: QueryResult) -> String {
+    let mut ret = String::new();
+    match result {
+        QueryResult::Error((msg, _)) => return format!("Error: {msg}"),
+        QueryResult::Success((result, _)) => {
+            for column in &result.columns {
+                ret += &format!("| {column:16} |");
+            }
+            ret += "\n| -------------------------------------------------------- |\n";
+            for row in result.rows {
+                for column in &result.columns {
+                    ret += &format!("| {:16} |", row.cells[column].to_string());
+                }
+                ret += "\n";
+            }
+        }
+    };
+    ret
+}
+
+// Bumps a counter for one of the geographic locations picked at random.
+async fn bump_counter(db: impl Connection) -> String {
+    // Recreate the tables if they do not exist yet
+    db.batch([
+        "CREATE TABLE IF NOT EXISTS counter(country TEXT, city TEXT, value, PRIMARY KEY(country, city)) WITHOUT ROWID",
+        "CREATE TABLE IF NOT EXISTS coordinates(lat INT, long INT, airport TEXT, PRIMARY KEY (lat, long))"
+    ]).await.ok();
+
+    // For demo purposes, let's pick a pseudorandom location
+    const FAKE_LOCATIONS: &[(&str, &str, &str, f64, f64)] = &[
+        ("WAW", "PL", "Warsaw", 52.22959, 21.0067),
+        ("EWR", "US", "Newark", 42.99259, -81.3321),
+        ("HAM", "DE", "Hamburg", 50.118801, 7.684300),
+        ("HEL", "FI", "Helsinki", 60.3183, 24.9497),
+        ("NSW", "AU", "Sydney", -33.9500, 151.1819),
+    ];
+
+    let (airport, country, city, latitude, longitude) =
+        *FAKE_LOCATIONS.choose(&mut rand::thread_rng()).unwrap();
+
+    db.transaction([
+        Statement::with_params(
+            "INSERT OR IGNORE INTO counter VALUES (?, ?, 0)",
+            &[country, city],
+        ),
+        Statement::with_params(
+            "UPDATE counter SET value = value + 1 WHERE country = ? AND city = ?",
+            &[country, city],
+        ),
+        Statement::with_params(
+            "INSERT OR IGNORE INTO coordinates VALUES (?, ?, ?)",
+            &[
+                Value::Real(latitude),
+                Value::Real(longitude),
+                airport.into(),
+            ],
+        ),
+    ])
+    .await
+    .ok();
+
+    let counter_response = match db.execute("SELECT * FROM counter").await {
+        Ok(resp) => resp,
+        Err(e) => return format!("Error: {e}"),
+    };
+    let scoreboard = result_to_string(counter_response);
+    let html = format!("Scoreboard:\n{scoreboard}");
+    html
+}
+
+#[tokio::main]
+async fn main() {
+    let db = connect().unwrap();
+    let response = bump_counter(db).await;
+    println!(
+        "Connection parameters: backend={:?} url={:?}\n{response}",
+        std::env::var("LIBSQL_CLIENT_BACKEND"),
+        std::env::var("LIBSQL_CLIENT_URL")
+    );
+}

--- a/libsql-client/examples/select.rs
+++ b/libsql-client/examples/select.rs
@@ -53,8 +53,8 @@ async fn bump_counter(db: impl Connection) -> String {
         Statement::with_params(
             "INSERT OR IGNORE INTO coordinates VALUES (?, ?, ?)",
             &[
-                Value::Float(latitude),
-                Value::Float(longitude),
+                Value::Real(latitude),
+                Value::Real(longitude),
                 airport.into(),
             ],
         ),

--- a/libsql-client/examples/select.rs
+++ b/libsql-client/examples/select.rs
@@ -1,4 +1,4 @@
-use libsql_client::{Connection, QueryResult, Statement, Value};
+use libsql_client::{params, Connection, QueryResult, Statement};
 use rand::prelude::SliceRandom;
 
 fn result_to_string(result: QueryResult) -> String {
@@ -44,6 +44,7 @@ async fn bump_counter(db: impl Connection) -> String {
     db.transaction([
         Statement::with_params(
             "INSERT OR IGNORE INTO counter VALUES (?, ?, 0)",
+            // Parameters that have a single type can be passed as a regular slice
             &[country, city],
         ),
         Statement::with_params(
@@ -52,11 +53,8 @@ async fn bump_counter(db: impl Connection) -> String {
         ),
         Statement::with_params(
             "INSERT OR IGNORE INTO coordinates VALUES (?, ?, ?)",
-            &[
-                Value::Real(latitude),
-                Value::Real(longitude),
-                airport.into(),
-            ],
+            // Parameters with different types can be passed to a convenience macro - params!()
+            params!(latitude, longitude, airport),
         ),
     ])
     .await

--- a/libsql-client/examples/select.rs
+++ b/libsql-client/examples/select.rs
@@ -79,8 +79,9 @@ async fn main() {
         Err(e) => println!("Failed to fetch from a remote database: {e}"),
     }
 
-    let local_db =
-        libsql_client::local::Connection::connect("/tmp/libsql_client_test_db.db").unwrap();
+    let mut path_buf = std::env::temp_dir();
+    path_buf.push("libsql_client_test_db.db");
+    let local_db = libsql_client::local::Connection::connect(path_buf.as_path()).unwrap();
     let response = bump_counter(local_db).await;
     println!("Local:\n{response}");
 }

--- a/libsql-client/src/connection.rs
+++ b/libsql-client/src/connection.rs
@@ -89,17 +89,15 @@ impl Connection for GenericConnection {
 /// Establishes a database connection based on environment variables
 ///
 /// # Env
-/// * `LIBSQL_CLIENT_BACKEND` - one of the available backends; e.g. `reqwest`, `local`, `workers`
 /// * `LIBSQL_CLIENT_URL` - URL of the database endpoint - e.g. a https:// endpoint for remote connections (with specified credentials) or local file:/// path for a local database
+/// * (optional) `LIBSQL_CLIENT_BACKEND` - one of the available backends; e.g. `reqwest`, `local`, `workers`
 /// *
 /// # Examples
 ///
 /// ```
 /// # use libsql_client::Connection;
-/// use url::Url;
-///
-/// let url  = Url::parse("https://foo:bar@localhost:8080").unwrap();
-/// let db = Connection::connect_from_url(&url).unwrap();
+/// # std::env::set_var("LIBSQL_CLIENT_URL", "file:////tmp/example.db");
+/// let db = libsql_client::connect().unwrap();
 /// ```
 pub fn connect() -> anyhow::Result<GenericConnection> {
     /*

--- a/libsql-client/src/connection.rs
+++ b/libsql-client/src/connection.rs
@@ -25,7 +25,6 @@ pub trait Connection {
     ///
     /// # Arguments
     /// * `stmts` - SQL statements
-    /// ```
     async fn batch(
         &self,
         stmts: impl IntoIterator<Item = impl Into<Statement>>,
@@ -37,7 +36,6 @@ pub trait Connection {
     ///
     /// # Arguments
     /// * `stmts` - SQL statements
-    /// ```
     async fn transaction(
         &self,
         stmts: impl IntoIterator<Item = impl Into<Statement>>,

--- a/libsql-client/src/connection.rs
+++ b/libsql-client/src/connection.rs
@@ -87,8 +87,11 @@ impl Connection for GenericConnection {
 /// Establishes a database connection based on environment variables
 ///
 /// # Env
-/// * `LIBSQL_CLIENT_URL` - URL of the database endpoint - e.g. a https:// endpoint for remote connections (with specified credentials) or local file:/// path for a local database
-/// * (optional) `LIBSQL_CLIENT_BACKEND` - one of the available backends; e.g. `reqwest`, `local`, `workers`
+/// * `LIBSQL_CLIENT_URL` - URL of the database endpoint - e.g. a https:// endpoint for remote connections
+///   (with specified credentials) or local file:/// path for a local database
+/// * (optional) `LIBSQL_CLIENT_BACKEND` - one of the available backends,
+///   e.g. `reqwest`, `local`, `workers`. The library will try to deduce the backend
+///   from the URL if not set explicitly. For instance, it will assume that https:// is not a local file.
 /// *
 /// # Examples
 ///

--- a/libsql-client/src/connection.rs
+++ b/libsql-client/src/connection.rs
@@ -56,3 +56,93 @@ pub trait Connection {
         Ok(ret)
     }
 }
+
+/// A generic connection struct, wrapping possible backends.
+/// It's a convenience struct which allows implementing connect()
+/// with backends being passed as env parameters.
+pub enum GenericConnection {
+    #[cfg(feature = "local_backend")]
+    Local(super::local::Connection),
+    #[cfg(feature = "reqwest_backend")]
+    Reqwest(super::reqwest::Connection),
+    #[cfg(feature = "workers_backend")]
+    Workers(super::workers::Connection),
+}
+
+#[async_trait(?Send)]
+impl Connection for GenericConnection {
+    async fn batch(
+        &self,
+        stmts: impl IntoIterator<Item = impl Into<Statement>>,
+    ) -> Result<Vec<QueryResult>> {
+        match self {
+            #[cfg(feature = "local_backend")]
+            Self::Local(l) => l.batch(stmts).await,
+            #[cfg(feature = "reqwest_backend")]
+            Self::Reqwest(r) => r.batch(stmts).await,
+            #[cfg(feature = "workers_backend")]
+            Self::Workers(w) => w.batch(stmts).await,
+        }
+    }
+}
+
+/// Establishes a database connection based on environment variables
+///
+/// # Env
+/// * `LIBSQL_CLIENT_BACKEND` - one of the available backends; e.g. `reqwest`, `local`, `workers`
+/// * `LIBSQL_CLIENT_URL` - URL of the database endpoint - e.g. a https:// endpoint for remote connections (with specified credentials) or local file:/// path for a local database
+/// *
+/// # Examples
+///
+/// ```
+/// # use libsql_client::Connection;
+/// use url::Url;
+///
+/// let url  = Url::parse("https://foo:bar@localhost:8080").unwrap();
+/// let db = Connection::connect_from_url(&url).unwrap();
+/// ```
+pub fn connect() -> anyhow::Result<GenericConnection> {
+    /*
+    #[cfg(feature = "workers_backend")]
+    pub mod workers;
+
+    #[cfg(feature = "reqwest_backend")]
+    pub mod reqwest;
+
+    #[cfg(feature = "local_backend")]
+    pub mod local;
+        */
+    let url = std::env::var("LIBSQL_CLIENT_URL").map_err(|_| {
+        anyhow::anyhow!("LIBSQL_CLIENT_URL variable should point to your libSQL/sqld database")
+    })?;
+    let backend = std::env::var("LIBSQL_CLIENT_BACKEND").unwrap_or_else(|_| {
+        if url.starts_with("http") {
+            return if cfg!(feature = "reqwest_backend") {
+                "reqwest"
+            } else if cfg!(feature = "workers_backend") {
+                "workers"
+            } else {
+                "local"
+            }
+            .to_string();
+        } else {
+            "local"
+        }
+        .to_string()
+    });
+    Ok(match backend.as_str() {
+        #[cfg(feature = "local_backend")]
+        "local" => {
+            GenericConnection::Local(super::local::Connection::connect(url)?)
+        },
+        #[cfg(feature = "reqwest_backend")]
+        "reqwest" => {
+            GenericConnection::Reqwest(super::reqwest::Connection::connect_from_url(&url::Url::parse(&url)?)?)
+        },
+        #[cfg(feature = "workers_backend")]
+        "workers" => {
+            anyhow::bail!("Connecting from workers API may need access to worker::RouteContext. Please call libsql_client::workers::Connection::connect_from_ctx() directly")
+        },
+        _ => anyhow::bail!("Unknown backend: {backend}. Make sure your backend exists and is enabled with its feature flag"),
+    })
+}

--- a/libsql-client/src/lib.rs
+++ b/libsql-client/src/lib.rs
@@ -21,7 +21,7 @@ pub mod value;
 pub use value::Value;
 
 pub mod connection;
-pub use connection::Connection;
+pub use connection::{connect, Connection};
 
 #[cfg(feature = "workers_backend")]
 pub mod workers;

--- a/libsql-client/src/lib.rs
+++ b/libsql-client/src/lib.rs
@@ -29,6 +29,9 @@ pub mod workers;
 #[cfg(feature = "reqwest_backend")]
 pub mod reqwest;
 
+#[cfg(feature = "local_backend")]
+pub mod local;
+
 /// Metadata of a database request
 #[derive(Clone, Debug, Default)]
 pub struct Meta {

--- a/libsql-client/src/lib.rs
+++ b/libsql-client/src/lib.rs
@@ -82,11 +82,10 @@ pub fn parse_value(
 ) -> Result<Value> {
     match cell {
         serde_json::Value::Null => Ok(Value::Null),
-        serde_json::Value::Bool(v) => Ok(Value::Bool(v)),
         serde_json::Value::Number(v) => match v.as_i64() {
-            Some(v) => Ok(Value::Number(v)),
+            Some(v) => Ok(Value::Integer(v)),
             None => match v.as_f64() {
-                Some(v) => Ok(Value::Float(v)),
+                Some(v) => Ok(Value::Real(v)),
                 None => Err(anyhow!(
                     "Result {result_idx} row {row_idx} cell {cell_idx} had unknown number value: {v}",
                 )),

--- a/libsql-client/src/lib.rs
+++ b/libsql-client/src/lib.rs
@@ -172,3 +172,23 @@ pub fn parse_query_result(result: serde_json::Value, idx: usize) -> Result<Query
         _ => Err(anyhow!("Result {idx} was not an object",)),
     }
 }
+
+/// A macro for passing parameters to statements without having to manually
+/// define their types.
+///
+/// # Example
+///
+/// ```rust,no_run
+///   let db = libsql_client::connect()?;
+///   db.execute(
+///       "INSERT INTO cart(product_id, product_name, quantity, price) VALUES (?, ?, ?, ?)",
+///       params!(64, "socks", 2, 4.5),
+///   ).await?;
+/// ```
+#[macro_export]
+macro_rules! params {
+    () => { &[] };
+    ($($param:expr),+ $(,)?) => {
+        &[$($param.into()),+] as &[libsql_client::Value]
+    };
+}

--- a/libsql-client/src/local.rs
+++ b/libsql-client/src/local.rs
@@ -1,10 +1,6 @@
 use super::{Meta, QueryResult, ResultSet, Row, Statement, Value};
 use async_trait::async_trait;
 
-pub use sqld_libsql_bindings::{
-    libsql_compile_wasm_module, libsql_free_wasm_module, libsql_run_wasm, libsql_wasm_engine_new,
-};
-
 use rusqlite::types::Value as RusqliteValue;
 
 /// Database connection. This is the main structure used to

--- a/libsql-client/src/local.rs
+++ b/libsql-client/src/local.rs
@@ -1,0 +1,121 @@
+use super::{Meta, QueryResult, ResultSet, Row, Statement, Value};
+use async_trait::async_trait;
+
+pub use sqld_libsql_bindings::{
+    libsql_compile_wasm_module, libsql_free_wasm_module, libsql_run_wasm, libsql_wasm_engine_new,
+};
+
+use rusqlite::types::Value as RusqliteValue;
+
+/// Database connection. This is the main structure used to
+/// communicate with the database.
+#[derive(Debug)]
+pub struct Connection {
+    inner: rusqlite::Connection,
+}
+
+impl From<Value> for RusqliteValue {
+    fn from(v: Value) -> Self {
+        match v {
+            Value::Null => RusqliteValue::Null,
+            Value::Integer(n) => RusqliteValue::Integer(n),
+            Value::Text(s) => RusqliteValue::Text(s),
+            Value::Real(d) => RusqliteValue::Real(d),
+            Value::Blob(b) => RusqliteValue::Blob(b),
+        }
+    }
+}
+
+impl From<RusqliteValue> for Value {
+    fn from(v: RusqliteValue) -> Self {
+        match v {
+            RusqliteValue::Null => Value::Null,
+            RusqliteValue::Integer(n) => Value::Integer(n),
+            RusqliteValue::Text(s) => Value::Text(s),
+            RusqliteValue::Real(d) => Value::Real(d),
+            RusqliteValue::Blob(b) => Value::Blob(b),
+        }
+    }
+}
+
+impl Connection {
+    /// Establishes a database connection.
+    ///
+    /// # Arguments
+    /// * `path` - path of the local database
+    pub fn connect(path: impl AsRef<std::path::Path>) -> anyhow::Result<Self> {
+        Ok(Self {
+            inner: rusqlite::Connection::open(path).map_err(|e| anyhow::anyhow!("{e}"))?,
+        })
+    }
+
+    /// Executes a batch of SQL statements.
+    /// Each statement is going to run in its own transaction,
+    /// unless they're wrapped in BEGIN and END
+    ///
+    /// # Arguments
+    /// * `stmts` - SQL statements
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # async fn f() {
+    /// let db = libsql_client::local::Connection::connect("/tmp/example321.db").unwrap();
+    /// let result = db
+    ///     .batch(["CREATE TABLE t(id)", "INSERT INTO t VALUES (42)"])
+    ///     .await;
+    /// # }
+    /// ```
+    pub async fn batch(
+        &self,
+        stmts: impl IntoIterator<Item = impl Into<Statement>>,
+    ) -> anyhow::Result<Vec<QueryResult>> {
+        let mut result = vec![];
+        for stmt in stmts {
+            let stmt = stmt.into();
+            let sql_string = &stmt.q;
+            let params =
+                rusqlite::params_from_iter(stmt.params.into_iter().map(RusqliteValue::from));
+            let mut stmt = self.inner.prepare(sql_string)?;
+            let columns: Vec<String> = stmt
+                .columns()
+                .into_iter()
+                .map(|c| c.name().to_string())
+                .collect();
+            let mut rows = Vec::new();
+            let mut input_rows = match stmt.query(params) {
+                Ok(rows) => rows,
+                Err(e) => {
+                    result.push(QueryResult::Error((format!("{e}"), Meta { duration: 0 })));
+                    break;
+                }
+            };
+            while let Some(row) = input_rows.next()? {
+                let cells = columns
+                    .iter()
+                    .map(|col| {
+                        (
+                            col.clone(),
+                            Value::from(row.get::<&str, RusqliteValue>(col.as_str()).unwrap()),
+                        )
+                    })
+                    .collect();
+                rows.push(Row { cells })
+            }
+            let meta = Meta { duration: 0 };
+            let result_set = ResultSet { columns, rows };
+            result.push(QueryResult::Success((result_set, meta)))
+        }
+        Ok(result)
+    }
+}
+
+#[async_trait(?Send)]
+impl super::Connection for Connection {
+    async fn batch(
+        &self,
+        stmts: impl IntoIterator<Item = impl Into<Statement>>,
+    ) -> anyhow::Result<Vec<QueryResult>> {
+        self.batch(stmts).await
+    }
+}

--- a/libsql-client/src/local.rs
+++ b/libsql-client/src/local.rs
@@ -49,6 +49,17 @@ impl Connection {
         })
     }
 
+    pub fn connect_from_env() -> anyhow::Result<Self> {
+        let path = std::env::var("LIBSQL_CLIENT_URL").map_err(|_| {
+            anyhow::anyhow!("LIBSQL_CLIENT_URL variable should point to your sqld database")
+        })?;
+        let path = match path.strip_prefix("file:///") {
+            Some(path) => path,
+            None => anyhow::bail!("Local URL needs to start with file:///"),
+        };
+        Self::connect(path)
+    }
+
     /// Executes a batch of SQL statements.
     /// Each statement is going to run in its own transaction,
     /// unless they're wrapped in BEGIN and END

--- a/libsql-client/src/reqwest.rs
+++ b/libsql-client/src/reqwest.rs
@@ -41,10 +41,10 @@ impl Connection {
         }
     }
 
-    /// Establishes a database connection, given a [`Url`]
+    /// Establishes a database connection, given a `Url`
     ///
     /// # Arguments
-    /// * `url` - [`Url`] object of the database endpoint. This cannot be a relative URL;
+    /// * `url` - `Url` object of the database endpoint. This cannot be a relative URL;
     ///
     /// # Examples
     ///

--- a/libsql-client/src/statement.rs
+++ b/libsql-client/src/statement.rs
@@ -5,8 +5,8 @@ use super::Value;
 
 /// SQL statement, possibly with bound parameters
 pub struct Statement {
-    q: String,
-    params: Vec<Value>,
+    pub(crate) q: String,
+    pub(crate) params: Vec<Value>,
 }
 
 impl Statement {

--- a/libsql-client/src/value.rs
+++ b/libsql-client/src/value.rs
@@ -2,6 +2,7 @@
 //! Each database row consists of one or more cell values.
 
 /// Value of a single database cell
+// FIXME: We need to support blobs as well
 #[derive(Clone, Debug)]
 pub enum Value {
     Text(String),
@@ -11,6 +12,7 @@ pub enum Value {
     Null,
 }
 
+// FIXME: we should *not* rely on Display for serialization purposes
 impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/libsql-client/src/value.rs
+++ b/libsql-client/src/value.rs
@@ -1,26 +1,32 @@
 //! `Value` represents libSQL values and types.
 //! Each database row consists of one or more cell values.
 
+use base64::prelude::BASE64_STANDARD_NO_PAD;
+use base64::Engine;
+
 /// Value of a single database cell
 // FIXME: We need to support blobs as well
 #[derive(Clone, Debug)]
 pub enum Value {
-    Text(String),
-    Float(f64),
-    Number(i64),
-    Bool(bool),
     Null,
+    Integer(i64),
+    Real(f64),
+    Text(String),
+    Blob(Vec<u8>),
 }
 
 // FIXME: we should *not* rely on Display for serialization purposes
 impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Value::Text(s) => write!(f, "\"{s}\""),
-            Value::Float(d) => write!(f, "{d}"),
-            Value::Number(n) => write!(f, "{n}"),
-            Value::Bool(b) => write!(f, "{}", if *b { "1" } else { "0" }),
             Value::Null => write!(f, "null"),
+            Value::Integer(n) => write!(f, "{n}"),
+            Value::Real(d) => write!(f, "{d}"),
+            Value::Text(s) => write!(f, "\"{s}\""),
+            Value::Blob(b) => {
+                let b = BASE64_STANDARD_NO_PAD.encode(b);
+                write!(f, "{{\"base64\": {b}}}")
+            }
         }
     }
 }
@@ -44,16 +50,16 @@ macro_rules! impl_from_value {
 impl_from_value!(String, Text);
 impl_from_value!(&str, Text);
 
-impl_from_value!(i8, Number);
-impl_from_value!(i16, Number);
-impl_from_value!(i32, Number);
-impl_from_value!(i64, Number);
+impl_from_value!(i8, Integer);
+impl_from_value!(i16, Integer);
+impl_from_value!(i32, Integer);
+impl_from_value!(i64, Integer);
 
-impl_from_value!(u8, Number);
-impl_from_value!(u16, Number);
-impl_from_value!(u32, Number);
+impl_from_value!(u8, Integer);
+impl_from_value!(u16, Integer);
+impl_from_value!(u32, Integer);
 
-impl_from_value!(f32, Float);
-impl_from_value!(f64, Float);
+impl_from_value!(f32, Real);
+impl_from_value!(f64, Real);
 
-impl_from_value!(bool, Bool);
+impl_from_value!(Vec<u8>, Blob);

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -27,7 +27,7 @@ pin-project-lite = "0.2.9"
 postgres-protocol = "0.6.4"
 prost = "0.11.3"
 regex = "1.7.0"
-rusqlite = { git = "https://github.com/psarna/rusqlite", rev = "4df75df0b0f5ecea2714a8b21bf9f2a0fcfd5905", default-features = false, features = [
+rusqlite = { version = "0.28.0", git = "https://github.com/psarna/rusqlite", rev = "4df75df0b0f5ecea2714a8b21bf9f2a0fcfd5905", default-features = false, features = [
     "buildtime_bindgen",
     "bundled-libsql",
     "column_decltype"


### PR DESCRIPTION
This series adds a local backend to libsql-client. With it, it's finally possible to pick between running a local prototype and sqld-over-http with a simple env variable switch. The local backend is based on rusqlite.

While introducing this backend, it also became apparent that we should unify type definitions, so it's done in a separate patch. (Most importantly, we were missing the blob type, which is now added)

This series also modifies the example -- now it also runs against a local database. Another example, `connect_from_env.rs`, shows how to connect to either a local or remote database, by setting the `LIBSQL_CLIENT_URL` variable to either a `file:///` url, or a `https://` one.

Example:
```sh
 $ LIBSQL_CLIENT_URL=https://psarna:xxx@workers-psarna.turso.io cargo run --example connect_from_env
    Connection parameters: backend=Err(NotPresent) url=Ok("https://xxx@workers-psarna.turso.io")
    Scoreboard:
    | country          || city             || value            |
    | -------------------------------------------------------- |
    | "AU"             || "Sydney"         || 1                |
    | "CA"             || "London"         || 1                |
    | "DE"             || "Frankfurt am Main" || 4                |
    | "DE"             || "Hamburg"        || 1                |
    | "PL"             || "Warsaw"         || 16               |
    | "RU"             || ""               || 1                |
    | "RU"             || "Yaroslavl"      || 1                |
    | "RU"             || "Yuzhno-Sakhalinsk" || 1                |
    | "US"             || "Saint Paul"     || 1                |
    
 $ LIBSQL_CLIENT_URL=file:////tmp/x cargo run --example connect_from_env
    Connection parameters: backend=Err(NotPresent) url=Ok("file:////tmp/x")
    Scoreboard:
    | country          || city             || value            |
    | -------------------------------------------------------- |
    | "DE"             || "Hamburg"        || 1                |
    | "FI"             || "Helsinki"       || 3                |
    | "US"             || "Newark"         || 3                |

```