### PR TITLE
sqld: add unix-excl-vfs flag

### DIFF
--- a/sqld-libsql-bindings/Cargo.toml
+++ b/sqld-libsql-bindings/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.66"
 libsql-wasmtime-bindings = "0"
 mvfs = { git = "https://github.com/psarna/mvsqlite", branch = "mwal", optional = true }
 mwal = { git = "https://github.com/psarna/mvsqlite", branch = "mwal", optional = true }
-rusqlite = { git = "https://github.com/psarna/rusqlite", rev = "4df75df0b0f5ecea2714a8b21bf9f2a0fcfd5905", default-features = false, features = [
+rusqlite = { git = "https://github.com/psarna/rusqlite", rev = "cc7d3f9d5344332c12c34e36be0c055480659d8c", default-features = false, features = [
     "buildtime_bindgen",
     "bundled-libsql",
     "column_decltype"
@@ -19,3 +19,4 @@ tracing = "0.1.37"
 
 [features]
 mwal_backend = ["mvfs", "mwal"]
+unix-excl-vfs = []

--- a/sqld-libsql-bindings/src/lib.rs
+++ b/sqld-libsql-bindings/src/lib.rs
@@ -51,7 +51,15 @@ pub fn open_with_regular_wal(
         "Opening a connection with regular WAL at {}",
         path.display()
     );
+    #[cfg(not(feature = "unix-excl-vfs"))]
     let conn = Connection::open_with_flags_and_wal(path, flags, WalMethodsHook::METHODS_NAME_STR)?;
+    #[cfg(feature = "unix-excl-vfs")]
+    let conn = Connection::open_with_flags_vfs_and_wal(
+        path,
+        flags,
+        "unix-excl",
+        WalMethodsHook::METHODS_NAME_STR,
+    )?;
     conn.pragma_update(None, "journal_mode", "wal")?;
     Ok(conn)
 }

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -32,7 +32,7 @@ pin-project-lite = "0.2.9"
 postgres-protocol = "0.6.4"
 prost = "0.11.3"
 regex = "1.7.0"
-rusqlite = { version = "0.28.0", git = "https://github.com/psarna/rusqlite", rev = "4df75df0b0f5ecea2714a8b21bf9f2a0fcfd5905", default-features = false, features = [
+rusqlite = { version = "0.28.0", git = "https://github.com/psarna/rusqlite", rev = "cc7d3f9d5344332c12c34e36be0c055480659d8c", default-features = false, features = [
     "buildtime_bindgen",
     "bundled-libsql",
     "column_decltype"
@@ -67,3 +67,4 @@ vergen = "6"
 
 [features]
 mwal_backend = ["sqld-libsql-bindings/mwal_backend"]
+unix-excl-vfs = ["sqld-libsql-bindings/unix-excl-vfs"]


### PR DESCRIPTION
Useful for Unikraft folks to bypass shared memory requirements.