### PR TITLE
github: publish docker image on release tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ name: Create and publish a Docker image
 on:
   push:
     branches: ['main']
+    tags:
+      - v*
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
For example, when someone tags `v0.1.0`, make sure there's a Docker image for that tag.