### PR TITLE
Add conditional execution and compute requests to Hrana

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2185,6 +2185,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
+name = "libsql-client"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff8fc509fdc221ac8c30e00bd1b1881fb8a340061adf4c983d8288e0270d194"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.21.0",
+ "num-traits",
+ "reqwest",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "libsql-wasmtime-bindings"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,6 +3306,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3300,16 +3316,20 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -3781,9 +3801,9 @@ dependencies = [
  "bytes 1.4.0",
  "fallible-iterator",
  "fn-error-context",
- "postgres-protocol",
- "postgres-types",
+ "libsql-client",
  "scram",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "unwrap_or",
@@ -4080,9 +4100,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes 1.4.0",
@@ -4095,7 +4115,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/docs/HRANA_SPEC.md
+++ b/docs/HRANA_SPEC.md
@@ -426,6 +426,7 @@ resources on the server. The result of this op is NULL.
 type ComputeExpr =
     | Value
     | { "type": "var", "var": int32 }
+    | { "type": "not", "expr": ComputeExpr }
 ```
 
 Expressions evaluate to values. Expressions are pure, their evaluation does not
@@ -434,9 +435,11 @@ have side effects.
 - Each `Value` is also an expression that evaluates to itself.
 - `var` evaluates to the current value of given variable. If the variable is not
 set, an error is returned.
+- `not` evaluates `expr` and returns the logical negative: if `expr` evaluated
+to true, it returns integer 0, otherwise it returns integer 1.
 
 When a value is treated as a boolean (such as in the condition of `execute`
-request), they are converted as follows:
+request or in `not` expression), they are converted as follows:
 
 - NULL is false.
 - Integers and floats are true iff they are nonzero.

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -38,7 +38,7 @@ rusqlite = { version = "0.28.0", git = "https://github.com/psarna/rusqlite", rev
     "bundled-libsql-wasm",
     "column_decltype"
 ] }
-serde = { version = "1.0.149", features = ["derive"] }
+serde = { version = "1.0.149", features = ["derive", "rc"] }
 serde_json = "1.0.91"
 smallvec = "1.10.0"
 sqld-libsql-bindings = { version = "0", path = "../sqld-libsql-bindings" }

--- a/sqld/src/hrana/compute.rs
+++ b/sqld/src/hrana/compute.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use once_cell::sync::Lazy;
+
+use super::proto;
+use super::session::ResponseError;
+
+pub type Result<T> = std::result::Result<T, ResponseError>;
+
+#[derive(Debug, Default)]
+pub struct Ctx {
+    vars: HashMap<i32, Arc<proto::Value>>,
+}
+
+pub fn eval_ops(ctx: &mut Ctx, ops: &[proto::ComputeOp]) -> Result<Vec<Arc<proto::Value>>> {
+    ops.iter().map(|op| eval_op(ctx, op)).collect()
+}
+
+pub fn eval_op(ctx: &mut Ctx, op: &proto::ComputeOp) -> Result<Arc<proto::Value>> {
+    match op {
+        proto::ComputeOp::Set { var, expr } => {
+            let value = eval_expr(ctx, expr)?;
+            ctx.vars.insert(*var, value);
+            Ok(NULL.clone())
+        }
+        proto::ComputeOp::Unset { var } => {
+            ctx.vars.remove(var);
+            Ok(NULL.clone())
+        }
+        proto::ComputeOp::Eval { expr } => eval_expr(ctx, expr),
+    }
+}
+
+static NULL: Lazy<Arc<proto::Value>> = Lazy::new(|| Arc::new(proto::Value::Null));
+
+pub fn eval_expr(ctx: &Ctx, expr: &proto::ComputeExpr) -> Result<Arc<proto::Value>> {
+    match expr {
+        proto::ComputeExpr::Expr(expr) => match expr {
+            proto::ComputeExpr_::Var { var } => match ctx.vars.get(var) {
+                Some(value) => Ok(value.clone()),
+                None => Err(ResponseError::ExprUnsetVar { var: *var }),
+            },
+        },
+        proto::ComputeExpr::Value(value) => Ok(value.clone()),
+    }
+}
+
+pub fn is_true(value: &proto::Value) -> bool {
+    match value {
+        proto::Value::Null => false,
+        proto::Value::Integer { value } => *value != 0,
+        proto::Value::Float { value } => *value != 0.,
+        proto::Value::Text { value } => !value.is_empty(),
+        proto::Value::Blob { value } => !value.is_empty(),
+    }
+}

--- a/sqld/src/hrana/mod.rs
+++ b/sqld/src/hrana/mod.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 
+mod compute;
 mod conn;
 mod handshake;
 mod proto;

--- a/sqld/src/hrana/proto.rs
+++ b/sqld/src/hrana/proto.rs
@@ -150,6 +150,7 @@ pub enum ComputeExpr {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ComputeExpr_ {
     Var { var: i32 },
+    Not { expr: Box<ComputeExpr> },
 }
 
 #[derive(Serialize, Debug)]

--- a/sqld/src/hrana/session.rs
+++ b/sqld/src/hrana/session.rs
@@ -163,7 +163,7 @@ pub(super) async fn handle_request(
                 Some(expr) => {
                     let ctx = session.compute_ctx.lock();
                     let value = compute::eval_expr(&ctx, expr)?;
-                    compute::is_true(&value)
+                    compute::is_truthy(&value)
                 }
                 None => true,
             };


### PR DESCRIPTION
The whole "edge" is (only) about reducing latency, so sqld clients should strive to minimize the number of network roundtrips. This means that users should prefer batched transactions to interactive transaction; these should take just a single roundtrip.

Unfortunately, up until now it was impossible to safely implement batched transactions in Hrana with just a single roundtrip. To execute a batch of statements _S1, ..., Sn_, we need to do the following:
- Execute a `BEGIN` statement
- If the `BEGIN` statement was successful, execute _S1_
- If `BEGIN` and _S1_ were successful, execute _S2_
- ...
- If `BEGIN` and _S1, ..., Sn-1_ were successful, execute _Sn_
- If `BEGIN` and _S1, ..., Sn_ were successful, execute `COMMIT`, otherwise execute a `ROLLBACK`

In other words, we need to execute statements conditionally, based on results of previous statements. The only way to do this in Hrana is to wait for the responses, so we need _n+2_ roundtrips instead of just one!

---

This PR changes that by introducing a mechanism for conditional execution of statements on the server. This mechanism is described in the Hrana spec, but a tl;dr is as follows:

- The server maintains a set of variables with values.
- A `compute` request can be used to execute operations that evaluate expressions and mutate the variables.
- The `execute` request can include a condition; if the condition evaluates to false, the statement is not executed. It can also contain a sequence of operations that will be executed when the statement was successful or when it failed.

This mechanism will allow clients to implement batched transactions using a single roundtrip. An alternative solution would be to bake the concept of a "batch" into the protocol, but it would have similar implementation complexity to this solution, while being much less general.