### PR TITLE
add logger layer to http

### DIFF
--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -24,6 +24,7 @@ use tower_http::{compression::CompressionLayer, cors};
 
 use crate::error::Error;
 use crate::http::services::idle_shutdown::IdleShutdownLayer;
+use crate::http::services::logger::LoggerLayer;
 use crate::http::types::HttpQuery;
 use crate::query::{self, Params, Queries, Query, QueryResult, ResultSet};
 use crate::query_analysis::{final_state, State, Statement};
@@ -287,6 +288,7 @@ where
     let idle_shutdown_layer = idle_shutdown.map(|d| IdleShutdownLayer::new(d, SHUTDOWN.clone()));
     let service = ServiceBuilder::new()
         .option_layer(idle_shutdown_layer)
+        .layer(LoggerLayer)
         .layer(CompressionLayer::new())
         .layer(
             cors::CorsLayer::new()

--- a/sqld/src/http/services/logger.rs
+++ b/sqld/src/http/services/logger.rs
@@ -1,0 +1,77 @@
+use std::pin::Pin;
+use std::task::{ready, Poll};
+use std::time::Instant;
+use std::{future::Future, task::Context};
+
+use hyper::{Method, Request, Uri};
+use tower::{Layer, Service};
+
+pub struct LoggerLayer;
+
+impl<S> Layer<S> for LoggerLayer {
+    type Service = LoggerService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        LoggerService { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct LoggerService<S> {
+    inner: S,
+}
+
+pin_project_lite::pin_project! {
+    pub struct LogFuture<F> {
+        method: Method,
+        uri: Uri,
+        start_time: Instant,
+        #[pin]
+        f: F,
+    }
+}
+
+impl<F> Future for LogFuture<F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let res = ready!(this.f.poll(cx));
+
+        tracing::info!(
+            "new request: {} {}; completed in {:.3?}",
+            this.method,
+            this.uri,
+            this.start_time.elapsed()
+        );
+
+        Poll::Ready(res)
+    }
+}
+
+impl<B, S> Service<Request<B>> for LoggerService<S>
+where
+    S: Service<Request<B>>,
+{
+    type Response = S::Response;
+
+    type Error = S::Error;
+
+    type Future = LogFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        LogFuture {
+            method: req.method().clone(),
+            uri: req.uri().clone(),
+            start_time: Instant::now(),
+            f: self.inner.call(req),
+        }
+    }
+}

--- a/sqld/src/http/services/mod.rs
+++ b/sqld/src/http/services/mod.rs
@@ -1,1 +1,2 @@
 pub mod idle_shutdown;
+pub mod logger;


### PR DESCRIPTION
This PR adds a logger layer to HTTP that logs request:

```
Welcome to sqld!

version: 0.2.0
commit SHA: 864a06622636b749fcaeced2d8fbc9f70d12ea13
build date: 2023-02-15

This software is in BETA version.
If you encounter any bug, please open an issue at https://github.com/libsql/sqld/issues

config:
        - mode: standalone
        - database path: data.sqld
        - listening for HTTP requests on: 127.0.0.1:8080
        - gprc_tls: no
2023-02-15T10:56:56.189839Z  INFO sqld::http: listening for HTTP requests on 127.0.0.1:8080
2023-02-15T10:57:51.332794Z  INFO sqld::http::services::logger: new request: POST /; completed in 2.469ms
2023-02-15T10:57:55.868745Z  INFO sqld::http::services::logger: new request: POST /; completed in 134.250µs
2023-02-15T10:57:57.866588Z  INFO sqld::http::services::logger: new request: POST /; completed in 158.250µs
2023-02-15T10:57:59.203116Z  INFO sqld::http::services::logger: new request: POST /; completed in 150.834µs
2023-02-15T10:58:04.312723Z  INFO sqld::http::services::logger: new request: POST /; completed in 105.667µs
2023-02-15T10:58:05.415635Z  INFO sqld::http::services::logger: new request: POST /; completed in 109.250µs
2023-02-15T10:58:07.246935Z  INFO sqld::http::services::logger: new request: POST /; completed in 103.209µs
2023-02-15T10:58:10.498002Z  INFO sqld::http::services::logger: new request: POST /; completed in 143.666µs
2023-02-15T10:58:24.115828Z  INFO sqld::http::services::logger: new request: GET /version; completed in 13.667µs
2023-02-15T10:58:32.815719Z  INFO sqld::http::services::logger: new request: GET /version; completed in 11.333µs

```
