### PR TITLE
RFC: read-only access JWT tokens

### DIFF
--- a/scripts/gen_jwt.py
+++ b/scripts/gen_jwt.py
@@ -40,6 +40,10 @@ claims = {
 }
 token = jwt.encode(claims, privkey_pem, "EdDSA")
 
+claims["access"] = "read-only"
+ro_token = jwt.encode(claims, privkey_pem, "EdDSA")
+
 open("jwt_key.pem", "wb").write(pubkey_pem)
 open("jwt_key.base64", "wb").write(pubkey_base64)
-print(token)
+print(f"Full access: {token}")
+print(f"Read-only:   {ro_token}")

--- a/scripts/gen_jwt.py
+++ b/scripts/gen_jwt.py
@@ -40,7 +40,7 @@ claims = {
 }
 token = jwt.encode(claims, privkey_pem, "EdDSA")
 
-claims["access"] = "read-only"
+claims["a"] = "ro"
 ro_token = jwt.encode(claims, privkey_pem, "EdDSA")
 
 open("jwt_key.pem", "wb").write(pubkey_pem)

--- a/sqld/proto/proxy.proto
+++ b/sqld/proto/proxy.proto
@@ -130,9 +130,15 @@ message OrCond {
     repeated Cond conds = 1;
 }
 
+enum Authorized {
+    READONLY = 0;
+    FULL = 1;
+}
+
 message ProgramReq {
     string client_id = 1;
     Program pgm = 2;
+    optional Authorized authorized = 3;
 }
 
 service Proxy {

--- a/sqld/src/auth.rs
+++ b/sqld/src/auth.rs
@@ -222,13 +222,13 @@ mod tests {
         auth.authenticate_http(Some(&HeaderValue::from_str(header).unwrap()))
     }
 
-    const VALID_JWT_KEY: &str = "HJwsOjoUT-Ct4G27f7GPkIywbg4jEgrmaPQbTx_Ld-c";
+    const VALID_JWT_KEY: &str = "-7VHgCfQpv3yxEQvrWO3Bh8h4j3ycRyafHMzmdTjsXU";
     const VALID_JWT: &str = "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.\
-        eyJleHAiOjE2ODAyNjA3MDl9.\
-        VvppV-_Q2MTJKZf0w64O-mgl-miNC0YE8SXwPThOdjctWzDicpR63rhl1MI1JynW33EtwEpmMFbtWvNU4QTyCA";
+        eyJleHAiOjc5ODg0ODE5MzB9.\
+        76nJKANvYKV3pnE97ny7c5PZBl6SE4L5TooJUZPENf0rYJETFfm_dS268OStcP_laNvm-O2_TX3E2u9cfko3BQ";
     const VALID_READONLY_JWT: &str = "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.\
-        eyJleHAiOjE2ODAyNjA3MDksImFjY2VzcyI6InJlYWQtb25seSJ9.\
-        EZsW-dlKKufbFkUpXRZRwL4kacbY3ZWYOYXv8JrM_hTaoE9bix2l-aCQKvVHV5uyN6cCby_TtThZl06CQxB0CA";
+        eyJleHAiOjc5ODg0ODE5MzAsImFjY2VzcyI6InJlYWQtb25seSJ9.\
+        85JOGgrdo0tnfgRq71rPXVuIyBWBeYD0axCY67Se3rwRYkTt9P0uJPA9dm4SRkvfbDee_G7qyDNzZ5I3ZuTtBg";
 
     macro_rules! assert_ok {
         ($e:expr) => {

--- a/sqld/src/auth.rs
+++ b/sqld/src/auth.rs
@@ -142,9 +142,9 @@ fn validate_jwt(
     match jsonwebtoken::decode::<serde_json::Value>(jwt, jwt_key, &validation).map(|t| t.claims) {
         Ok(serde_json::Value::Object(claims)) => {
             tracing::trace!("Claims: {claims:#?}");
-            Ok(match claims.get("access").and_then(|s| s.as_str()) {
-                Some("read-only") => Authenticated::Authorized(Authorized::ReadOnly),
-                Some("full-access") => Authenticated::Authorized(Authorized::FullAccess),
+            Ok(match claims.get("a").and_then(|s| s.as_str()) {
+                Some("ro") => Authenticated::Authorized(Authorized::ReadOnly),
+                Some("rw") => Authenticated::Authorized(Authorized::FullAccess),
                 Some(_) => Authenticated::Anonymous,
                 // Backward compatibility - no access claim means full access
                 None => Authenticated::Authorized(Authorized::FullAccess),
@@ -222,13 +222,13 @@ mod tests {
         auth.authenticate_http(Some(&HeaderValue::from_str(header).unwrap()))
     }
 
-    const VALID_JWT_KEY: &str = "-7VHgCfQpv3yxEQvrWO3Bh8h4j3ycRyafHMzmdTjsXU";
+    const VALID_JWT_KEY: &str = "zaMv-aFGmB7PXkjM4IrMdF6B5zCYEiEGXW3RgMjNAtc";
     const VALID_JWT: &str = "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.\
-        eyJleHAiOjc5ODg0ODE5MzB9.\
-        76nJKANvYKV3pnE97ny7c5PZBl6SE4L5TooJUZPENf0rYJETFfm_dS268OStcP_laNvm-O2_TX3E2u9cfko3BQ";
+        eyJleHAiOjc5ODg0ODM4Mjd9.\
+        MatB2aLnPFusagqH2RMoVExP37o2GFLmaJbmd52OdLtAehRNeqeJZPrefP1t2GBFidApUTLlaBRL6poKq_s3CQ";
     const VALID_READONLY_JWT: &str = "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.\
-        eyJleHAiOjc5ODg0ODE5MzAsImFjY2VzcyI6InJlYWQtb25seSJ9.\
-        85JOGgrdo0tnfgRq71rPXVuIyBWBeYD0axCY67Se3rwRYkTt9P0uJPA9dm4SRkvfbDee_G7qyDNzZ5I3ZuTtBg";
+        eyJleHAiOjc5ODg0ODM4MjcsImEiOiJybyJ9.\
+        _2ZZiO2HC8b3CbCHSCufXXBmwpl-dLCv5O9Owvpy7LZ9aiQhXODpgV-iCdTsLQJ5FVanWhfn3FtJSnmWHn25DQ";
 
     macro_rules! assert_ok {
         ($e:expr) => {

--- a/sqld/src/auth.rs
+++ b/sqld/src/auth.rs
@@ -37,9 +37,20 @@ pub enum AuthError {
     Other,
 }
 
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Authorized {
+    FullAccess,
+    ReadOnly,
+}
+
 /// A witness that the user has been authenticated.
-#[derive(Debug)]
-pub struct Authenticated(());
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Authenticated {
+    Anonymous,
+    Authorized(Authorized),
+}
 
 impl Auth {
     pub fn authenticate_http(
@@ -47,7 +58,7 @@ impl Auth {
         auth_header: Option<&hyper::header::HeaderValue>,
     ) -> Result<Authenticated, AuthError> {
         if self.disabled {
-            return Ok(Authenticated(()));
+            return Ok(Authenticated::Authorized(Authorized::FullAccess));
         }
 
         let Some(auth_header) = auth_header else {
@@ -64,7 +75,7 @@ impl Auth {
                 let actual_value = actual_value.trim_end_matches('=');
                 let expected_value = expected_value.trim_end_matches('=');
                 if actual_value == expected_value {
-                    Ok(Authenticated(()))
+                    Ok(Authenticated::Authorized(Authorized::FullAccess))
                 } else {
                     Err(AuthError::BasicRejected)
                 }
@@ -75,7 +86,7 @@ impl Auth {
 
     pub fn authenticate_jwt(&self, jwt: Option<&str>) -> Result<Authenticated, AuthError> {
         if self.disabled {
-            return Ok(Authenticated(()));
+            return Ok(Authenticated::Authorized(Authorized::FullAccess));
         }
 
         let Some(jwt) = jwt else {
@@ -128,8 +139,18 @@ fn validate_jwt(
     let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::EdDSA);
     validation.required_spec_claims.remove("exp");
 
-    match jsonwebtoken::decode::<serde_json::Value>(jwt, jwt_key, &validation) {
-        Ok(_token) => Ok(Authenticated(())),
+    match jsonwebtoken::decode::<serde_json::Value>(jwt, jwt_key, &validation).map(|t| t.claims) {
+        Ok(serde_json::Value::Object(claims)) => {
+            tracing::trace!("Claims: {claims:#?}");
+            Ok(match claims.get("access").and_then(|s| s.as_str()) {
+                Some("read-only") => Authenticated::Authorized(Authorized::ReadOnly),
+                Some("full-access") => Authenticated::Authorized(Authorized::FullAccess),
+                Some(_) => Authenticated::Anonymous,
+                // Backward compatibility - no access claim means full access
+                None => Authenticated::Authorized(Authorized::FullAccess),
+            })
+        }
+        Ok(_) => Err(AuthError::JwtInvalid),
         Err(error) => Err(match error.kind() {
             ErrorKind::InvalidToken
             | ErrorKind::InvalidSignature
@@ -201,10 +222,13 @@ mod tests {
         auth.authenticate_http(Some(&HeaderValue::from_str(header).unwrap()))
     }
 
-    const VALID_JWT: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSJ9.\
-        eyJleHAiOjQ4MzEwOTI5NDh9.\
-        TbPFJBxqb0fPPXj74DgmIZO41skmNEx-8b3PfAXv7IJMeLa3fNgBi7J5xxLm_-0SMEV3f6KMgUN0dBFbGRk4Ag";
-    const VALID_JWT_KEY: &str = "3dwzg2D96T4GcyZkK4MezpRQxU321g7aTrUn1iwOF0s";
+    const VALID_JWT_KEY: &str = "HJwsOjoUT-Ct4G27f7GPkIywbg4jEgrmaPQbTx_Ld-c";
+    const VALID_JWT: &str = "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.\
+        eyJleHAiOjE2ODAyNjA3MDl9.\
+        VvppV-_Q2MTJKZf0w64O-mgl-miNC0YE8SXwPThOdjctWzDicpR63rhl1MI1JynW33EtwEpmMFbtWvNU4QTyCA";
+    const VALID_READONLY_JWT: &str = "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.\
+        eyJleHAiOjE2ODAyNjA3MDksImFjY2VzcyI6InJlYWQtb25seSJ9.\
+        EZsW-dlKKufbFkUpXRZRwL4kacbY3ZWYOYXv8JrM_hTaoE9bix2l-aCQKvVHV5uyN6cCby_TtThZl06CQxB0CA";
 
     macro_rules! assert_ok {
         ($e:expr) => {
@@ -268,6 +292,11 @@ mod tests {
             &auth,
             &format!("Bearer {}", &VALID_JWT[..80])
         ));
+
+        assert_eq!(
+            authenticate_http(&auth, &format!("Bearer {VALID_READONLY_JWT}")).unwrap(),
+            Authenticated::Authorized(Authorized::ReadOnly)
+        );
     }
 
     #[test]

--- a/sqld/src/error.rs
+++ b/sqld/src/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
     Internal(String),
     #[error("Invalid batch step: {0}")]
     InvalidBatchStep(usize),
+    #[error("Not authorized to execute query: {0}")]
+    NotAuthorized(String),
 }
 
 impl From<tokio::sync::oneshot::error::RecvError> for Error {

--- a/sqld/src/hrana/stmt.rs
+++ b/sqld/src/hrana/stmt.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
 
 use super::proto;
+use crate::auth::Authenticated;
 use crate::database::Database;
 use crate::error::Error as SqldError;
 use crate::hrana;
@@ -37,9 +38,13 @@ pub enum StmtError {
     },
 }
 
-pub async fn execute_stmt(db: &dyn Database, stmt: &proto::Stmt) -> Result<proto::StmtResult> {
+pub async fn execute_stmt(
+    db: &dyn Database,
+    auth: Authenticated,
+    stmt: &proto::Stmt,
+) -> Result<proto::StmtResult> {
     let query = proto_stmt_to_query(stmt)?;
-    let (query_result, _) = db.execute_one(query).await?;
+    let (query_result, _) = db.execute_one(query, auth).await?;
     match query_result {
         Ok(query_response) => Ok(proto_stmt_result_from_query_response(query_response)),
         Err(sqld_error) => match stmt_error_from_sqld_error(sqld_error) {

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -181,7 +181,10 @@ async fn handle_query(
                 .header("Content-Type", "application/json")
                 .body(Body::from(json))?)
         }
-        Err(_) => Ok(error("internal error", StatusCode::INTERNAL_SERVER_ERROR)),
+        Err(e) => Ok(error(
+            &format!("internal error: {e}"),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )),
     }
 }
 

--- a/sqld/src/postgres/handlers.rs
+++ b/sqld/src/postgres/handlers.rs
@@ -38,8 +38,9 @@ impl QueryHandler {
         queries: Vec<Query>,
         col_defs: bool,
     ) -> PgWireResult<Vec<Response>> {
+        let auth = crate::auth::Authenticated::Authorized(crate::auth::Authorized::FullAccess);
         //FIXME: handle poll_ready error
-        match self.database.execute_batch(queries).await {
+        match self.database.execute_batch(queries, auth).await {
             Ok((resp, _)) => {
                 let ret = resp
                     .into_iter()

--- a/sqld/src/rpc/proxy.rs
+++ b/sqld/src/rpc/proxy.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use async_lock::{RwLock, RwLockUpgradableReadGuard};
 use uuid::Uuid;
 
+use crate::auth::{Authenticated, Authorized};
 use crate::database::factory::DbFactory;
 use crate::database::{Database, Program};
 
@@ -305,9 +306,22 @@ impl Proxy for ProxyService {
             }
         };
 
+        let auth = match req.authorized {
+            Some(0) => Authenticated::Authorized(Authorized::ReadOnly),
+            Some(1) => Authenticated::Authorized(Authorized::FullAccess),
+            Some(_) => {
+                return Err(tonic::Status::new(
+                    tonic::Code::PermissionDenied,
+                    "invalid authorization level",
+                ))
+            }
+            None => Authenticated::Anonymous,
+        };
         tracing::debug!("executing request for {client_id}");
-        let auth = crate::auth::Authenticated::Authorized(crate::auth::Authorized::FullAccess);
-        let (results, state) = db.execute_program(pgm, auth).await.unwrap();
+        let (results, state) = db
+            .execute_program(pgm, auth)
+            .await
+            .map_err(|e| tonic::Status::new(tonic::Code::PermissionDenied, e.to_string()))?;
         let results = results.into_iter().map(|r| r.into()).collect();
 
         Ok(tonic::Response::new(ExecuteResults {

--- a/sqld/src/rpc/proxy.rs
+++ b/sqld/src/rpc/proxy.rs
@@ -306,7 +306,8 @@ impl Proxy for ProxyService {
         };
 
         tracing::debug!("executing request for {client_id}");
-        let (results, state) = db.execute_program(pgm).await.unwrap();
+        let auth = crate::auth::Authenticated::Authorized(crate::auth::Authorized::FullAccess);
+        let (results, state) = db.execute_program(pgm, auth).await.unwrap();
         let results = results.into_iter().map(|r| r.into()).collect();
 
         Ok(tonic::Response::new(ExecuteResults {


### PR DESCRIPTION
I wanted to quickly evaluate how we could add coarse-grained access control to sqld with JWT and came up with this short patch, I'd be grateful for any comments/opinions.

The mechanism of authenticating JWT is extended a little bit. So far we only cared if the token is there and is valid. What JWT offers is an easily extensible mechanism for "claims", which is more or less just a JSON object which allows you to define properties that the token bearer holds. This patch introduces another JWT claim, with a working name "access". If this field is set to "read-only", `sqld` will refuse to execute any requests except ones categorized as reads.

The change turned out to be extremely small and took ~30 minutes tests included, since thanks to @MarinPostma's work we already categorize queries anyway.

The class of use cases I have in mind here are browser apps. We certainly don't want to push full access tokens to users' browsers, but it might be just fine to "leak" a read-only token that lets you access the database, but not modify it. To bring a concrete example, one of my demo apps I use for testing sqld (http://sorry.idont.date) would no longer need to run on Cloudflare Workers and could instead fetch data straight from the browser - far edge!