### PR TITLE
Upgrade Hrana WebSocket connections from HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.63.0"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -1928,6 +1928,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tungstenite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "880b8b1c98a5ec2a505c7c90db6d3f6f1f480af5655d9c5b55facc9382a5a5b5"
+dependencies = [
+ "hyper",
+ "pin-project 1.0.12",
+ "tokio",
+ "tokio-tungstenite",
+ "tungstenite",
+]
+
+[[package]]
 name = "hyperlocal"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2173,9 +2186,9 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libsql-wasmtime-bindings"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8478ca7544bb9af6db74b039b7ade536e4b6063db728d09480a38e456c541ac"
+checksum = "3fa5fdc38eaca73665efc04abce4b4a8e597d8c14483baa166ccfc679c08ee07"
 dependencies = [
  "wasmtime",
 ]
@@ -2183,10 +2196,11 @@ dependencies = [
 [[package]]
 name = "libsqlite3-sys"
 version = "0.25.2"
-source = "git+https://github.com/psarna/rusqlite?rev=4df75df0b0f5ecea2714a8b21bf9f2a0fcfd5905#4df75df0b0f5ecea2714a8b21bf9f2a0fcfd5905"
+source = "git+https://github.com/psarna/rusqlite?rev=cba0667f23949312f122f4e05#cba0667f23949312f122f4e05728a3ebd8ba0076"
 dependencies = [
  "bindgen",
  "cc",
+ "libsql-wasmtime-bindings",
  "pkg-config",
  "vcpkg",
 ]
@@ -3339,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "rusqlite"
 version = "0.28.0"
-source = "git+https://github.com/psarna/rusqlite?rev=4df75df0b0f5ecea2714a8b21bf9f2a0fcfd5905#4df75df0b0f5ecea2714a8b21bf9f2a0fcfd5905"
+source = "git+https://github.com/psarna/rusqlite?rev=cba0667f23949312f122f4e05#cba0667f23949312f122f4e05728a3ebd8ba0076"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -3600,17 +3614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.6",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3808,6 +3811,7 @@ dependencies = [
  "futures",
  "hex",
  "hyper",
+ "hyper-tungstenite",
  "insta",
  "itertools",
  "jsonwebtoken",
@@ -3849,7 +3853,6 @@ name = "sqld-libsql-bindings"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "libsql-wasmtime-bindings",
  "mvfs",
  "mwal",
  "rusqlite",
@@ -4150,9 +4153,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util",
  "log",
@@ -4372,9 +4375,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -4383,7 +4386,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "sha-1",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",
@@ -4484,7 +4487,8 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 [[package]]
 name = "uuid"
 version = "1.3.0"
-source = "git+https://github.com/psarna/uuid?branch=stable_v7#044e1f812d9ac9e1540b240c6815a5c006e82a57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "atomic",
  "getrandom",

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -22,6 +22,7 @@ fallible-iterator = "0.2.0"
 futures = "0.3.25"
 hex = "0.4.3"
 hyper = { version = "0.14.23", features = ["http2"] }
+hyper-tungstenite = "0.9"
 itertools = "0.10.5"
 jsonwebtoken = "8.2.0"
 localtunnel-client = "0.0.13"
@@ -45,7 +46,7 @@ sqlite3-parser = { version = "0.6.0", default-features = false, features = [ "YY
 thiserror = "1.0.38"
 tokio = { version = "1.22.2", features = ["rt-multi-thread", "net", "io-std", "io-util", "time", "macros", "sync", "fs"] }
 tokio-stream = "0.1.11"
-tokio-tungstenite = "0.17.2"
+tokio-tungstenite = "0.18"
 tokio-util = "0.7.4"
 tonic = { version = "0.8.3", features = ["tls"] }
 tower = { version = "0.4.13", features = ["make"] }

--- a/sqld/src/hrana/handshake.rs
+++ b/sqld/src/hrana/handshake.rs
@@ -1,0 +1,128 @@
+use anyhow::{anyhow, bail, Context as _, Result};
+use futures::{SinkExt as _, StreamExt as _};
+use tokio_tungstenite::tungstenite;
+use tungstenite::http;
+
+use super::Upgrade;
+
+#[derive(Debug, Copy, Clone)]
+pub enum Protocol {
+    Hrana1,
+}
+
+#[derive(Debug)]
+pub enum WebSocket {
+    Tcp(tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>),
+    Upgraded(tokio_tungstenite::WebSocketStream<hyper::upgrade::Upgraded>),
+}
+
+pub async fn handshake_tcp(socket: tokio::net::TcpStream) -> Result<WebSocket> {
+    let callback = |req: &http::Request<()>, resp: http::Response<()>| {
+        let (mut resp_parts, _) = resp.into_parts();
+        resp_parts
+            .headers
+            .insert("server", http::HeaderValue::from_static("sqld-hrana-tcp"));
+
+        match negotiate_protocol(req.headers(), &mut resp_parts.headers) {
+            Ok(_protocol) => Ok(http::Response::from_parts(resp_parts, ())),
+            Err(resp_body) => Err(http::Response::from_parts(resp_parts, Some(resp_body))),
+        }
+    };
+
+    let ws_config = Some(get_ws_config());
+    let stream =
+        tokio_tungstenite::accept_hdr_async_with_config(socket, callback, ws_config).await?;
+    Ok(WebSocket::Tcp(stream))
+}
+
+pub async fn handshake_upgrade(upgrade: Upgrade) -> Result<WebSocket> {
+    let mut req = upgrade.request;
+
+    let ws_config = Some(get_ws_config());
+    let (mut resp, stream_fut_res) = match hyper_tungstenite::upgrade(&mut req, ws_config) {
+        Ok((mut resp, stream_fut)) => match negotiate_protocol(req.headers(), resp.headers_mut()) {
+            Ok(_protocol) => (resp, Ok(stream_fut)),
+            Err(msg) => {
+                *resp.status_mut() = http::StatusCode::BAD_REQUEST;
+                *resp.body_mut() = hyper::Body::from(msg.clone());
+                (
+                    resp,
+                    Err(anyhow!("Could not negotiate subprotocol: {}", msg)),
+                )
+            }
+        },
+        Err(err) => {
+            let resp = http::Response::builder()
+                .status(http::StatusCode::BAD_REQUEST)
+                .body(hyper::Body::from(format!("{err}")))
+                .unwrap();
+            (
+                resp,
+                Err(anyhow!(err).context("Protocol error in HTTP upgrade")),
+            )
+        }
+    };
+
+    resp.headers_mut().insert(
+        "server",
+        http::HeaderValue::from_static("sqld-hrana-upgrade"),
+    );
+    if upgrade.response_tx.send(resp).is_err() {
+        bail!("Could not send the HTTP upgrade response")
+    }
+
+    let stream_fut = stream_fut_res?;
+    let stream = stream_fut
+        .await
+        .context("Could not upgrade HTTP request to a WebSocket")?;
+    Ok(WebSocket::Upgraded(stream))
+}
+
+fn negotiate_protocol(
+    req_headers: &http::HeaderMap,
+    resp_headers: &mut http::HeaderMap,
+) -> Result<Protocol, String> {
+    if let Some(protocol_hdr) = req_headers.get("sec-websocket-protocol") {
+        let has_hrana1 = protocol_hdr
+            .to_str()
+            .unwrap_or("")
+            .split(',')
+            .any(|p| p.trim() == "hrana1");
+        if has_hrana1 {
+            resp_headers.append(
+                "sec-websocket-protocol",
+                http::HeaderValue::from_static("hrana1"),
+            );
+            Ok(Protocol::Hrana1)
+        } else {
+            Err("Only the 'hrana1' subprotocol is supported".into())
+        }
+    } else {
+        // Sec-WebSocket-Protocol header not present, assume that the client wants hrana1
+        // According to RFC 6455, we must not set the Sec-WebSocket-Protocol response header
+        Ok(Protocol::Hrana1)
+    }
+}
+
+fn get_ws_config() -> tungstenite::protocol::WebSocketConfig {
+    tungstenite::protocol::WebSocketConfig {
+        max_send_queue: Some(1 << 20),
+        ..Default::default()
+    }
+}
+
+impl WebSocket {
+    pub async fn recv(&mut self) -> Option<tungstenite::Result<tungstenite::Message>> {
+        match self {
+            Self::Tcp(stream) => stream.next().await,
+            Self::Upgraded(stream) => stream.next().await,
+        }
+    }
+
+    pub async fn send(&mut self, msg: tungstenite::Message) -> tungstenite::Result<()> {
+        match self {
+            Self::Tcp(stream) => stream.send(msg).await,
+            Self::Upgraded(stream) => stream.send(msg).await,
+        }
+    }
+}

--- a/sqld/src/hrana/mod.rs
+++ b/sqld/src/hrana/mod.rs
@@ -3,23 +3,38 @@ use crate::database::service::DbFactory;
 use anyhow::{Context as _, Result};
 use enclose::enclose;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot};
 
 mod conn;
+mod handshake;
 mod proto;
 mod session;
 
 struct Server {
     db_factory: Arc<dyn DbFactory>,
     auth: Arc<Auth>,
+    next_conn_id: AtomicU64,
+}
+
+#[derive(Debug)]
+pub struct Upgrade {
+    pub request: hyper::Request<hyper::Body>,
+    pub response_tx: oneshot::Sender<hyper::Response<hyper::Body>>,
 }
 
 pub async fn serve(
     db_factory: Arc<dyn DbFactory>,
-    bind_addr: SocketAddr,
     auth: Arc<Auth>,
+    bind_addr: SocketAddr,
+    mut upgrade_rx: mpsc::Receiver<Upgrade>,
 ) -> Result<()> {
-    let server = Arc::new(Server { db_factory, auth });
+    let server = Arc::new(Server {
+        db_factory,
+        auth,
+        next_conn_id: AtomicU64::new(0),
+    });
 
     let listener = tokio::net::TcpListener::bind(bind_addr)
         .await
@@ -28,22 +43,31 @@ pub async fn serve(
     tracing::info!("Listening for Hrana connections on {}", local_addr);
 
     let mut join_set = tokio::task::JoinSet::new();
-    let mut conn_id = 0;
     loop {
         tokio::select! {
             accept_res = listener.accept() => {
                 let (socket, peer_addr) = accept_res
                     .context("Could not accept a TCP connection")?;
-                tracing::info!("Accepted connection #{} from {}", conn_id, peer_addr);
+                let conn_id = server.next_conn_id.fetch_add(1, Ordering::AcqRel);
+                tracing::info!("Received TCP connection #{} from {}", conn_id, peer_addr);
 
                 join_set.spawn(enclose!{(server, conn_id) async move {
-                    match conn::handle_conn(server, socket, conn_id).await {
-                        Ok(_) => tracing::info!("Connection #{} was terminated", conn_id),
-                        Err(err) => tracing::error!("Connection #{} failed: {:?}", conn_id, err),
+                    match conn::handle_tcp(server, socket, conn_id).await {
+                        Ok(_) => tracing::info!("TCP connection #{} was terminated", conn_id),
+                        Err(err) => tracing::error!("TCP connection #{} failed: {:?}", conn_id, err),
                     }
                 }});
+            },
+            Some(upgrade) = upgrade_rx.recv() => {
+                let conn_id = server.next_conn_id.fetch_add(1, Ordering::AcqRel);
+                tracing::info!("Received HTTP upgrade connection #{}", conn_id);
 
-                conn_id += 1;
+                join_set.spawn(enclose!{(server, conn_id) async move {
+                    match conn::handle_upgrade(server, upgrade, conn_id).await {
+                        Ok(_) => tracing::info!("HTTP upgrade connection #{} was terminated", conn_id),
+                        Err(err) => tracing::error!("HTTP upgrade connection #{} failed: {:?}", conn_id, err),
+                    }
+                }});
             },
             Some(task_res) = join_set.join_next() => {
                 task_res.expect("Hrana connection task failed")


### PR DESCRIPTION
Our infrastructure on Fly.io can only handle connections on port 443, so we need to use the same port for HTTP and for Hrana. Fortunately, WebSockets were specifically designed to allow this! The WebSocket handshake is an HTTP request with `Connection: upgrade` and `Upgrade: websocket` headers, so we can just hijack these HTTP requests and pass them to Hrana.

Note that Hrana still needs to be enabled using the `-l` flag, so it's currently impossible to enable Hrana without binding to a Hrana-specific port in addition to the HTTP port.