### PR TITLE
Add `last_insert_rowid` to Hrana statement result

### DIFF
--- a/docs/HRANA_SPEC.md
+++ b/docs/HRANA_SPEC.md
@@ -319,7 +319,8 @@ separated by a semicolon is not supported.
 type StmtResult = {
     "cols": Array<Col>,
     "rows": Array<Array<Value>>,
-    "affected_row_count": uint64,
+    "affected_row_count": int32,
+    "last_insert_rowid": string | null,
 }
 
 type Col = {
@@ -328,10 +329,18 @@ type Col = {
 ```
 
 The result of executing an SQL statement contains information about the returned
-columns in `cols`, the returned rows in `rows` (the array is empty if the
-statement did not produce any rows or if `want_rows` was `false` in the request)
-and the number of rows that were changed by the statement in
-`affected_row_count`.
+columns in `cols` and the returned rows in `rows` (the array is empty if the
+statement did not produce any rows or if `want_rows` was `false` in the request).
+
+`affected_row_count` counts the number of rows that were changed by the
+statement. This is meaningful only if the statement was an INSERT, UPDATE or
+DELETE, and the value is otherwise undefined.
+
+`last_insert_rowid` is the ROWID of the last successful insert into a rowid
+table. The rowid value is a 64-bit signed integer encoded as a string. For
+other statements, the value is undefined.
+
+### Values
 
 ```
 type Value =

--- a/sqld/proto/proxy.proto
+++ b/sqld/proto/proxy.proto
@@ -47,6 +47,7 @@ message ResultRows {
     repeated Column   column_descriptions = 1;
     repeated Row      rows = 2;
     uint64            affected_row_count = 3;
+    optional int64    last_insert_rowid = 4;
 }
 
 message Value {

--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -63,10 +63,18 @@ fn execute_query(conn: &rusqlite::Connection, stmt: &Statement, params: Params) 
         false => 0,
     };
 
+    // sqlite3_last_insert_rowid() only makes sense for INSERTs into a rowid table. we can't detect
+    // a rowid table, but at least we can detect an INSERT
+    let last_insert_rowid = match stmt.is_insert {
+        true => Some(conn.last_insert_rowid()),
+        false => None,
+    };
+
     Ok(QueryResponse::ResultSet(ResultSet {
         columns,
         rows,
         affected_row_count,
+        last_insert_rowid,
         include_column_defs: true,
     }))
 }

--- a/sqld/src/hrana/proto.rs
+++ b/sqld/src/hrana/proto.rs
@@ -83,6 +83,8 @@ pub struct StmtResult {
     pub cols: Vec<Col>,
     pub rows: Vec<Vec<Value>>,
     pub affected_row_count: u64,
+    #[serde(with = "option_i64_as_str")]
+    pub last_insert_rowid: Option<i64>,
 }
 
 #[derive(Serialize, Debug)]
@@ -131,6 +133,14 @@ mod i64_as_str {
                 &"decimal integer as a string",
             )
         })
+    }
+}
+
+mod option_i64_as_str {
+    use serde::{ser, Serialize as _};
+
+    pub fn serialize<S: ser::Serializer>(value: &Option<i64>, ser: S) -> Result<S::Ok, S::Error> {
+        value.map(|v| v.to_string()).serialize(ser)
     }
 }
 

--- a/sqld/src/hrana/session.rs
+++ b/sqld/src/hrana/session.rs
@@ -251,6 +251,7 @@ fn proto_stmt_result_from_query_response(query_response: QueryResponse) -> proto
         cols: proto_cols,
         rows: proto_rows,
         affected_row_count: result_set.affected_row_count,
+        last_insert_rowid: result_set.last_insert_rowid,
     }
 }
 

--- a/sqld/src/query.rs
+++ b/sqld/src/query.rs
@@ -149,6 +149,7 @@ pub struct ResultSet {
     pub columns: Vec<Column>,
     pub rows: Vec<Row>,
     pub affected_row_count: u64,
+    pub last_insert_rowid: Option<i64>,
     pub include_column_defs: bool,
 }
 
@@ -158,6 +159,7 @@ impl ResultSet {
             columns: Vec::new(),
             rows: Vec::new(),
             affected_row_count: 0,
+            last_insert_rowid: None,
             include_column_defs: col_defs,
         }
     }
@@ -226,6 +228,7 @@ impl From<ResultSet> for ResultRows {
             column_descriptions,
             rows,
             affected_row_count: other.affected_row_count,
+            last_insert_rowid: other.last_insert_rowid,
         }
     }
 }
@@ -257,6 +260,7 @@ impl From<ResultRows> for ResultSet {
             columns,
             rows,
             affected_row_count: result_rows.affected_row_count,
+            last_insert_rowid: result_rows.last_insert_rowid,
             include_column_defs: true,
         }
     }

--- a/sqld/src/query_analysis.rs
+++ b/sqld/src/query_analysis.rs
@@ -12,6 +12,7 @@ pub struct Statement {
     pub kind: StmtKind,
     /// Is the statement an INSERT, UPDATE or DELETE?
     pub is_iud: bool,
+    pub is_insert: bool,
 }
 
 impl Default for Statement {
@@ -88,6 +89,7 @@ impl Statement {
             // empty statement is arbitrarely made of the read kind so it is not send to a writer
             kind: StmtKind::Read,
             is_iud: false,
+            is_insert: false,
         }
     }
 
@@ -99,6 +101,7 @@ impl Statement {
             stmt,
             kind: StmtKind::Write,
             is_iud: false,
+            is_insert: false,
         }
     }
 
@@ -129,11 +132,13 @@ impl Statement {
                 c,
                 Cmd::Stmt(Stmt::Insert { .. } | Stmt::Update { .. } | Stmt::Delete { .. })
             );
+            let is_insert = matches!(c, Cmd::Stmt(Stmt::Insert { .. }));
 
             Ok(Statement {
                 stmt: c.to_string(),
                 kind,
                 is_iud,
+                is_insert,
             })
         }
         // The parser needs to be boxed because it's large, and you don't want it on the stack.


### PR DESCRIPTION
This information may be useful, and it's required to implement some client libraries (for example, to emulate the Node.js `sqlite3` package).