### PR TITLE
Integrate Python client with pandas

### DIFF
--- a/pypackages/libsql-client/libsql_client/result.py
+++ b/pypackages/libsql-client/libsql_client/result.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterator, List, Tuple, Union
+from typing import Dict, Iterator, List, Tuple, Union, overload
 import collections
 
 Value = Union[str, float, int, bytes, None]
@@ -43,13 +43,22 @@ class Row(collections.abc.Sequence):
         self._column_idxs = column_idxs
         self._values = values
 
+    @overload
     def __getitem__(self, key: Union[int, str]) -> Value:
+        pass
+
+    @overload
+    def __getitem__(self, key: slice) -> Tuple[Value, ...]:
+        pass
+
+    def __getitem__(self, key: Union[int, str, slice]) -> Union[Value, Tuple[Value, ...]]:
         """Access a value by index or by name."""
+        tuple_key: Union[int, slice]
         if isinstance(key, str):
-            idx = self._column_idxs[key]
+            tuple_key = self._column_idxs[key]
         else:
-            idx = key
-        return self._values[idx]
+            tuple_key = key
+        return self._values[tuple_key]
 
     def __len__(self) -> int:
         return len(self._values)

--- a/pypackages/libsql-client/libsql_client/result.py
+++ b/pypackages/libsql-client/libsql_client/result.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Iterator, List, Tuple, Union
+import collections
 
 Value = Union[str, float, int, bytes, None]
 
@@ -26,7 +27,10 @@ class ResultSet:
         """List of all rows in the result set."""
         return self._rows
 
-class Row:
+    def __iter__(self) -> Iterator["Row"]:
+        return self._rows.__iter__()
+
+class Row(collections.abc.Sequence):
     """A row returned by an SQL statement.
 
     The row values can be accessed with an index or by name.
@@ -52,3 +56,7 @@ class Row:
 
     def __repr__(self) -> str:
         return repr(self._values)
+
+    @property
+    def _fields(self) -> Tuple[str, ...]:
+        return tuple(self._column_idxs.keys())

--- a/pypackages/libsql-client/pyproject.toml
+++ b/pypackages/libsql-client/pyproject.toml
@@ -13,10 +13,11 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 aiohttp = "^3.0"
 
 [tool.poetry.group.dev.dependencies]
+pandas = "^1.5"
 pytest = "^7.2"
 pytest-asyncio = "^0.20.3"
 mypy = "^0.991"

--- a/pypackages/libsql-client/pyproject.toml
+++ b/pypackages/libsql-client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "libsql-client"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
     "Jan Špaček <honza@chiselstrike.com>",
     "ChiselStrike",

--- a/pypackages/libsql-client/tests/test_result.py
+++ b/pypackages/libsql-client/tests/test_result.py
@@ -60,6 +60,12 @@ async def test_row_repr(url):
         assert repr(result_set.rows[0]) == "(42, 0.5, 'brontosaurus', None)"
 
 @pytest.mark.asyncio
+async def test_row_slice(url):
+    async with libsql_client.Client(url) as client:
+        result_set = await client.execute("SELECT 'one', 'two', 'three', 'four', 'five'")
+        assert result_set.rows[0][1:3] == ("two", "three")
+
+@pytest.mark.asyncio
 async def test_pandas_from_records(url):
     async with libsql_client.Client(url) as client:
         result_set = await client.execute("SELECT 1, 'two', 3.0")

--- a/pypackages/libsql-client/tests/test_result.py
+++ b/pypackages/libsql-client/tests/test_result.py
@@ -1,3 +1,4 @@
+import pandas
 import libsql_client
 import pytest
 
@@ -57,3 +58,10 @@ async def test_row_repr(url):
     async with libsql_client.Client(url) as client:
         result_set = await client.execute("SELECT 42, 0.5, 'brontosaurus', NULL")
         assert repr(result_set.rows[0]) == "(42, 0.5, 'brontosaurus', None)"
+
+@pytest.mark.asyncio
+async def test_pandas_data_frame(url):
+    async with libsql_client.Client(url) as client:
+        result_set = await client.execute("SELECT 1, 'two', 3.0")
+        data_frame = pandas.DataFrame.from_records(result_set.rows)
+        assert data_frame.shape == (1, 3)

--- a/pypackages/libsql-client/tests/test_result.py
+++ b/pypackages/libsql-client/tests/test_result.py
@@ -60,8 +60,16 @@ async def test_row_repr(url):
         assert repr(result_set.rows[0]) == "(42, 0.5, 'brontosaurus', None)"
 
 @pytest.mark.asyncio
-async def test_pandas_data_frame(url):
+async def test_pandas_from_records(url):
     async with libsql_client.Client(url) as client:
         result_set = await client.execute("SELECT 1, 'two', 3.0")
         data_frame = pandas.DataFrame.from_records(result_set.rows)
         assert data_frame.shape == (1, 3)
+
+@pytest.mark.asyncio
+async def test_pandas_ctor(url):
+    async with libsql_client.Client(url) as client:
+        result_set = await client.execute("SELECT 1 AS one, 'two' AS two, 3.0 AS three")
+        data_frame = pandas.DataFrame(result_set)
+        assert data_frame.shape == (1, 3)
+        assert tuple(data_frame.columns) == ("one", "two", "three")


### PR DESCRIPTION
This feature was requested by a user on Discord and it seems to be a low-hanging fruit. This PR implements the necessary interfaces to allow `pandas.DataFrame(result_set)`.