### PR TITLE
sqld-libsql-bindings: migrate to new rusqlite rev

### DIFF
--- a/sqld-libsql-bindings/Cargo.toml
+++ b/sqld-libsql-bindings/Cargo.toml
@@ -7,12 +7,11 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.66"
-libsql-wasmtime-bindings = "0.2"
 mvfs = { git = "https://github.com/psarna/mvsqlite", branch = "mwal", optional = true }
 mwal = { git = "https://github.com/psarna/mvsqlite", branch = "mwal", optional = true }
-rusqlite = { git = "https://github.com/psarna/rusqlite", rev = "cc7d3f9d5344332c12c34e36be0c055480659d8c", default-features = false, features = [
+rusqlite = { version = "0.28.0", git = "https://github.com/psarna/rusqlite", rev = "cba0667f23949312f122f4e05", default-features = false, features = [
     "buildtime_bindgen",
-    "bundled-libsql",
+    "bundled-libsql-wasm",
     "column_decltype"
 ] }
 tracing = "0.1.37"

--- a/sqld-libsql-bindings/src/lib.rs
+++ b/sqld-libsql-bindings/src/lib.rs
@@ -5,10 +5,6 @@ pub mod ffi;
 pub mod mwal;
 pub mod wal_hook;
 
-pub use libsql_wasm::{
-    libsql_compile_wasm_module, libsql_free_wasm_module, libsql_run_wasm, libsql_wasm_engine_new,
-};
-
 use anyhow::ensure;
 use rusqlite::Connection;
 

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -32,9 +32,9 @@ pin-project-lite = "0.2.9"
 postgres-protocol = "0.6.4"
 prost = "0.11.3"
 regex = "1.7.0"
-rusqlite = { version = "0.28.0", git = "https://github.com/psarna/rusqlite", rev = "cc7d3f9d5344332c12c34e36be0c055480659d8c", default-features = false, features = [
+rusqlite = { version = "0.28.0", git = "https://github.com/psarna/rusqlite", rev = "cba0667f23949312f122f4e05", default-features = false, features = [
     "buildtime_bindgen",
-    "bundled-libsql",
+    "bundled-libsql-wasm",
     "column_decltype"
 ] }
 serde = { version = "1.0.149", features = ["derive"] }


### PR DESCRIPTION
It embeds WebAssembly integration in itself, so we no longer need to directly rely on it.