### PR TITLE
Hrana server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "enclose"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1056f553da426e9c025a662efa48b52e62e0a3a7648aa2d15aeaaf7f0d329357"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3786,6 +3792,7 @@ dependencies = [
  "clap",
  "crc",
  "crossbeam",
+ "enclose",
  "fallible-iterator",
  "futures",
  "hex",

--- a/docs/HRANA_SPEC.md
+++ b/docs/HRANA_SPEC.md
@@ -297,7 +297,7 @@ separated by a semicolon is not supported.
 type StmtResult = {
     "cols": Array<Col>,
     "rows": Array<Array<Value>>,
-    "affected_row_count": number,
+    "affected_row_count": uint64,
 }
 
 type Col = {

--- a/packages/js/hrana-client/test_server.py
+++ b/packages/js/hrana-client/test_server.py
@@ -64,7 +64,11 @@ async def handle_socket(websocket):
             if stmt["want_rows"]:
                 rows.append([value_from_sqlite(val) for val in row])
 
-        return {"cols": cols, "rows": rows, "affected_row_count": cursor.rowcount}
+        if cursor.rowcount >= 0:
+            affected_row_count = cursor.rowcount
+        else:
+            affected_row_count = 0
+        return {"cols": cols, "rows": rows, "affected_row_count": affected_row_count}
 
     def value_to_sqlite(value):
         if value["type"] == "null":

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -17,6 +17,7 @@ bytes = { version = "1.2.1", features = ["serde"] }
 clap = { version = "4.0.23", features = [ "derive", "env"] }
 crc = "3.0.0"
 crossbeam = "0.8.2"
+enclose = "1.1"
 fallible-iterator = "0.2.0"
 futures = "0.3.25"
 hex = "0.4.3"

--- a/sqld/proto/proxy.proto
+++ b/sqld/proto/proxy.proto
@@ -46,6 +46,7 @@ message Error {
 message ResultRows {
     repeated Column   column_descriptions = 1;
     repeated Row      rows = 2;
+    uint64            affected_row_count = 3;
 }
 
 message Value {

--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -63,7 +63,11 @@ fn execute_query(conn: &rusqlite::Connection, stmt: &Statement, params: Params) 
         false => 0,
     };
 
-    Ok(QueryResponse::ResultSet(ResultSet { columns, rows, affected_row_count }))
+    Ok(QueryResponse::ResultSet(ResultSet {
+        columns,
+        rows,
+        affected_row_count,
+    }))
 }
 
 struct ConnectionState {

--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -249,7 +249,7 @@ impl LibSqlDb {
 
 #[async_trait::async_trait]
 impl Database for LibSqlDb {
-    async fn execute(&self, queries: Queries) -> Result<(Vec<QueryResult>, State)> {
+    async fn execute_batch(&self, queries: Queries) -> Result<(Vec<QueryResult>, State)> {
         let (resp, receiver) = oneshot::channel();
         let msg = Message { queries, resp };
         let _ = self.sender.send(msg);

--- a/sqld/src/database/mod.rs
+++ b/sqld/src/database/mod.rs
@@ -1,4 +1,4 @@
-use crate::query::{Query, Queries, QueryResult};
+use crate::query::{Queries, Query, QueryResult};
 use crate::query_analysis::State;
 use crate::Result;
 

--- a/sqld/src/database/mod.rs
+++ b/sqld/src/database/mod.rs
@@ -1,4 +1,4 @@
-use crate::query::{Queries, QueryResult};
+use crate::query::{Query, Queries, QueryResult};
 use crate::query_analysis::State;
 use crate::Result;
 
@@ -10,7 +10,15 @@ const TXN_TIMEOUT_SECS: u64 = 5;
 
 #[async_trait::async_trait]
 pub trait Database: Send + Sync {
-    /// Executes a batch of queries, and return the a vec of results corresponding to the queries,
+    /// Executes a query (statement), and returns the result of the query and the state of the
+    /// database connection after the query.
+    async fn execute_one(&self, query: Query) -> Result<(QueryResult, State)> {
+        let (mut results, state) = self.execute_batch(vec![query]).await?;
+        let mut results = results.drain(..);
+        Ok((results.next().unwrap(), state))
+    }
+
+    /// Executes a batch of queries, and returns a vec of results corresponding to the queries,
     /// and the state the database is in after the call to execute.
-    async fn execute(&self, queries: Queries) -> Result<(Vec<QueryResult>, State)>;
+    async fn execute_batch(&self, queries: Queries) -> Result<(Vec<QueryResult>, State)>;
 }

--- a/sqld/src/database/service.rs
+++ b/sqld/src/database/service.rs
@@ -29,7 +29,7 @@ where
 
 #[derive(Clone)]
 pub struct DbFactoryService {
-    factory: Arc<dyn DbFactory>,
+    pub factory: Arc<dyn DbFactory>,
 }
 
 impl DbFactoryService {
@@ -78,6 +78,6 @@ impl Service<Queries> for DbService {
 
     fn call(&mut self, queries: Queries) -> Self::Future {
         let db = self.db.clone();
-        Box::pin(async move { Ok(db.execute(queries).await?.0) })
+        Box::pin(async move { Ok(db.execute_batch(queries).await?.0) })
     }
 }

--- a/sqld/src/database/write_proxy.rs
+++ b/sqld/src/database/write_proxy.rs
@@ -118,13 +118,13 @@ impl WriteProxyDatabase {
 
 #[async_trait::async_trait]
 impl Database for WriteProxyDatabase {
-    async fn execute(&self, queries: query::Queries) -> Result<(Vec<QueryResult>, State)> {
+    async fn execute_batch(&self, queries: query::Queries) -> Result<(Vec<QueryResult>, State)> {
         let mut state = self.state.lock().await;
         if *state == State::Init
             && queries.iter().all(|q| q.stmt.is_read_only())
             && final_state(*state, queries.iter().map(|s| &s.stmt)) == State::Init
         {
-            self.read_db.execute(queries).await
+            self.read_db.execute_batch(queries).await
         } else {
             let queries = Queries {
                 queries: queries

--- a/sqld/src/hrana/conn.rs
+++ b/sqld/src/hrana/conn.rs
@@ -68,8 +68,7 @@ async fn handshake(socket: tokio::net::TcpStream) -> Result<WebSocket> {
                 .to_str()
                 .unwrap_or("")
                 .split(',')
-                .find(|p| p.trim() == "hrana1")
-                .is_some();
+                .any(|p| p.trim() == "hrana1");
             if has_hrana1 {
                 resp_parts.headers.append(
                     "sec-websocket-protocol",
@@ -157,7 +156,7 @@ async fn handle_hello_msg(conn: &mut Conn, jwt: Option<String>) -> Result<bool> 
                 send_msg(conn, &proto::ServerMsg::HelloError { error }).await?;
                 Ok(false)
             }
-            Err(err) => return Err(err),
+            Err(err) => Err(err),
         },
     }
 }
@@ -190,7 +189,7 @@ async fn handle_request_msg(
                 send_msg(conn, &proto::ServerMsg::ResponseError { request_id, error }).await?;
                 Ok(true)
             }
-            Err(err) => return Err(err),
+            Err(err) => Err(err),
         },
     }
 }

--- a/sqld/src/hrana/conn.rs
+++ b/sqld/src/hrana/conn.rs
@@ -1,0 +1,195 @@
+use std::sync::Arc;
+
+use anyhow::{Result, Context as _};
+use futures::{TryStreamExt as _, SinkExt as _};
+use tokio_tungstenite::tungstenite;
+use tungstenite::http;
+use tungstenite::protocol::frame::coding::CloseCode;
+
+use super::{Server, proto, session};
+
+struct Conn {
+    conn_id: u64,
+    server: Arc<Server>,
+    ws: WebSocket,
+    ws_closed: bool,
+    session: Option<session::Session>,
+}
+
+type WebSocket = tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>; 
+
+pub(super) async fn handle_conn(server: Arc<Server>, socket: tokio::net::TcpStream, conn_id: u64) -> Result<()> {
+    let ws = handshake(socket).await
+        .context("Could not perform the WebSocket handshake")?;
+
+    let mut conn = Conn {
+        conn_id,
+        server,
+        ws,
+        ws_closed: false,
+        session: None,
+    };
+
+    while let Some(client_msg) = conn.ws.try_next().await
+        .context("Could not receive a WebSocket message")?
+    {
+        match handle_msg(&mut conn, client_msg).await {
+            Ok(true) => continue,
+            Ok(false) => break,
+            Err(err) => {
+                close(&mut conn, CloseCode::Error, "Internal server error").await;
+                return Err(err);
+            }
+        }
+    }
+
+    close(&mut conn, CloseCode::Normal, "Thank you for using sqld").await;
+    Ok(())
+}
+
+async fn handshake(socket: tokio::net::TcpStream) -> Result<WebSocket> {
+    let ws_config = tungstenite::protocol::WebSocketConfig {
+        max_send_queue: Some(1<<20),
+        .. Default::default()
+    };
+
+    let callback = |req: &http::Request<()>, resp: http::Response<()>| {
+        let (mut resp_parts, _) = resp.into_parts();
+        if let Some(protocol_hdr) = req.headers().get("sec-websocket-protocol") {
+            let has_hrana1 = protocol_hdr.to_str().unwrap_or("")
+                .split(',')
+                .find(|p| p.trim() == "hrana1")
+                .is_some();
+            if has_hrana1 {
+                resp_parts.headers.append(
+                    "sec-websocket-protocol",
+                    http::HeaderValue::from_static("hrana1"),
+                );
+            } else {
+                resp_parts.status = http::StatusCode::BAD_REQUEST;
+                let resp_body = Some("Only the 'hrana1' subprotocol is supported".into());
+                return Err(http::Response::from_parts(resp_parts, resp_body))
+            }
+        } else {
+            // Sec-WebSocket-Protocol header not present, assume that the client wants hrana1
+            // According to RFC 6455, we must not set the Sec-WebSocket-Protocol response header
+        }
+        Ok(http::Response::from_parts(resp_parts, ()))
+    };
+
+    Ok(tokio_tungstenite::accept_hdr_async_with_config(socket, callback, Some(ws_config)).await?)
+}
+
+async fn handle_msg(conn: &mut Conn, client_msg: tungstenite::Message) -> Result<bool> {
+    match client_msg {
+        tungstenite::Message::Text(client_msg) => {
+            // client messages are received as text WebSocket messages that encode the `ClientMsg`
+            // in JSON
+            let client_msg: proto::ClientMsg = match serde_json::from_str(&client_msg) {
+                Ok(client_msg) => client_msg,
+                Err(err) => {
+                    close(conn, CloseCode::Invalid, "Invalid format of client message").await;
+                    tracing::warn!("Could not deserialize client message: {}", err);
+                    return Ok(false)
+                },
+            };
+
+            match client_msg {
+                proto::ClientMsg::Hello { jwt } =>
+                    handle_hello_msg(conn, jwt).await,
+                proto::ClientMsg::Request { request_id, request } =>
+                    handle_request_msg(conn, request_id, request).await,
+            }
+        },
+        tungstenite::Message::Ping(ping_data) => {
+            let pong_msg = tungstenite::Message::Pong(ping_data);
+            conn.ws.send(pong_msg).await
+                .context("Could not send pong to the WebSocket")?;
+            Ok(true)
+        },
+        tungstenite::Message::Close(_) => {
+            Ok(false)
+        },
+        _ => {
+            close(conn, CloseCode::Unsupported, "Unsupported WebSocket message type").await;
+            tracing::warn!("Received an unsupported WebSocket message");
+            Ok(false)
+        },
+    }
+}
+
+async fn handle_hello_msg(conn: &mut Conn, jwt: Option<String>) -> Result<bool> {
+    if conn.session.is_some() {
+        close(conn, CloseCode::Policy, "Hello message can only be sent once").await;
+        tracing::warn!("Received a hello message twice");
+        return Ok(false)
+    }
+
+    match session::handle_hello(jwt).await {
+        Ok(session) => {
+            conn.session = Some(session);
+            send_msg(conn, &proto::ServerMsg::HelloOk {}).await?;
+            Ok(true)
+        },
+        Err(err) => match downcast_error(err) {
+            Ok(error) => {
+                send_msg(conn, &proto::ServerMsg::HelloError { error }).await?;
+                Ok(false)
+            },
+            Err(err) => return Err(err),
+        },
+    }
+}
+
+async fn handle_request_msg(conn: &mut Conn, request_id: i32, request: proto::Request) -> Result<bool> {
+    let Some(session) = conn.session.as_mut() else {
+        close(conn, CloseCode::Policy, "Requests can only be sent after a hello").await;
+        tracing::warn!("Received a request message before hello");
+        return Ok(false)
+    };
+
+    match session::handle_request(&conn.server, session, request).await {
+        Ok(response) => {
+            send_msg(conn, &proto::ServerMsg::ResponseOk { request_id, response }).await?;
+            Ok(true)
+        },
+        Err(err) => match downcast_error(err) {
+            Ok(error) => {
+                send_msg(conn, &proto::ServerMsg::ResponseError { request_id, error }).await?;
+                Ok(true)
+            },
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+fn downcast_error(err: anyhow::Error) -> Result<proto::Error> {
+    match err.downcast_ref::<session::ResponseError>() {
+        Some(error) => Ok(proto::Error { message: error.to_string() }),
+        None => Err(err),
+    }
+}
+
+async fn send_msg(conn: &mut Conn, msg: &proto::ServerMsg) -> Result<()> {
+    let msg = serde_json::to_string(&msg)
+        .context("Could not serialize response message")?;
+    let msg = tungstenite::Message::Text(msg);
+    conn.ws.send(msg).await
+        .context("Could not send response to the WebSocket")
+}
+
+async fn close(conn: &mut Conn, code: CloseCode, reason: &'static str) {
+    if conn.ws_closed {
+        return;
+    }
+
+    let close_frame = tungstenite::protocol::frame::CloseFrame { code, reason: reason.into() };
+    if let Err(err) = conn.ws.send(tungstenite::Message::Close(Some(close_frame))).await {
+        if !matches!(err, tungstenite::Error::AlreadyClosed | tungstenite::Error::ConnectionClosed) {
+            tracing::warn!("Could not send close frame to WebSocket of connection #{}: {:?}", conn.conn_id, err);
+        }
+    }
+
+    conn.ws_closed = true;
+}
+

--- a/sqld/src/hrana/mod.rs
+++ b/sqld/src/hrana/mod.rs
@@ -1,8 +1,8 @@
+use crate::database::service::DbFactory;
+use anyhow::{Context as _, Result};
+use enclose::enclose;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use anyhow::{Result, Context as _};
-use enclose::enclose;
-use crate::database::service::DbFactory;
 
 mod conn;
 mod proto;
@@ -15,7 +15,8 @@ struct Server {
 pub async fn serve(db_factory: Arc<dyn DbFactory>, bind_addr: SocketAddr) -> Result<()> {
     let server = Arc::new(Server { db_factory });
 
-    let listener = tokio::net::TcpListener::bind(bind_addr).await
+    let listener = tokio::net::TcpListener::bind(bind_addr)
+        .await
         .context("Could not bind TCP listener")?;
     let local_addr = listener.local_addr()?;
     tracing::info!("Listening for Hrana connections on {}", local_addr);
@@ -33,7 +34,7 @@ pub async fn serve(db_factory: Arc<dyn DbFactory>, bind_addr: SocketAddr) -> Res
                     match conn::handle_conn(server, socket, conn_id).await {
                         Ok(_) => tracing::info!("Connection #{} was terminated", conn_id),
                         Err(err) => tracing::error!("Connection #{} failed: {:?}", conn_id, err),
-                    } 
+                    }
                 }});
 
                 conn_id += 1;

--- a/sqld/src/hrana/mod.rs
+++ b/sqld/src/hrana/mod.rs
@@ -1,0 +1,46 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use anyhow::{Result, Context as _};
+use enclose::enclose;
+use crate::database::service::DbFactory;
+
+mod conn;
+mod proto;
+mod session;
+
+struct Server {
+    db_factory: Arc<dyn DbFactory>,
+}
+
+pub async fn serve(db_factory: Arc<dyn DbFactory>, bind_addr: SocketAddr) -> Result<()> {
+    let server = Arc::new(Server { db_factory });
+
+    let listener = tokio::net::TcpListener::bind(bind_addr).await
+        .context("Could not bind TCP listener")?;
+    let local_addr = listener.local_addr()?;
+    tracing::info!("Listening for Hrana connections on {}", local_addr);
+
+    let mut join_set = tokio::task::JoinSet::new();
+    let mut conn_id = 0;
+    loop {
+        tokio::select! {
+            accept_res = listener.accept() => {
+                let (socket, peer_addr) = accept_res
+                    .context("Could not accept a TCP connection")?;
+                tracing::info!("Accepted connection #{} from {}", conn_id, peer_addr);
+
+                join_set.spawn(enclose!{(server, conn_id) async move {
+                    match conn::handle_conn(server, socket, conn_id).await {
+                        Ok(_) => tracing::info!("Connection #{} was terminated", conn_id),
+                        Err(err) => tracing::error!("Connection #{} failed: {:?}", conn_id, err),
+                    } 
+                }});
+
+                conn_id += 1;
+            },
+            Some(task_res) = join_set.join_next() => {
+                task_res.expect("Hrana connection task failed")
+            },
+        }
+    }
+}

--- a/sqld/src/hrana/proto.rs
+++ b/sqld/src/hrana/proto.rs
@@ -1,0 +1,144 @@
+//! Messages in the Hrana protocol.
+//!
+//! Please consult the Hrana specification in the `docs/` directory for more information.
+use serde::{Serialize, Deserialize};
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClientMsg {
+    Hello {
+        jwt: Option<String>,
+    },
+    Request {
+        request_id: i32,
+        request: Request,
+    },
+}
+
+#[derive(Serialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ServerMsg {
+    HelloOk {},
+    HelloError {
+        error: Error,
+    },
+    ResponseOk {
+        request_id: i32,
+        response: Response,
+    },
+    ResponseError {
+        request_id: i32,
+        error: Error,
+    },
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Request {
+    OpenStream(OpenStreamReq),
+    CloseStream(OpenStreamReq),
+    Execute(ExecuteReq),
+}
+
+#[derive(Serialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Response {
+    OpenStream(OpenStreamResp),
+    CloseStream(CloseStreamResp),
+    Execute(ExecuteResp),
+}
+
+
+#[derive(Deserialize, Debug)]
+pub struct OpenStreamReq {
+    pub stream_id: u32,
+}
+
+#[derive(Serialize, Debug)]
+pub struct OpenStreamResp {}
+
+#[derive(Deserialize, Debug)]
+pub struct CloseStreamReq {
+    pub stream_id: u32,
+}
+
+#[derive(Serialize, Debug)]
+pub struct CloseStreamResp {}
+
+#[derive(Deserialize, Debug)]
+pub struct ExecuteReq {
+    pub stream_id: u32,
+    pub stmt: Stmt,
+}
+
+#[derive(Serialize, Debug)]
+pub struct ExecuteResp {
+    pub result: StmtResult,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Stmt {
+    pub sql: String,
+    pub args: Vec<Value>,
+    pub want_rows: bool,
+}
+
+#[derive(Serialize, Debug)]
+pub struct StmtResult {
+    pub cols: Vec<Col>,
+    pub rows: Vec<Vec<Value>>,
+    pub affected_row_count: u64,
+}
+
+#[derive(Serialize, Debug)]
+pub struct Col {
+    pub name: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Value {
+    Null,
+    Integer { #[serde(with = "i64_as_str")] value: i64 },
+    Float { value: f64 },
+    Text { value: String },
+    Blob { #[serde(with = "bytes_as_base64", rename = "base64")] value: Vec<u8> },
+}
+
+#[derive(Serialize, Debug)]
+pub struct Error {
+    pub message: String,
+}
+
+mod i64_as_str {
+    use serde::{ser, de};
+    use serde::{Serialize as _, de::Error as _};
+
+    pub fn serialize<S: ser::Serializer>(value: &i64, ser: S) -> Result<S::Ok, S::Error> {
+        value.to_string().serialize(ser)
+    }
+
+    pub fn deserialize<'de, D: de::Deserializer<'de>>(de: D) -> Result<i64, D::Error> {
+        let str_value = <&'de str as de::Deserialize>::deserialize(de)?;
+        str_value.parse().map_err(|_| {
+            D::Error::invalid_value(de::Unexpected::Str(str_value), &"decimal integer as a string")
+        })
+    }
+}
+
+mod bytes_as_base64 {
+    use base64::{Engine as _, engine::general_purpose::STANDARD_NO_PAD};
+    use serde::{ser, de};
+    use serde::{Serialize as _, de::Error as _};
+
+    pub fn serialize<S: ser::Serializer>(value: &Vec<u8>, ser: S) -> Result<S::Ok, S::Error> {
+        STANDARD_NO_PAD.encode(value).serialize(ser)
+    }
+
+    pub fn deserialize<'de, D: de::Deserializer<'de>>(de: D) -> Result<Vec<u8>, D::Error> {
+        let str_value = <&'de str as de::Deserialize>::deserialize(de)?;
+        STANDARD_NO_PAD.decode(str_value.trim_end_matches('=')).map_err(|_| {
+            D::Error::invalid_value(de::Unexpected::Str(str_value), &"binary data encoded as base64")
+        })
+    }
+}

--- a/sqld/src/hrana/session.rs
+++ b/sqld/src/hrana/session.rs
@@ -184,7 +184,7 @@ fn proto_response_error_from_error(error: Error) -> Result<ResponseError, Error>
             } => ResponseError::SqlInputError {
                 source: sqlite_error,
                 message,
-                offset: offset as i32,
+                offset,
             },
             rusqlite_error => return Err(Error::RusqliteError(rusqlite_error)),
         },

--- a/sqld/src/hrana/session.rs
+++ b/sqld/src/hrana/session.rs
@@ -1,0 +1,91 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{Result, Context as _, bail};
+
+use crate::database::Database;
+use crate::error::Error;
+use crate::query::{Query, QueryResult};
+use super::{Server, proto};
+
+pub struct Session {
+    streams: HashMap<u32, Stream>,
+}
+
+struct Stream {
+    db: Arc<dyn Database>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ResponseError {
+    #[error("Stream {stream_id} not found")]
+    StreamNotFound { stream_id: u32 },
+    #[error("Stream {stream_id} already exists")]
+    StreamExists { stream_id: u32 },
+}
+
+pub async fn handle_hello(_jwt: Option<String>) -> Result<Session> {
+    // TODO: handle the jwt
+    Ok(Session { streams: HashMap::new() })
+}
+
+pub(super) async fn handle_request(
+    server: &Server,
+    session: &mut Session,
+    req: proto::Request,
+) -> Result<proto::Response> {
+    match req {
+        proto::Request::OpenStream(req) => {
+            let stream_id = req.stream_id;
+
+            if session.streams.contains_key(&stream_id) {
+                bail!(ResponseError::StreamExists { stream_id })
+            }
+
+            let db = server.db_factory.create().await
+                .context("Could not create a database connection")?;
+            let stream = Stream { db };
+            session.streams.insert(stream_id, stream);
+
+            Ok(proto::Response::OpenStream(proto::OpenStreamResp {}))
+        },
+        proto::Request::CloseStream(req) => {
+            session.streams.remove(&req.stream_id);
+            Ok(proto::Response::CloseStream(proto::CloseStreamResp {}))
+        },
+        proto::Request::Execute(req) => {
+            let stream_id = req.stream_id;
+
+            let Some(stream) = session.streams.get_mut(&stream_id) else {
+                bail!(ResponseError::StreamNotFound { stream_id })
+            };
+
+            let result = execute_stmt(stream, req.stmt).await?;
+            Ok(proto::Response::Execute(proto::ExecuteResp { result }))
+        },
+    }
+}
+
+async fn execute_stmt(stream: &mut Stream, stmt: proto::Stmt) -> Result<proto::StmtResult> {
+    let query = stmt_to_query(stmt)?;
+    let query_result = match stream.db.execute_one(query).await {
+        Ok((query_result, _)) => query_result,
+        Err(error) => match response_error_from_error(error) {
+            Ok(resp_error) => bail!(resp_error),
+            Err(error) => bail!(error),
+        },
+    };
+    stmt_result_from_query(query_result)
+}
+
+fn stmt_to_query(_stmt: proto::Stmt) -> Result<Query> {
+    bail!("not implemented")
+}
+
+fn stmt_result_from_query(_result: QueryResult) -> Result<proto::StmtResult> {
+    bail!("not implemented")
+}
+
+fn response_error_from_error(error: Error) -> Result<ResponseError, Error> {
+    Err(error)
+}

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -78,7 +78,7 @@ enum ResultResponse {
 }
 
 fn query_response_to_json(results: Vec<QueryResult>) -> anyhow::Result<Bytes> {
-    fn result_set_to_json(ResultSet { columns, rows }: ResultSet) -> anyhow::Result<RowsResponse> {
+    fn result_set_to_json(ResultSet { columns, rows, .. }: ResultSet) -> anyhow::Result<RowsResponse> {
         let mut out_rows = Vec::with_capacity(rows.len());
         for row in rows {
             let mut out_row = Vec::with_capacity(row.values.len());

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -78,7 +78,9 @@ enum ResultResponse {
 }
 
 fn query_response_to_json(results: Vec<QueryResult>) -> anyhow::Result<Bytes> {
-    fn result_set_to_json(ResultSet { columns, rows, .. }: ResultSet) -> anyhow::Result<RowsResponse> {
+    fn result_set_to_json(
+        ResultSet { columns, rows, .. }: ResultSet,
+    ) -> anyhow::Result<RowsResponse> {
         let mut out_rows = Vec::with_capacity(rows.len());
         for row in rows {
             let mut out_row = Vec::with_capacity(row.values.len());

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -117,7 +117,9 @@ async fn run_service(
 
     if let Some(addr) = config.hrana_addr {
         join_set.spawn(async move {
-            hrana::serve(service.factory, addr).await.context("Hrana server failed")
+            hrana::serve(service.factory, addr)
+                .await
+                .context("Hrana server failed")
         });
     }
 

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -18,6 +18,9 @@ struct Cli {
     /// The address and port the PostgreSQL over WebSocket server listens to.
     #[clap(long, short, env = "SQLD_WS_LISTEN_ADDR")]
     ws_listen_addr: Option<SocketAddr>,
+    /// The address and port the Hrana server listens to.
+    #[clap(long, short = 'l', env = "SQLD_HRANA_LISTEN_ADDR")]
+    hrana_listen_addr: Option<SocketAddr>,
 
     /// The address and port the inter-node RPC protocol listens to. Example: `0.0.0.0:5001`.
     #[clap(
@@ -145,6 +148,7 @@ impl From<Cli> for Config {
             http_addr: Some(cli.http_listen_addr),
             http_auth: cli.http_auth,
             enable_http_console: cli.enable_http_console,
+            hrana_addr: cli.hrana_listen_addr,
             backend: cli.backend,
             writer_rpc_addr: cli.primary_grpc_url,
             writer_rpc_tls: cli.primary_grpc_tls,

--- a/sqld/src/query.rs
+++ b/sqld/src/query.rs
@@ -239,7 +239,11 @@ impl From<ResultRows> for ResultSet {
             .map(|values| Row { values })
             .collect();
 
-        Self { columns, rows, affected_row_count: result_rows.affected_row_count }
+        Self {
+            columns,
+            rows,
+            affected_row_count: result_rows.affected_row_count,
+        }
     }
 }
 

--- a/sqld/src/query_analysis.rs
+++ b/sqld/src/query_analysis.rs
@@ -106,7 +106,8 @@ impl Statement {
         fn parse_inner(c: Cmd) -> Result<Statement> {
             let kind =
                 StmtKind::kind(&c).ok_or_else(|| anyhow::anyhow!("unsupported statement"))?;
-            let is_iud = matches!(c,
+            let is_iud = matches!(
+                c,
                 Cmd::Stmt(Stmt::Insert { .. } | Stmt::Update { .. } | Stmt::Delete { .. })
             );
 

--- a/sqld/src/query_analysis.rs
+++ b/sqld/src/query_analysis.rs
@@ -10,6 +10,8 @@ use sqlite3_parser::{
 pub struct Statement {
     pub stmt: String,
     pub kind: StmtKind,
+    /// Is the statement an INSERT, UPDATE or DELETE?
+    pub is_iud: bool,
 }
 
 impl Default for Statement {
@@ -85,6 +87,7 @@ impl Statement {
             stmt: String::new(),
             // empty statement is arbitrarely made of the read kind so it is not send to a writer
             kind: StmtKind::Read,
+            is_iud: false,
         }
     }
 
@@ -95,6 +98,7 @@ impl Statement {
         Self {
             stmt: s.to_string(),
             kind: StmtKind::Write,
+            is_iud: false,
         }
     }
 
@@ -102,10 +106,14 @@ impl Statement {
         fn parse_inner(c: Cmd) -> Result<Statement> {
             let kind =
                 StmtKind::kind(&c).ok_or_else(|| anyhow::anyhow!("unsupported statement"))?;
+            let is_iud = matches!(c,
+                Cmd::Stmt(Stmt::Insert { .. } | Stmt::Update { .. } | Stmt::Delete { .. })
+            );
 
             Ok(Statement {
                 stmt: c.to_string(),
                 kind,
+                is_iud,
             })
         }
         // The parser needs to be boxed because it's large, and you don't want it on the stack.

--- a/sqld/src/rpc/proxy.rs
+++ b/sqld/src/rpc/proxy.rs
@@ -199,7 +199,7 @@ impl Proxy for ProxyService {
                 tonic::Status::new(tonic::Code::Internal, "failed to deserialize query")
             })?;
 
-        let (results, state) = db.execute(queries).await.unwrap();
+        let (results, state) = db.execute_batch(queries).await.unwrap();
         let results = results.into_iter().map(|r| r.into()).collect();
 
         Ok(tonic::Response::new(ExecuteResults {


### PR DESCRIPTION
Implement a basic Hrana server for sqld.

To keep the PR small, the following features will be done in follow-up PRs:
- Execute statements concurrently (right now, all requests are handled in order, but the protocol supports reordering)
- Implement JWT authentication, so that we can expose the protocol on Turso databases
- Add tests (I only tested this using tests from `packages/js/hrana-client`)