### PR TITLE
sqld: add --create-local-http-tunnel option

### DIFF
--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -20,6 +20,7 @@ hex = "0.4.3"
 hyper = { version = "0.14.23", features = ["http2"] }
 itertools = "0.10.5"
 jsonwebtoken = "8.2.0"
+localtunnel-client = "0.0.13"
 once_cell = "1.17.0"
 parking_lot = "0.12.1"
 pgwire = "0.7.0"

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -80,6 +80,9 @@ struct Cli {
     no_welcome: bool,
     #[clap(long, env = "SQLD_ENABLE_BOTTOMLESS_REPLICATION")]
     enable_bottomless_replication: bool,
+    /// Create a tunnel for the HTTP interface, available publicly via the https://localtunnel.me interface. The tunnel URL will be printed to stdin
+    #[clap(long)]
+    create_local_http_tunnel: bool,
 }
 
 impl Cli {
@@ -150,6 +153,7 @@ impl From<Cli> for Config {
             #[cfg(feature = "mwal_backend")]
             mwal_addr: cli.mwal_addr,
             enable_bottomless_replication: cli.enable_bottomless_replication,
+            create_local_http_tunnel: cli.create_local_http_tunnel,
         }
     }
 }


### PR DESCRIPTION
This option piggy-backs on a great https://localtunnel.me project and creates a tunnel which exposes the local HTTP interface with a public endpoint. This endpoint can be used to e.g. send it to your friends for a joint debugging session, or for using a local database in environments like Cloudflare Workers.

The tunnel only works as long as the `sqld` instance, which makes it perfect for development.

Example:
```
$ cargo run -- --no-welcome --http-listen-addr 127.0.0.1:8080 --create-local-http-tunnel
    Finished dev [unoptimized + debuginfo] target(s) in 0.26s
     Running `/home/sarna/repo/sqld/target/debug/sqld --no-welcome --http-listen-addr '127.0.0.1:8080' --create-local-http-tunnel`
HTTP tunnel created: https://silver-maps-pump-83-24-35-122.loca.lt
```