### PR TITLE
sqlc: build a static lib as well

### DIFF
--- a/sqlc/Cargo.toml
+++ b/sqlc/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [lib]
 name = "sqlc"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 anyhow = "1.0.66"


### PR DESCRIPTION
A static library is going to be useful for projects which intend to compile-in libSQL/SQLite statically.