### PR TITLE
Change query route from `/` to `/queries`

### DIFF
--- a/libsql-client/src/reqwest.rs
+++ b/libsql-client/src/reqwest.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use base64::Engine;
+use reqwest::Url;
 
 use super::{parse_query_result, QueryResult, Statement};
 
@@ -7,7 +8,7 @@ use super::{parse_query_result, QueryResult, Statement};
 /// communicate with the database.
 #[derive(Clone, Debug)]
 pub struct Connection {
-    url: String,
+    url: Url,
     auth: String,
 }
 
@@ -32,6 +33,8 @@ impl Connection {
         } else {
             url
         };
+        // FIXME: handle error
+        let url = Url::parse(&url).unwrap();
         Self {
             url,
             auth: format!(
@@ -99,7 +102,7 @@ impl super::Connection for Connection {
         body += "]}";
         let client = reqwest::Client::new();
         let response = client
-            .post(&self.url)
+            .post(self.url.join("/queries")?)
             .body(body)
             .header("Authorization", &self.auth)
             .send()

--- a/packages/libsql-client/src/lib/driver/HttpDriver.ts
+++ b/packages/libsql-client/src/lib/driver/HttpDriver.ts
@@ -26,7 +26,8 @@ export class HttpDriver implements Driver {
 
         const statements = buildStatements(["BEGIN", ...stmts, "COMMIT"]);
 
-        const response = await fetch(this.url + "/queries", {
+        const url = new URL("/queries", this.url);
+        const response = await fetch(url , {
             method: "POST",
             body: JSON.stringify(statements)
         });

--- a/packages/libsql-client/src/lib/driver/HttpDriver.ts
+++ b/packages/libsql-client/src/lib/driver/HttpDriver.ts
@@ -26,7 +26,7 @@ export class HttpDriver implements Driver {
 
         const statements = buildStatements(["BEGIN", ...stmts, "COMMIT"]);
 
-        const response = await fetch(this.url, {
+        const response = await fetch(this.url + "/queries", {
             method: "POST",
             body: JSON.stringify(statements)
         });

--- a/pypackages/libsql-client/libsql_client/http_driver.py
+++ b/pypackages/libsql-client/libsql_client/http_driver.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional
 import aiohttp
 import base64
 import json
+import urllib.parse
 
 from .driver import _Driver, _RawStmt
 from .errors import ClientResponseError, ClientHttpError
@@ -20,7 +21,8 @@ class _HttpDriver(_Driver):
             "statements": [_encode_stmt(stmt) for stmt in stmts],
         }
 
-        async with await self._session.post(self._url + "/queries", json=req_body) as resp:
+        url = urllib.parse.urljoin(self._url, "/queries")
+        async with await self._session.post(url , json=req_body) as resp:
             if not resp.ok:
                 resp_body = await resp.read()
                 try:

--- a/pypackages/libsql-client/libsql_client/http_driver.py
+++ b/pypackages/libsql-client/libsql_client/http_driver.py
@@ -20,7 +20,7 @@ class _HttpDriver(_Driver):
             "statements": [_encode_stmt(stmt) for stmt in stmts],
         }
 
-        async with await self._session.post(self._url, json=req_body) as resp:
+        async with await self._session.post(self._url + "/queries", json=req_body) as resp:
             if not resp.ok:
                 resp_body = await resp.read()
                 try:

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -155,7 +155,7 @@ fn parse_payload(data: &[u8]) -> Result<HttpQuery, Response<Body>> {
     }
 }
 
-async fn handle_query(
+async fn handle_queries(
     mut req: Request<Body>,
     sender: mpsc::Sender<Message>,
 ) -> anyhow::Result<Response<Body>> {
@@ -211,7 +211,7 @@ async fn handle_request(
         }
     }
     match (req.method(), req.uri().path()) {
-        (&Method::POST, "/") => handle_query(req, sender).await,
+        (&Method::POST, "/queries") => handle_queries(req, sender).await,
         (&Method::GET, "/console") if enable_console => show_console().await,
         (&Method::GET, "/health") => Ok(handle_health()),
         (&Method::POST, "/load-dump") => Ok(load_dump(req, sender).await?),

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -210,7 +210,13 @@ async fn handle_request(
                 .unwrap());
         }
     }
+
     match (req.method(), req.uri().path()) {
+        (&Method::POST, "/") => Ok(Response::builder()
+            .status(StatusCode::MOVED_PERMANENTLY)
+            .header("Location", "/queries")
+            .body(Body::empty())
+            .unwrap()),
         (&Method::POST, "/queries") => handle_queries(req, sender).await,
         (&Method::GET, "/console") if enable_console => show_console().await,
         (&Method::GET, "/health") => Ok(handle_health()),

--- a/testing/end-to-end/integration/basic_cluster/dump.rs
+++ b/testing/end-to-end/integration/basic_cluster/dump.rs
@@ -15,7 +15,7 @@ async fn load_dump_from_primary(app: App) {
     // wait for dump to be loaded and replicated
     tokio::time::sleep(Duration::from_secs(3)).await;
 
-    let url = format!("http://{primary_ip}:8080");
+    let url = format!("http://{primary_ip}:8080/queries");
     let resp = client
         .post(url)
         .json(&json!({
@@ -29,7 +29,7 @@ async fn load_dump_from_primary(app: App) {
 
     // ensure replica is up to date
     let replica_id = app.service("replica").unwrap().ip().await.unwrap();
-    let url = format!("http://{replica_id}:8080");
+    let url = format!("http://{replica_id}:8080/queries");
     let resp = client
         .post(url)
         .json(&json!({
@@ -53,7 +53,7 @@ async fn load_dump_from_replica(app: App) {
     // wait for dump to be loaded and replicated
     tokio::time::sleep(Duration::from_secs(4)).await;
 
-    let url = format!("http://{replica_ip}:8080");
+    let url = format!("http://{replica_ip}:8080/queries");
     let resp = client
         .post(url)
         .json(&json!({

--- a/testing/end-to-end/integration/basic_cluster/simple.rs
+++ b/testing/end-to-end/integration/basic_cluster/simple.rs
@@ -7,8 +7,8 @@ use serde_json::json;
 async fn proxy_write(app: App) {
     let replica_ip = app.service("replica").unwrap().ip().await.unwrap();
     let primary_ip = app.service("primary").unwrap().ip().await.unwrap();
-    let primary_url = format!("http://{primary_ip}:8080/");
-    let replica_url = format!("http://{replica_ip}:8080/");
+    let primary_url = format!("http://{primary_ip}:8080/queries");
+    let replica_url = format!("http://{replica_ip}:8080/queries");
     let client = reqwest::Client::new();
 
     // perform a write to the writer and ensure it's proxied to to primary
@@ -56,7 +56,7 @@ async fn replica_catch_up(app: App) {
     let replica = app.service("replica").unwrap();
     replica.pause().await.unwrap();
     let primary_ip = app.service("primary").unwrap().ip().await.unwrap();
-    let primary_url = format!("http://{primary_ip}:8080/");
+    let primary_url = format!("http://{primary_ip}:8080/queries");
     let client = reqwest::Client::new();
 
     let payload = json!({ "statements": ["create table test (x)"] });
@@ -97,7 +97,7 @@ async fn replica_catch_up(app: App) {
     tokio::time::sleep(Duration::from_secs(3)).await;
 
     let replica_ip = replica.ip().await.unwrap();
-    let replica_url = format!("http://{replica_ip}:8080/");
+    let replica_url = format!("http://{replica_ip}:8080/queries");
     // check that everything is there
     let payload = json!({ "statements": [format!("select * from test")] });
     let resp = client


### PR DESCRIPTION
This PR changes the HTTP route use to query sqld from `/` to `/queries`, as per #106.
