### PR TITLE
log compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,9 +2152,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libgit2-sys"
@@ -2352,6 +2352,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2508,6 +2518,20 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3836,6 +3860,8 @@ dependencies = [
  "itertools",
  "jsonwebtoken",
  "localtunnel-client",
+ "memmap",
+ "nix",
  "once_cell",
  "parking_lot",
  "pgwire",
@@ -3903,6 +3929,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -54,6 +54,9 @@ tower-http = { version = "0.3.5", features = ["compression-full", "cors", "trace
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 uuid = { version = "1.3", features = ["v4", "serde"] }
+nix = { version = "0.26.2", features = ["fs"] }
+tempfile = "3.3.0"
+memmap = "0.7.0"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/sqld/proto/replication_log.proto
+++ b/sqld/proto/replication_log.proto
@@ -24,4 +24,5 @@ message Frame {
 service ReplicationLog {
     rpc Hello(HelloRequest) returns (HelloResponse) {}
     rpc LogEntries(LogOffset) returns (stream Frame) {}
+    rpc Snapshot(LogOffset) returns (stream Frame) {}
 }

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -13,7 +13,7 @@ use database::write_proxy::WriteProxyDbFactory;
 use once_cell::sync::Lazy;
 #[cfg(feature = "mwal_backend")]
 use once_cell::sync::OnceCell;
-use replication::logger::{ReplicationLogger, ReplicationLoggerHook};
+use replication::{ReplicationLogger, ReplicationLoggerHook};
 use rpc::run_rpc_server;
 use tokio::sync::{mpsc, Notify};
 use tokio::task::JoinSet;
@@ -89,6 +89,7 @@ pub struct Config {
     pub create_local_http_tunnel: bool,
     pub idle_shutdown_timeout: Option<Duration>,
     pub load_from_dump: Option<PathBuf>,
+    pub max_log_size: u64,
 }
 
 async fn run_service(
@@ -214,7 +215,10 @@ async fn start_primary(
     idle_shutdown_layer: Option<IdleShutdownLayer>,
 ) -> anyhow::Result<()> {
     let is_fresh_db = check_fresh_db(&config.db_path);
-    let logger = Arc::new(ReplicationLogger::open(&config.db_path)?);
+    let logger = Arc::new(ReplicationLogger::open(
+        &config.db_path,
+        config.max_log_size,
+    )?);
     let logger_clone = logger.clone();
     let path_clone = config.db_path.clone();
     #[cfg(feature = "bottomless")]

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -110,6 +110,11 @@ struct Cli {
     /// Requires that the node is not in replica mode
     #[clap(long, env = "SQLD_LOAD_DUMP_PATH", conflicts_with = "primary_grpc_url")]
     load_from_dump: Option<PathBuf>,
+
+    /// Maximum size the replication log is allowed to grow (in MB).
+    /// defaults to 200MB.
+    #[clap(long, env = "SQLD_MAX_LOG_SIZE", default_value = "200")]
+    max_log_size: u64,
 }
 
 impl Cli {
@@ -198,6 +203,7 @@ fn config_from_args(args: Cli) -> Result<Config> {
         create_local_http_tunnel: args.create_local_http_tunnel,
         idle_shutdown_timeout: args.idle_shutdown_timeout_s.map(Duration::from_secs),
         load_from_dump: args.load_from_dump,
+        max_log_size: args.max_log_size,
     })
 }
 

--- a/sqld/src/replication/log_compaction.rs
+++ b/sqld/src/replication/log_compaction.rs
@@ -1,0 +1,228 @@
+use std::collections::HashSet;
+use std::fs::create_dir_all;
+use std::mem::size_of;
+use std::os::unix::prelude::FileExt;
+use std::path::{Path, PathBuf};
+
+use bytemuck::bytes_of;
+use crossbeam::channel::{bounded, Sender};
+use tempfile::NamedTempFile;
+use uuid::Uuid;
+
+use crate::replication::logger::FrameHeader;
+
+use super::logger::LogFile;
+use super::snapshot::SnapshotFileHeader;
+
+#[derive(Clone)]
+pub struct LogCompactor {
+    sender: Sender<(LogFile, PathBuf, u32)>,
+}
+
+impl LogCompactor {
+    pub fn new(path: PathBuf) -> Self {
+        // we create a 0 sized channel, in order to create backpressure when we can't
+        // keep up with snapshop creation: if there isn't any ongoind comptaction task processing,
+        // the compact does not block, and the log is compacted in the background. Otherwise, the
+        // block until there is a free slot to perform compaction.
+        let (sender, receiver) = bounded::<(LogFile, PathBuf, u32)>(0);
+        let _handle = std::thread::spawn(move || {
+            while let Ok((file, log_path, size_after)) = receiver.recv() {
+                match perform_compaction(&path, size_after, file) {
+                    Ok(name) => {
+                        tracing::info!("snapshot `{name}` successfully created");
+                        if let Err(e) = std::fs::remove_file(&log_path) {
+                            tracing::error!(
+                                "failed to remove old log file `{}`: {e}",
+                                log_path.display()
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("fatal error creating snapshot: {e}");
+                    }
+                }
+            }
+        });
+
+        Self { sender }
+    }
+
+    /// Sends a compaction task to the background compaction thread. Blocks if a compaction task is
+    /// already ongoing.
+    pub fn compact(&self, file: LogFile, path: PathBuf, size_after: u32) -> anyhow::Result<()> {
+        self.sender.send((file, path, size_after))?;
+        Ok(())
+    }
+}
+
+fn perform_compaction(
+    db_path: &Path,
+    size_after: u32,
+    file_to_compact: LogFile,
+) -> anyhow::Result<String> {
+    let header = *file_to_compact.header();
+    let mut snapshot_header = SnapshotFileHeader {
+        db_id: header.db_id,
+        start_frame_id: header.start_frame_id,
+        end_frame_index: header.start_frame_id + header.frame_count - 1,
+        size_after,
+        frame_count: 0,
+        _pad: 0,
+    };
+
+    let snapshot_file = NamedTempFile::new_in(db_path)?;
+    snapshot_file
+        .as_file()
+        .write_all_at(bytes_of(&snapshot_header), 0)?;
+    let mut seen = HashSet::new();
+    let mut frame_count = 0;
+    // We iterate on the frames starting from the end of the log and working our way backward. We
+    // make sure that only the most recent version of each file is present in the resulting
+    // snapshot.
+    //
+    // The snapshot file contains the most recent version of each page, in descending frame id
+    // order. That last part is important for when we read it later on.
+    for frame in file_to_compact.rev_frames_iter()? {
+        let frame = frame?;
+        let page_no = frame.header.page_no;
+        if !seen.contains(&page_no) {
+            let byte_offset = size_of::<SnapshotFileHeader>() + frame_count * LogFile::FRAME_SIZE;
+            seen.insert(page_no);
+            snapshot_file
+                .as_file()
+                .write_all_at(bytes_of(&frame.header), byte_offset as u64)?;
+            snapshot_file
+                .as_file()
+                .write_all_at(&frame.data, (byte_offset + size_of::<FrameHeader>()) as u64)?;
+
+            frame_count += 1;
+        }
+    }
+
+    // update snapshot header
+    snapshot_header.frame_count = frame_count as _;
+    snapshot_file
+        .as_file()
+        .write_all_at(bytes_of(&snapshot_header), 0)?;
+
+    let snapshot_name = format!(
+        "{}-{}-{}.snap",
+        Uuid::from_u128(header.db_id),
+        header.start_frame_id,
+        header.start_frame_id + header.frame_count - 1,
+    );
+
+    // persist the snapshot
+    let snapshot_dir = db_path.join("snapshots");
+    create_dir_all(&snapshot_dir)?;
+    snapshot_file.persist(snapshot_dir.join(&snapshot_name))?;
+
+    Ok(snapshot_name)
+}
+
+#[cfg(test)]
+mod test {
+    use std::fs::read;
+    use std::{thread, time::Duration};
+
+    use bytemuck::{pod_read_unaligned, try_from_bytes};
+    use bytes::Bytes;
+    use tempfile::tempdir;
+
+    use crate::replication::logger::{
+        FrameHeader, LogFileHeader, WalFrame, WAL_MAGIC, WAL_PAGE_SIZE,
+    };
+    use crate::replication::snapshot::SnapshotFile;
+
+    use super::*;
+
+    #[test]
+    fn compact_file_create_snapshot() {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        let mut log_file = LogFile::new(temp.as_file().try_clone().unwrap(), 0).unwrap();
+        let db_id = Uuid::new_v4();
+        let expected_header = LogFileHeader {
+            magic: WAL_MAGIC,
+            start_checksum: 0,
+            db_id: db_id.as_u128(),
+            start_frame_id: 0,
+            frame_count: 50,
+            version: 0,
+            page_size: WAL_PAGE_SIZE,
+            _pad: 0,
+        };
+        log_file.write_header(&expected_header).unwrap();
+
+        // add 50 pages, each one in two versions
+        let mut frame_id = 0;
+        for _ in 0..2 {
+            for i in 0..25 {
+                let frame_header = FrameHeader {
+                    frame_id,
+                    checksum: 0,
+                    page_no: i,
+                    size_after: i + 1,
+                };
+                let data = std::iter::repeat(0).take(4096).collect();
+                let frame = WalFrame {
+                    header: frame_header,
+                    data,
+                };
+                log_file.push_frame(frame).unwrap();
+
+                frame_id += 1;
+            }
+        }
+
+        let dump_dir = tempdir().unwrap();
+        let compactor = LogCompactor::new(dump_dir.path().to_path_buf());
+        compactor
+            .compact(log_file, temp.path().to_path_buf(), 25)
+            .unwrap();
+
+        thread::sleep(Duration::from_secs(1));
+
+        let snapshot_path = dump_dir
+            .path()
+            .join("snapshots")
+            .join(format!("{}-{}-{}.snap", db_id, 0, 49));
+        let snapshot = read(&snapshot_path).unwrap();
+        let header: &SnapshotFileHeader =
+            try_from_bytes(&snapshot[..std::mem::size_of::<SnapshotFileHeader>()]).unwrap();
+
+        assert_eq!(header.start_frame_id, 0);
+        assert_eq!(header.end_frame_index, 49);
+        assert_eq!(header.frame_count, 25);
+        assert_eq!(header.db_id, db_id.as_u128());
+        assert_eq!(header.size_after, 25);
+
+        let mut seen_frames = HashSet::new();
+        let mut seen_page_no = HashSet::new();
+        let data = &snapshot[std::mem::size_of::<SnapshotFileHeader>()..];
+        data.chunks(LogFile::FRAME_SIZE).for_each(|f| {
+            let frame = WalFrame::decode(Bytes::copy_from_slice(f)).unwrap();
+            assert!(!seen_frames.contains(&frame.header.frame_id));
+            assert!(!seen_page_no.contains(&frame.header.page_no));
+            seen_page_no.insert(frame.header.page_no);
+            seen_frames.insert(frame.header.frame_id);
+            assert!(frame.header.frame_id >= 25);
+        });
+
+        assert_eq!(seen_frames.len(), 25);
+        assert_eq!(seen_page_no.len(), 25);
+
+        let snapshot_file = SnapshotFile::open(&snapshot_path).unwrap();
+
+        let frames = snapshot_file.frames_iter_until(0);
+        let mut expected_frame_id = 49;
+        for frame in frames {
+            let frame = frame.unwrap();
+            let header: FrameHeader = pod_read_unaligned(&frame[..size_of::<FrameHeader>()]);
+            assert_eq!(header.frame_id, expected_frame_id);
+            expected_frame_id -= 1;
+        }
+
+        assert_eq!(expected_frame_id, 24);
+    }
+}

--- a/sqld/src/replication/mod.rs
+++ b/sqld/src/replication/mod.rs
@@ -1,2 +1,6 @@
 pub mod client;
-pub mod logger;
+mod log_compaction;
+mod logger;
+mod snapshot;
+
+pub use logger::{FrameId, LogReadError, ReplicationLogger, ReplicationLoggerHook};

--- a/sqld/src/replication/snapshot.rs
+++ b/sqld/src/replication/snapshot.rs
@@ -1,0 +1,69 @@
+use std::fs::File;
+use std::mem::size_of;
+use std::os::unix::prelude::FileExt;
+use std::path::Path;
+
+use bytemuck::{pod_read_unaligned, Pod, Zeroable};
+use bytes::{Bytes, BytesMut};
+
+use super::logger::{FrameHeader, LogFile};
+
+#[derive(Debug, Copy, Clone, Zeroable, Pod, PartialEq, Eq)]
+#[repr(C)]
+pub struct SnapshotFileHeader {
+    /// id of the database
+    pub db_id: u128,
+    /// first frame in the snapshot
+    pub start_frame_id: u64,
+    /// end frame in the snapshot
+    pub end_frame_index: u64,
+    /// number of frames in the snapshot
+    pub frame_count: u64,
+    /// safe of the database after applying the snapshot
+    pub size_after: u32,
+    pub _pad: u32,
+}
+
+pub struct SnapshotFile {
+    file: File,
+    header: SnapshotFileHeader,
+}
+
+impl SnapshotFile {
+    pub fn open(path: &Path) -> anyhow::Result<Self> {
+        let file = File::open(path)?;
+        let mut header_buf = [0; size_of::<SnapshotFileHeader>()];
+        file.read_exact_at(&mut header_buf, 0)?;
+        let header: SnapshotFileHeader = pod_read_unaligned(&header_buf);
+
+        Ok(Self { file, header })
+    }
+
+    /// Iterator on the frames contained in the snapshot file, in reverse frame_id order.
+    pub fn frames_iter_until(
+        &self,
+        offset: u64,
+    ) -> impl Iterator<Item = anyhow::Result<Bytes>> + '_ {
+        let mut current_offset = 0;
+        std::iter::from_fn(move || {
+            if current_offset >= self.header.frame_count {
+                return None;
+            }
+            let read_offset = size_of::<SnapshotFileHeader>() as u64
+                + current_offset * LogFile::FRAME_SIZE as u64;
+            current_offset += 1;
+            let mut buf = BytesMut::zeroed(LogFile::FRAME_SIZE);
+            match self.file.read_exact_at(&mut buf, read_offset as _) {
+                Ok(_) => {
+                    let header: FrameHeader = pod_read_unaligned(&buf[..size_of::<FrameHeader>()]);
+                    if header.frame_id <= offset {
+                        None
+                    } else {
+                        Some(Ok(buf.freeze()))
+                    }
+                }
+                Err(e) => Some(Err(e.into())),
+            }
+        })
+    }
+}

--- a/sqld/src/rpc/mod.rs
+++ b/sqld/src/rpc/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tower::util::option_layer;
 
 use crate::database::service::DbFactory;
-use crate::replication::logger::ReplicationLogger;
+use crate::replication::ReplicationLogger;
 use crate::rpc::proxy::rpc::proxy_server::ProxyServer;
 use crate::rpc::proxy::ProxyService;
 use crate::rpc::replication_log::rpc::replication_log_server::ReplicationLogServer;


### PR DESCRIPTION
# Log compaction and snapshotting

This PR enables log compaction and snapshotting.

## Motivation

The replication log follows sqlite WAL and grows indefinitely. Fortunately, it contains a lot of duplicate data, so we can compress it by getting by keeping only the most recent version of each page. This is what this PR does: whenever the replication log grows above some threshold, a new log is created, and the old log is compacted. This operation is done atomically, so the compaction can happen in the background, while we keep writing to the old log.

## Log compaction:

The log compaction is very straightforward. We iterate backwards through the replication log, and write the frames to the snapshot file. We keep track of what pages we have already seen, and ignore older version of them. When the snapshot is finished, we remove the old log file.

Notice how the frames are now in a reverse order in the snapshot: starting with the most recent, and ending with the oldest.

## Snapshoting:

Whenever a replica asks for a frame that is not present in the current log (i.e, it asks for a frame index less than the log starting frame id), then it sends the replica an error, asking it to ask for a snapshot.

The replica receives this message, and immediately asks for a snapshot, sending over the frame id that got it rejected in the first place.
The primary looks for a snapshot containing the request frame, and starts iterating through it, until it reaches a frame that is less than the requested one.

This mechanism allows us to send partial snapshot: the replica gets minimal amount of frames required to get up to speed.

The replica writes the snapshot frames to a file, and then `mmap` that file to build a chained list of pages to append to the WAL.


## Future work:

This PR was getting a bit too long, so I left out some work for followup PRs:

- Even though the snapshot significantly compresses the size of the log, a new log is created, that will lead to the creation of a new snapshot. Those snapshot will pile up and we're back at step one. The next step is to merge snapshots into bigger snapshots, and get rid of the older snapshots.
- Every query for a frame causes a read to the snapshot/log. To speed things up, let's add a MRU cache.
- Explore compression
