### PR TITLE
support more statements

### DIFF
--- a/sqld/src/query_analysis.rs
+++ b/sqld/src/query_analysis.rs
@@ -42,7 +42,9 @@ impl StmtKind {
                 | Stmt::CreateTable { .. }
                 | Stmt::Update { .. }
                 | Stmt::Delete { .. }
-                | Stmt::DropTable { .. },
+                | Stmt::DropTable { .. }
+                | Stmt::AlterTable { .. }
+                | Stmt::CreateIndex { .. },
             ) => Some(Self::Write),
             Cmd::Stmt(Stmt::Select { .. }) => Some(Self::Read),
             _ => None,


### PR DESCRIPTION
This pr adds support for more sqlite statements:
- `ALTER TABLE`
- `CREATE INDEX`

fix #228