### PR TITLE
limit replica frame buffer size

### DIFF
--- a/sqld/src/rpc/replication_log.rs
+++ b/sqld/src/rpc/replication_log.rs
@@ -39,8 +39,7 @@ impl ReplicationLogService {
                 match logger.frame_bytes(offset) {
                     Ok(None) => break,
                     Ok(Some(data)) => {
-                        if let Err(e) = sender.blocking_send(Ok(Frame { data })) {
-                            tracing::error!("failed to send frame: {e}");
+                        if sender.blocking_send(Ok(Frame { data })).is_err() {
                             break;
                         }
                         offset += 1;


### PR DESCRIPTION
This PR limits the number of frames the replica can buffer when fetching from the primary


If a transaction exceeds the maximum buffer size (1000 pages), then the replica will fail to make progress. I will address this issue in a subsequent issue.