### PR TITLE
sqld: bump libsqlite3-sys dependency

### DIFF
--- a/sqld-libsql-bindings/Cargo.toml
+++ b/sqld-libsql-bindings/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 anyhow = "1.0.66"
 mvfs = { git = "https://github.com/psarna/mvsqlite", branch = "mwal", optional = true }
 mwal = { git = "https://github.com/psarna/mvsqlite", branch = "mwal", optional = true }
-rusqlite = { version = "0.28.0", git = "https://github.com/psarna/rusqlite", rev = "cba0667f23949312f122f4e05", default-features = false, features = [
+rusqlite = { version = "0.29.0", git = "https://github.com/psarna/rusqlite", rev = "63b7aabfccbc21738", default-features = false, features = [
     "buildtime_bindgen",
-    "bundled-libsql-wasm",
+    "bundled-libsql-wasm-experimental",
     "column_decltype"
 ] }
 tracing = "0.1.37"

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -33,9 +33,9 @@ pin-project-lite = "0.2.9"
 postgres-protocol = "0.6.4"
 prost = "0.11.3"
 regex = "1.7.0"
-rusqlite = { version = "0.28.0", git = "https://github.com/psarna/rusqlite", rev = "cba0667f23949312f122f4e05", default-features = false, features = [
+rusqlite = { version = "0.29.0", git = "https://github.com/psarna/rusqlite", rev = "63b7aabfccbc21738", default-features = false, features = [
     "buildtime_bindgen",
-    "bundled-libsql-wasm",
+    "bundled-libsql-wasm-experimental",
     "column_decltype"
 ] }
 serde = { version = "1.0.149", features = ["derive", "rc"] }


### PR DESCRIPTION
We still rely on a git dependency, but now it points to an updated fork of rusqlite, which we hope will get merged soon.

Ref: https://github.com/rusqlite/rusqlite/pull/1283