### PR TITLE
libsql-client: drop buildtime_bindgen feature

### DIFF
--- a/libsql-client/Cargo.toml
+++ b/libsql-client/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = "1.0.69"
 async-trait = "0.1.64"
 reqwest = { version = "0.11.14", optional = true, default-features = false, features = ["rustls-tls"] }
 rusqlite = { version = "0.28.0", optional = true, default-features = false, features = [
-    "buildtime_bindgen",
     "column_decltype"
 ] }
 


### PR DESCRIPTION
We do not rely on it, and it is counterproductive for Wasm environments.