### PR TITLE
sqlite dump

### DIFF
--- a/sqld/src/query_analysis.rs
+++ b/sqld/src/query_analysis.rs
@@ -86,6 +86,16 @@ impl Statement {
         }
     }
 
+    /// Returns a statement instance without performing any validation to the input
+    /// It is always assumed that such a statement will be a write, and will always be handled by
+    /// the primary
+    pub fn new_unchecked(s: &str) -> Self {
+        Self {
+            stmt: s.to_string(),
+            kind: StmtKind::Write,
+        }
+    }
+
     pub fn parse(s: &str) -> impl Iterator<Item = Result<Self>> + '_ {
         fn parse_inner(c: Cmd) -> Result<Statement> {
             let kind =


### PR DESCRIPTION
This PR allows sqlite dumps to be loaded over HTTP.
For now it requires that the dump fits in memory.

you can create a dump to the `sqlite-dump` file, from a sqlite db with the following commands:
```
> .out sqlite-dump
> .dump
```

and you can load it to an existing sqlite instance with:
```
POST /load-dump
```
