### PR TITLE
bottomless: drop tokio signals

### DIFF
--- a/bottomless/Cargo.toml
+++ b/bottomless/Cargo.toml
@@ -17,7 +17,7 @@ bytes = "1"
 crc = "3.0.0"
 futures = { version = "0.3.25" }
 sqld-libsql-bindings = { version = "0", path = "../sqld-libsql-bindings" }
-tokio = { version = "1.22.0", features = ["full"] }
+tokio = { version = "1.22.2", features = ["rt-multi-thread", "net", "io-std", "io-util", "time", "macros", "sync", "fs"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 uuid = { version = "1.3", features = ["v7"] }


### PR DESCRIPTION
Not needed, and they do not run on Unikraft.