### PR TITLE
Raw statements and results in Hrana client

### DIFF
--- a/packages/hrana-client/package.json
+++ b/packages/hrana-client/package.json
@@ -22,6 +22,11 @@
     "test": "jest"
   },
 
+  "files": [
+    "lib-cjs/**",
+    "lib-esm/**"
+  ],
+
   "dependencies": {
     "isomorphic-ws": "^5.0.0"
   },

--- a/packages/hrana-client/src/__tests__/index.ts
+++ b/packages/hrana-client/src/__tests__/index.ts
@@ -82,6 +82,29 @@ test("Stream.execute()", withClient(async (c) => {
     expect(res.rowsAffected).toStrictEqual(1);
 }));
 
+test("Stream.executeRaw()", withClient(async (c) => {
+    const s = c.openStream();
+
+    let res = await s.executeRaw({
+        "sql": "SELECT 1 as one, ? as two, NULL as three",
+        "args": [{"type": "text", "value": "1+1"}],
+        "want_rows": true,
+    });
+
+    expect(res.cols).toStrictEqual([
+        {"name": "one"},
+        {"name": "two"},
+        {"name": "three"},
+    ]);
+    expect(res.rows).toStrictEqual([
+        [
+            {"type": "integer", "value": "1"},
+            {"type": "text", "value": "1+1"},
+            {"type": "null"},
+        ],
+    ]);
+}));
+
 test("concurrent streams", withClient(async (c) => {
     const s1 = c.openStream();
     await s1.execute("CREATE TABLE t (number)");

--- a/packages/hrana-client/src/index.ts
+++ b/packages/hrana-client/src/index.ts
@@ -9,6 +9,7 @@ import IdAlloc from "./id_alloc.js";
 import type * as proto from "./proto.js";
 
 export type { Stmt, Value, StmtResult, RowArray, Row } from "./convert";
+export type { proto };
 
 /** Open a Hrana client connected to the given `url`. */
 export function open(url: string, jwt?: string): Client {
@@ -283,6 +284,13 @@ export class Stream {
     constructor(client: Client, state: StreamState) {
         this.#client = client;
         this.#state = state;
+    }
+
+    /** Execute a raw Hrana statement. */
+    executeRaw(stmt: proto.Stmt): Promise<proto.StmtResult> {
+        return new Promise((resultCallback, errorCallback) => {
+            this.#client._execute(this.#state, {stmt, resultCallback, errorCallback});
+        });
     }
 
     /** Execute a statement that returns rows. */


### PR DESCRIPTION
This is useful for data mapper libraries which introduce their own mapping between JavaScript and SQLite types.

The disadvantage is that it exposes protocol-level details in the public API, but the protocol should be at least as stable as the library itself, so this should not be a big problem. If it is, we can mark the `executeRaw()` method as unstable.