### PR TITLE
sqlc: fix and work around DBeaver integration issues

### DIFF
--- a/sqlc/src/lib.rs
+++ b/sqlc/src/lib.rs
@@ -17,6 +17,14 @@ use std::ops::Range;
 use std::os::raw::{c_char, c_int, c_void};
 use std::rc::Rc;
 use tracing::trace;
+
+/* NOTE: Uncomment for DBeaver debugging sessions instead of tracing::trace!
+macro_rules! trace {
+    ($($arg:tt)*) => {{
+        println!($($arg)*);
+    }};
+}
+*/
 use unwrap_or::unwrap_ok_or;
 
 thread_local! {
@@ -35,6 +43,7 @@ macro_rules! define_stub {
         pub extern "C" fn $name() -> c_int {
             let func_name = std::stringify!($name);
             trace!("STUB {}", func_name);
+            println!("STUB {func_name}");
             set_error_message(format!("{} not implemented", func_name));
             SQLITE_ERROR
         }
@@ -316,15 +325,21 @@ pub extern "C" fn sqlite3_prepare_v2(
         return SQLITE_ERROR;
     });
     let sql = sql.to_string();
-    unsafe {
-        let stmt = Statement::new(database, sql);
-        let ptr = Box::new(sqlite3_stmt { inner: stmt });
-        *ppStmt = Box::into_raw(ptr);
-    }
+    trace!("QUERY prepared: {sql}");
+    let mut stmt = Statement::new(database, sql);
+    let ptr = Box::new(sqlite3_stmt { inner: stmt });
+    unsafe { *ppStmt = Box::into_raw(ptr) }
     if !pzTail.is_null() {
         unsafe { *pzTail = "\0".as_ptr() as *const c_char };
     }
     SQLITE_OK
+}
+
+#[no_mangle]
+pub extern "C" fn sqlite3_bind_parameter_count(_stmt: *mut sqlite3_stmt) -> c_int {
+    trace!("Bind count");
+    tracing::warn!("STUB sqlite3_bind_parameter_count");
+    0
 }
 
 #[no_mangle]
@@ -492,20 +507,32 @@ pub extern "C" fn sqlite3_column_count(stmt: *mut sqlite3_stmt) -> c_int {
     trace!("TRACE sqlite3_column_count");
     let stmt = to_stmt(stmt);
     if let Some(metadata) = stmt.metadata.as_ref() {
+        trace!("Count: {}", metadata.col_names.len());
         metadata.col_types.len().try_into().unwrap()
     } else {
+        trace!("Count: 0 (no metadata)");
         0
     }
 }
 
 #[no_mangle]
-pub extern "C" fn sqlite3_column_name(_stmt: *mut sqlite3_stmt, _n: c_int) -> *const c_char {
-    trace!("STUB sqlite3_column_name");
-    std::ptr::null()
+pub extern "C" fn sqlite3_column_name(stmt: *mut sqlite3_stmt, n: c_int) -> *const c_char {
+    let stmt = to_stmt(stmt);
+    if let Some(metadata) = stmt.metadata.as_ref() {
+        metadata
+            .col_names
+            .get(n as usize)
+            .map(|s| s.as_ptr() as *const c_char)
+            .unwrap_or("\0".as_ptr() as *const c_char) // FIXME: does not have the trailing \0 character
+    } else {
+        trace!("Column name: (empty) (no metadata)");
+        "\0".as_ptr() as *const c_char
+    }
 }
 
 const SQLITE_INTEGER: c_int = 1;
 const SQLITE3_TEXT: c_int = 3;
+const SQLITE_NULL: c_int = 5;
 
 #[no_mangle]
 pub extern "C" fn sqlite3_column_type(stmt: *mut sqlite3_stmt, n: c_int) -> c_int {
@@ -515,6 +542,7 @@ pub extern "C" fn sqlite3_column_type(stmt: *mut sqlite3_stmt, n: c_int) -> c_in
     match ty.oid() {
         25 => SQLITE3_TEXT,
         1700 => SQLITE_INTEGER,
+        705 => SQLITE_NULL,
         _ => todo!("{}", ty.oid()),
     }
 }
@@ -527,12 +555,12 @@ pub extern "C" fn sqlite3_column_decltype(_stmt: *mut sqlite3_stmt, _n: c_int) -
 
 #[no_mangle]
 pub extern "C" fn sqlite3_column_bytes(stmt: *mut sqlite3_stmt, n: c_int) -> c_int {
-    trace!("TRACE sqlite3_column_bytes");
+    trace!("TRACE sqlite3_column_bytes: {n}");
     let stmt = to_stmt(stmt);
     if let Some((_, column_ranges)) = &stmt.current_row {
         column_ranges[n as usize]
             .as_ref()
-            .unwrap()
+            .unwrap_or(&(0..0))
             .len()
             .try_into()
             .unwrap()
@@ -607,7 +635,6 @@ define_stub!(sqlite3_backup_init);
 define_stub!(sqlite3_backup_pagecount);
 define_stub!(sqlite3_backup_remaining);
 define_stub!(sqlite3_backup_step);
-define_stub!(sqlite3_bind_parameter_count);
 define_stub!(sqlite3_bind_parameter_index);
 define_stub!(sqlite3_bind_parameter_name);
 define_stub!(sqlite3_blob_bytes);

--- a/sqlc/src/postgres.rs
+++ b/sqlc/src/postgres.rs
@@ -159,7 +159,8 @@ impl Connection {
                 trace!("TRACE postgres -> RowDescription");
                 let mut fields = row_description.fields();
                 while let Some(field) = fields.next()? {
-                    metadata.col_names.push(field.name().into());
+                    let name = format!("{}\0", field.name());
+                    metadata.col_names.push(name);
                     let ty = Type::from_oid(field.type_oid()).unwrap();
                     metadata.col_types.push(ty);
                 }


### PR DESCRIPTION
This commit implements some of the stubs, so that we make DBeaver work over `sqlc`.
Also, a few DBeaver-specific statements are special-cased
so that DBeaver is capable of booting table schemas.
Once we implement enough stubs and add a protocol message
for preparing a statement server-side, they can be dropped.

In order to work with `sqld`, the following mini-patch needs to be added too: https://github.com/psarna/sqld/commit/4615f505b3cd9627aa6845db19e14b7fe4e1875f. The fact we need it is very likely a subtle `sqld` bug, since DBeaver uses a rather obscure `ESCAPE '\'` statement, that seems to trigger an error in sqld.