### PR TITLE
sqld: move bottomless support under a feature flag

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "uuid_unstable"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,13 +8,14 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: --cfg=uuid_unstable
 
 jobs:
   checks:
     runs-on: ubuntu-latest
     name: Run Checks
     env:
-      RUSTFLAGS: -D warnings
+      RUSTFLAGS: -D warnings --cfg=uuid_unstable
     steps:
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,3 @@ members = [
     "sqld-libsql-bindings",
     "testing/end-to-end",
 ]
-
-[patch.crates-io]
-uuid = { git = "https://github.com/psarna/uuid", branch = "stable_v7" }

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -10,7 +10,7 @@ async-lock = "2.6.0"
 async-trait = "0.1.58"
 base64 = "0.21.0"
 bincode = "1.3.3"
-bottomless = { version = "0", path = "../bottomless", features = ["libsql_linked_statically"] }
+bottomless = { version = "0", path = "../bottomless", features = ["libsql_linked_statically"], optional = true }
 byteorder = "1.4.3"
 bytemuck = { version = "1.13.0", features = ["derive"] }
 bytes = { version = "1.2.1", features = ["serde"] }
@@ -68,3 +68,4 @@ vergen = "6"
 [features]
 mwal_backend = ["sqld-libsql-bindings/mwal_backend"]
 unix-excl-vfs = ["sqld-libsql-bindings/unix-excl-vfs"]
+bottomless = ["dep:bottomless"]

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -94,6 +94,7 @@ struct Cli {
     /// Don't display welcome message
     #[clap(long)]
     no_welcome: bool,
+    #[cfg(feature = "bottomless")]
     #[clap(long, env = "SQLD_ENABLE_BOTTOMLESS_REPLICATION")]
     enable_bottomless_replication: bool,
     /// Create a tunnel for the HTTP interface, available publicly via the https://localtunnel.me interface. The tunnel URL will be printed to stdin
@@ -187,6 +188,7 @@ fn config_from_args(args: Cli) -> Result<Config> {
         rpc_server_ca_cert: args.grpc_ca_cert_file,
         #[cfg(feature = "mwal_backend")]
         mwal_addr: args.mwal_addr,
+        #[cfg(feature = "bottomless")]
         enable_bottomless_replication: args.enable_bottomless_replication,
         create_local_http_tunnel: args.create_local_http_tunnel,
         idle_shutdown_timeout: args.idle_shutdown_timeout_s.map(Duration::from_secs),


### PR DESCRIPTION
Bottomless depends on an unstable v7 uuid, so let's move it
under a feature flag - it will make adoption to crates.io
easier.