### PR TITLE
libsql: optionally strip "file:" prefix from an URL

### DIFF
--- a/sqlc/src/lib.rs
+++ b/sqlc/src/lib.rs
@@ -77,6 +77,7 @@ pub struct sqlite3 {
 
 impl sqlite3 {
     fn connect(addr: &str) -> Result<Self> {
+        let addr = addr.strip_prefix("file:").unwrap_or(addr);
         let mut conn = postgres::Connection::connect(addr)?;
         conn.send_startup()?;
         let (_metadata, rows) = conn.wait_until_ready()?;


### PR DESCRIPTION
This is arguably a hack - one to skip JDBC validation for JDBC environment, which will in turn make DBeaver (and similar Java tools) way easier to integrate.