### PR TITLE
Small simplifications

### DIFF
--- a/sqld/src/database/mod.rs
+++ b/sqld/src/database/mod.rs
@@ -9,7 +9,7 @@ pub mod write_proxy;
 const TXN_TIMEOUT_SECS: u64 = 5;
 
 #[async_trait::async_trait]
-pub trait Database {
+pub trait Database: Send + Sync {
     /// Executes a batch of queries, and return the a vec of results corresponding to the queries,
     /// and the state the database is in after the call to execute.
     async fn execute(&self, queries: Queries) -> Result<(Vec<QueryResult>, State)>;

--- a/sqld/src/database/service.rs
+++ b/sqld/src/database/service.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 use std::task::Poll;
 
-use futures::Future;
 use futures::future::BoxFuture;
+use futures::Future;
 use tower::Service;
 
 use super::Database;

--- a/sqld/src/database/write_proxy.rs
+++ b/sqld/src/database/write_proxy.rs
@@ -1,5 +1,5 @@
-use std::future::{ready, Ready};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crossbeam::channel::TryRecvError;
@@ -89,16 +89,14 @@ impl WriteProxyDbFactory {
     }
 }
 
+#[async_trait::async_trait]
 impl DbFactory for WriteProxyDbFactory {
-    type Future = Ready<Result<Self::Db>>;
-
-    type Db = WriteProxyDatabase;
-
-    fn create(&self) -> Self::Future {
-        ready(WriteProxyDatabase::new(
+    async fn create(&self) -> Result<Arc<dyn Database>> {
+        let db = WriteProxyDatabase::new(
             self.write_proxy.clone(),
             self.db_path.clone(),
-        ))
+        )?;
+        Ok(Arc::new(db))
     }
 }
 

--- a/sqld/src/database/write_proxy.rs
+++ b/sqld/src/database/write_proxy.rs
@@ -92,10 +92,7 @@ impl WriteProxyDbFactory {
 #[async_trait::async_trait]
 impl DbFactory for WriteProxyDbFactory {
     async fn create(&self) -> Result<Arc<dyn Database>> {
-        let db = WriteProxyDatabase::new(
-            self.write_proxy.clone(),
-            self.db_path.clone(),
-        )?;
+        let db = WriteProxyDatabase::new(self.write_proxy.clone(), self.db_path.clone())?;
         Ok(Arc::new(db))
     }
 }

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -83,7 +83,11 @@ pub struct Config {
     pub idle_shutdown_timeout: Option<Duration>,
 }
 
-async fn run_service(service: DbFactoryService, config: &Config, join_set: &mut JoinSet<anyhow::Result<()>>) -> anyhow::Result<()> {
+async fn run_service(
+    service: DbFactoryService,
+    config: &Config,
+    join_set: &mut JoinSet<anyhow::Result<()>>,
+) -> anyhow::Result<()> {
     let mut server = Server::new();
 
     if let Some(addr) = config.tcp_addr {
@@ -113,7 +117,10 @@ async fn run_service(service: DbFactoryService, config: &Config, join_set: &mut 
 }
 
 /// nukes current DB and start anew
-async fn hard_reset(config: &Config, mut join_set: JoinSet<anyhow::Result<()>>) -> anyhow::Result<()> {
+async fn hard_reset(
+    config: &Config,
+    mut join_set: JoinSet<anyhow::Result<()>>,
+) -> anyhow::Result<()> {
     tracing::error!("received hard-reset command: reseting replica.");
 
     tracing::info!("Shutting down all services...");
@@ -126,7 +133,11 @@ async fn hard_reset(config: &Config, mut join_set: JoinSet<anyhow::Result<()>>) 
     Ok(())
 }
 
-async fn start_primary(config: &Config, join_set: &mut JoinSet<anyhow::Result<()>>, addr: &str) -> anyhow::Result<()> {
+async fn start_primary(
+    config: &Config,
+    join_set: &mut JoinSet<anyhow::Result<()>>,
+    addr: &str,
+) -> anyhow::Result<()> {
     let (factory, handle) = WriteProxyDbFactory::new(
         addr,
         config.writer_rpc_tls,
@@ -141,9 +152,7 @@ async fn start_primary(config: &Config, join_set: &mut JoinSet<anyhow::Result<()
     // the `JoinSet` does not support inserting arbitrary `JoinHandles` (and it also does not
     // support spawning blocking tasks, so we must spawn a proxy task to add the `handle` to
     // `join_set`
-    join_set.spawn(async move {
-        handle.await.expect("WriteProxy DB task failed")
-    });
+    join_set.spawn(async move { handle.await.expect("WriteProxy DB task failed") });
 
     let service = DbFactoryService::new(Arc::new(factory));
     run_service(service, config, join_set).await?;
@@ -151,7 +160,10 @@ async fn start_primary(config: &Config, join_set: &mut JoinSet<anyhow::Result<()
     Ok(())
 }
 
-async fn start_replica(config: &Config, join_set: &mut JoinSet<anyhow::Result<()>>) -> anyhow::Result<()> {
+async fn start_replica(
+    config: &Config,
+    join_set: &mut JoinSet<anyhow::Result<()>>,
+) -> anyhow::Result<()> {
     let logger = Arc::new(ReplicationLogger::open(&config.db_path)?);
     let logger_clone = logger.clone();
     let path_clone = config.db_path.clone();

--- a/sqld/src/postgres/service.rs
+++ b/sqld/src/postgres/service.rs
@@ -124,7 +124,7 @@ impl<T, F> Service<(T, SocketAddr)> for PgConnectionFactory<F>
 where
     T: AsyncRead + AsyncWrite + AsyncPeekable + Unpin + Send + Sync + 'static,
     F: MakeService<(), Queries, MakeError = Error> + Sync,
-    F::Future: 'static + Send + Sync,
+    F::Future: 'static + Send,
     F::Service: Service<Queries, Response = Vec<QueryResult>, Error = Error> + Sync + Send,
     <F::Service as Service<Queries>>::Future: Send,
 {

--- a/sqld/src/rpc/mod.rs
+++ b/sqld/src/rpc/mod.rs
@@ -13,20 +13,15 @@ use crate::rpc::replication_log::ReplicationLogService;
 pub mod proxy;
 pub mod replication_log;
 
-pub async fn run_rpc_server<F>(
+pub async fn run_rpc_server(
     addr: SocketAddr,
     tls: bool,
     cert_path: Option<PathBuf>,
     key_path: Option<PathBuf>,
     ca_cert_path: Option<PathBuf>,
-    factory: F,
+    factory: Arc<dyn DbFactory>,
     logger: Arc<ReplicationLogger>,
-) -> anyhow::Result<()>
-where
-    F: DbFactory + 'static,
-    F::Db: Sync + Send + Clone,
-    F::Future: Sync,
-{
+) -> anyhow::Result<()> {
     let proxy_service = ProxyService::new(factory);
     let logger_service = ReplicationLogService::new(logger);
 


### PR DESCRIPTION
- Replace some generics with dynamic polymorphism
- Replace `FuturesUnordered<JoinHandle>` with a `JoinSet`
- Drop `FutOrNever`: this reimplements `Fuse` from the `futures` crate, and does not seem to be used anyway
- Drop some unnecessary `Sync` constraints (it is almost never legitimate to require a future to be `Sync`)

These are just small local simplifications that I found when starting the work on Hrana server that I think can be merged separately to avoid polluting the main PR.
