### PR TITLE
Hrana server authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ client_cert.pem
 client_key.pem
 server_cert.pem
 server_key.pem
+jwt_key.pem
+jwt_key.base64
 Session.vim
 bottomless/test/test.db
 bottomless/test/*.bottomless.backup

--- a/packages/js/hrana-client/examples/jwt_auth.mjs
+++ b/packages/js/hrana-client/examples/jwt_auth.mjs
@@ -1,9 +1,6 @@
 import * as hrana from "@libsql/hrana-client";
 
-const jwt = (
-    "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSJ9.eyJleHAiOjE2NzY5MDkwOTR9._8Dt3MSN7b5-ykbxM2dCh8CzIPpkqDmPagRXfSO3s1es-6vRN_qMrNGsEUdCFP6tAmCNYd9RJZ9zaUT_wCQ3Bg"
-);
-const client = hrana.open("ws://localhost:2023", jwt);
+const client = hrana.open("ws://localhost:2023", process.env.JWT);
 const stream = client.openStream();
 console.log(await stream.queryValue("SELECT 1"));
 client.close();

--- a/packages/js/hrana-client/examples/jwt_auth.mjs
+++ b/packages/js/hrana-client/examples/jwt_auth.mjs
@@ -1,0 +1,9 @@
+import * as hrana from "@libsql/hrana-client";
+
+const jwt = (
+    "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSJ9.eyJleHAiOjE2NzY5MDkwOTR9._8Dt3MSN7b5-ykbxM2dCh8CzIPpkqDmPagRXfSO3s1es-6vRN_qMrNGsEUdCFP6tAmCNYd9RJZ9zaUT_wCQ3Bg"
+);
+const client = hrana.open("ws://localhost:2023", jwt);
+const stream = client.openStream();
+console.log(await stream.queryValue("SELECT 1"));
+client.close();

--- a/packages/js/hrana-client/src/index.ts
+++ b/packages/js/hrana-client/src/index.ts
@@ -127,7 +127,7 @@ export class Client {
             this.#handleMsg(event.data);
         } catch (e) {
             this.#socket.close(3007, "Could not handle message");
-            this.#setClosed(new Error("Error while handling message from server", {cause: e}));
+            this.#setClosed(e as Error);
         }
     }
 

--- a/scripts/gen_jwt.py
+++ b/scripts/gen_jwt.py
@@ -18,10 +18,13 @@ pubkey_pem = pubkey.public_bytes(
     format=serialization.PublicFormat.SubjectPublicKeyInfo,
 )
 
-pubkey_base64 = base64.b64encode(pubkey.public_bytes(
-    encoding=serialization.Encoding.Raw,
-    format=serialization.PublicFormat.Raw,
-))
+pubkey_base64 = base64.b64encode(
+    pubkey.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    ),
+    altchars=b"-_",
+)
 while pubkey_base64[-1] == ord("="):
     pubkey_base64 = pubkey_base64[:-1]
 

--- a/scripts/gen_jwt.py
+++ b/scripts/gen_jwt.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""utility that generates Ed25519 key and a JWT for testing
+
+the public key is stored in jwt_key.pem (in PEM format) and jwt_key.base64 (raw
+base64 format) and the JWT is printed to stdout
+"""
+import base64
+import datetime
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+privkey = Ed25519PrivateKey.generate()
+pubkey = privkey.public_key()
+
+pubkey_pem = pubkey.public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+)
+
+pubkey_base64 = base64.b64encode(pubkey.public_bytes(
+    encoding=serialization.Encoding.Raw,
+    format=serialization.PublicFormat.Raw,
+))
+while pubkey_base64[-1] == ord("="):
+    pubkey_base64 = pubkey_base64[:-1]
+
+privkey_pem = privkey.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.PKCS8,
+    encryption_algorithm=serialization.NoEncryption(),
+)
+
+exp = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=3)
+claims = {
+    "exp": int(exp.timestamp()),
+}
+token = jwt.encode(claims, privkey_pem, "EdDSA")
+
+open("jwt_key.pem", "wb").write(pubkey_pem)
+open("jwt_key.base64", "wb").write(pubkey_base64)
+print(token)

--- a/sqld/src/hrana/conn.rs
+++ b/sqld/src/hrana/conn.rs
@@ -176,7 +176,7 @@ async fn handle_hello_msg(conn: &mut Conn, jwt: Option<String>) -> Result<bool> 
         return Ok(false);
     }
 
-    match session::handle_hello(jwt).await {
+    match session::handle_hello(&conn.server, jwt).await {
         Ok(session) => {
             conn.session = Some(session);
             send_msg(conn, &proto::ServerMsg::HelloOk {}).await?;

--- a/sqld/src/hrana/session.rs
+++ b/sqld/src/hrana/session.rs
@@ -49,9 +49,7 @@ pub enum ResponseError {
     #[error("Authentication using JWT is required")]
     AuthJwtRequired,
     #[error("Authentication using JWT failed")]
-    AuthJwtRejected {
-        source: jsonwebtoken::errors::Error,
-    },
+    AuthJwtRejected { source: jsonwebtoken::errors::Error },
 
     #[error("Stream {stream_id} not found")]
     StreamNotFound { stream_id: i32 },

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -67,6 +67,7 @@ pub struct Config {
     pub http_auth: Option<String>,
     pub enable_http_console: bool,
     pub hrana_addr: Option<SocketAddr>,
+    pub hrana_jwt_key: Option<PathBuf>,
     pub backend: Backend,
     #[cfg(feature = "mwal_backend")]
     pub mwal_addr: Option<String>,
@@ -116,8 +117,13 @@ async fn run_service(
     }
 
     if let Some(addr) = config.hrana_addr {
+        let jwt_key = config.hrana_jwt_key.as_deref()
+            .map(hrana::load_jwt_key)
+            .transpose()
+            .context("Could not load JWT decoding key for Hrana")?;
+
         join_set.spawn(async move {
-            hrana::serve(service.factory, addr)
+            hrana::serve(service.factory, addr, jwt_key)
                 .await
                 .context("Hrana server failed")
         });

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -67,7 +67,7 @@ pub struct Config {
     pub http_auth: Option<String>,
     pub enable_http_console: bool,
     pub hrana_addr: Option<SocketAddr>,
-    pub hrana_jwt_key: Option<PathBuf>,
+    pub hrana_jwt_key: Option<String>,
     pub backend: Backend,
     #[cfg(feature = "mwal_backend")]
     pub mwal_addr: Option<String>,
@@ -117,10 +117,12 @@ async fn run_service(
     }
 
     if let Some(addr) = config.hrana_addr {
-        let jwt_key = config.hrana_jwt_key.as_deref()
-            .map(hrana::load_jwt_key)
+        let jwt_key = config
+            .hrana_jwt_key
+            .as_deref()
+            .map(hrana::parse_jwt_key)
             .transpose()
-            .context("Could not load JWT decoding key for Hrana")?;
+            .context("Could not parse JWT decoding key for Hrana")?;
 
         join_set.spawn(async move {
             hrana::serve(service.factory, addr, jwt_key)

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -18,9 +18,15 @@ struct Cli {
     /// The address and port the PostgreSQL over WebSocket server listens to.
     #[clap(long, short, env = "SQLD_WS_LISTEN_ADDR")]
     ws_listen_addr: Option<SocketAddr>,
+
     /// The address and port the Hrana server listens to.
     #[clap(long, short = 'l', env = "SQLD_HRANA_LISTEN_ADDR")]
     hrana_listen_addr: Option<SocketAddr>,
+    /// Path to a file with a JWT decoding key used to authenticate Hrana connections. If you do
+    /// not specify a key, Hrana authentication is not required. The key is either PKCS#8-encoded
+    /// Ed25519 public key, or just plain bytes of the Ed25519 public key in base64.
+    #[clap(long, env = "SQLD_HRANA_JWT_KEY_FILE")]
+    hrana_jwt_key_file: Option<PathBuf>,
 
     /// The address and port the inter-node RPC protocol listens to. Example: `0.0.0.0:5001`.
     #[clap(
@@ -149,6 +155,7 @@ impl From<Cli> for Config {
             http_auth: cli.http_auth,
             enable_http_console: cli.enable_http_console,
             hrana_addr: cli.hrana_listen_addr,
+            hrana_jwt_key: cli.hrana_jwt_key_file,
             backend: cli.backend,
             writer_rpc_addr: cli.primary_grpc_url,
             writer_rpc_tls: cli.primary_grpc_tls,

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -1,6 +1,6 @@
-use std::{net::SocketAddr, path::PathBuf, time::Duration};
+use std::{env, fs, net::SocketAddr, path::PathBuf, time::Duration};
 
-use anyhow::Result;
+use anyhow::{bail, Context as _, Result};
 use clap::Parser;
 use sqld::Config;
 use tracing_subscriber::filter::LevelFilter;
@@ -24,7 +24,9 @@ struct Cli {
     hrana_listen_addr: Option<SocketAddr>,
     /// Path to a file with a JWT decoding key used to authenticate Hrana connections. If you do
     /// not specify a key, Hrana authentication is not required. The key is either PKCS#8-encoded
-    /// Ed25519 public key, or just plain bytes of the Ed25519 public key in base64.
+    /// Ed25519 public key, or just plain bytes of the Ed25519 public key in URL-safe base64.
+    ///
+    /// You can also pass the key directly in the env variable SQLD_HRANA_JWT_KEY.
     #[clap(long, env = "SQLD_HRANA_JWT_KEY_FILE")]
     hrana_jwt_key_file: Option<PathBuf>,
 
@@ -141,39 +143,51 @@ impl Cli {
         if let Some(ref addr) = self.pg_listen_addr {
             eprintln!("\t- listening for PostgreSQL wire on: {addr}");
         }
-        eprintln!("\t- gprc_tls: {}", if self.grpc_tls { "yes" } else { "no" });
+        eprintln!("\t- grpc_tls: {}", if self.grpc_tls { "yes" } else { "no" });
     }
 }
 
-impl From<Cli> for Config {
-    fn from(cli: Cli) -> Self {
-        Self {
-            db_path: cli.db_path,
-            tcp_addr: cli.pg_listen_addr,
-            ws_addr: cli.ws_listen_addr,
-            http_addr: Some(cli.http_listen_addr),
-            http_auth: cli.http_auth,
-            enable_http_console: cli.enable_http_console,
-            hrana_addr: cli.hrana_listen_addr,
-            hrana_jwt_key: cli.hrana_jwt_key_file,
-            backend: cli.backend,
-            writer_rpc_addr: cli.primary_grpc_url,
-            writer_rpc_tls: cli.primary_grpc_tls,
-            writer_rpc_cert: cli.primary_grpc_cert_file,
-            writer_rpc_key: cli.primary_grpc_key_file,
-            writer_rpc_ca_cert: cli.primary_grpc_ca_cert_file,
-            rpc_server_addr: cli.grpc_listen_addr,
-            rpc_server_tls: cli.grpc_tls,
-            rpc_server_cert: cli.grpc_cert_file,
-            rpc_server_key: cli.grpc_key_file,
-            rpc_server_ca_cert: cli.grpc_ca_cert_file,
-            #[cfg(feature = "mwal_backend")]
-            mwal_addr: cli.mwal_addr,
-            enable_bottomless_replication: cli.enable_bottomless_replication,
-            create_local_http_tunnel: cli.create_local_http_tunnel,
-            idle_shutdown_timeout: cli.idle_shutdown_timeout_s.map(Duration::from_secs),
+fn config_from_args(args: Cli) -> Result<Config> {
+    let hrana_jwt_key = if let Some(file_path) = args.hrana_jwt_key_file {
+        let data =
+            fs::read_to_string(file_path).context("Could not read file with Hrana JWT key")?;
+        Some(data)
+    } else {
+        match env::var("SQLD_HRANA_JWT_KEY") {
+            Ok(key) => Some(key),
+            Err(env::VarError::NotPresent) => None,
+            Err(env::VarError::NotUnicode(_)) => {
+                bail!("Env variable SQLD_HRANA_JWT_KEY does not contain a valid Unicode value")
+            }
         }
-    }
+    };
+
+    Ok(Config {
+        db_path: args.db_path,
+        tcp_addr: args.pg_listen_addr,
+        ws_addr: args.ws_listen_addr,
+        http_addr: Some(args.http_listen_addr),
+        http_auth: args.http_auth,
+        enable_http_console: args.enable_http_console,
+        hrana_addr: args.hrana_listen_addr,
+        hrana_jwt_key,
+        backend: args.backend,
+        writer_rpc_addr: args.primary_grpc_url,
+        writer_rpc_tls: args.primary_grpc_tls,
+        writer_rpc_cert: args.primary_grpc_cert_file,
+        writer_rpc_key: args.primary_grpc_key_file,
+        writer_rpc_ca_cert: args.primary_grpc_ca_cert_file,
+        rpc_server_addr: args.grpc_listen_addr,
+        rpc_server_tls: args.grpc_tls,
+        rpc_server_cert: args.grpc_cert_file,
+        rpc_server_key: args.grpc_key_file,
+        rpc_server_ca_cert: args.grpc_ca_cert_file,
+        #[cfg(feature = "mwal_backend")]
+        mwal_addr: args.mwal_addr,
+        enable_bottomless_replication: args.enable_bottomless_replication,
+        create_local_http_tunnel: args.create_local_http_tunnel,
+        idle_shutdown_timeout: args.idle_shutdown_timeout_s.map(Duration::from_secs),
+    })
 }
 
 #[tokio::main]
@@ -203,7 +217,8 @@ async fn main() -> Result<()> {
         _ => (),
     }
 
-    sqld::run_server(args.into()).await?;
+    let config = config_from_args(args)?;
+    sqld::run_server(config).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Implement authentication in Hrana using JWTs. An Ed25519 public key is passed to sqld using `--hrana-jwt-key-file`, and the received JWT is verified using this key. We ignore the claims, except by validating the expiration in `exp`.

I also added a helper script `scripts/gen_jwt.py` to generate the key and a JWT.

This PR is stacked on top of #231.