### PR TITLE
Replica connection wait for replication

### DIFF
--- a/sqld/proto/proxy.proto
+++ b/sqld/proto/proxy.proto
@@ -89,6 +89,8 @@ message ExecuteResults {
     }
     /// State after executing the queries
     State state = 2;
+    /// Primary frame_no after executing the request.
+    uint64 current_frame_no = 3;
 }
 
 message Program {

--- a/sqld/src/error.rs
+++ b/sqld/src/error.rs
@@ -25,6 +25,8 @@ pub enum Error {
     InvalidBatchStep(usize),
     #[error("Not authorized to execute query: {0}")]
     NotAuthorized(String),
+    #[error("The replicator exited, instance cannot make any progress.")]
+    ReplicatorExited,
 }
 
 impl From<tokio::sync::oneshot::error::RecvError> for Error {

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -201,10 +201,17 @@ async fn start_replica(
 ) -> anyhow::Result<()> {
     let (channel, uri) = configure_rpc(config)?;
     let replicator = Replicator::new(config.db_path.clone(), channel.clone(), uri.clone());
+    let applied_frame_no_receiver = replicator.current_frame_no_notifier.subscribe();
 
     join_set.spawn(replicator.run());
 
-    let factory = WriteProxyDbFactory::new(config.db_path.clone(), channel, uri, stats.clone());
+    let factory = WriteProxyDbFactory::new(
+        config.db_path.clone(),
+        channel,
+        uri,
+        stats.clone(),
+        applied_frame_no_receiver,
+    );
     run_service(
         Arc::new(factory),
         config,

--- a/sqld/src/replication/replica/replicator.rs
+++ b/sqld/src/replication/replica/replicator.rs
@@ -28,7 +28,7 @@ pub struct Replicator {
     db_path: PathBuf,
     injector: Option<FrameInjectorHandle>,
     current_frame_no: FrameNo,
-    current_frame_no_notifier: watch::Sender<FrameNo>,
+    pub current_frame_no_notifier: watch::Sender<FrameNo>,
 }
 
 impl Replicator {

--- a/sqld/src/rpc/mod.rs
+++ b/sqld/src/rpc/mod.rs
@@ -26,7 +26,7 @@ pub async fn run_rpc_server(
     logger: Arc<ReplicationLogger>,
     idle_shutdown_layer: Option<IdleShutdownLayer>,
 ) -> anyhow::Result<()> {
-    let proxy_service = ProxyService::new(factory);
+    let proxy_service = ProxyService::new(factory, logger.new_frame_notifier.subscribe());
     let logger_service = ReplicationLogService::new(logger);
 
     tracing::info!("serving write proxy server at {addr}");

--- a/sqld/src/rpc/proxy.rs
+++ b/sqld/src/rpc/proxy.rs
@@ -327,11 +327,12 @@ impl Proxy for ProxyService {
             .await
             .map_err(|e| tonic::Status::new(tonic::Code::PermissionDenied, e.to_string()))?;
         let results = results.into_iter().map(|r| r.into()).collect();
-        let _current_frame_no = *self.new_frame_notifier.borrow();
+        let current_frame_no = *self.new_frame_notifier.borrow();
 
         Ok(tonic::Response::new(ExecuteResults {
             results,
             state: State::from(state).into(),
+            current_frame_no,
         }))
     }
 


### PR DESCRIPTION
What this PR do is quite simple: it makes every replica database connection to wait for the replica instance to catch up with the last write that they performed.

When a replica detects a write, this write is proxied to the primary, that executes it, and then starts replicating the state. The replica receives a response that contains a logical timestamp issued after the write was performed. The replica's connection keep this timestamp and on subsequent operation on the _local_ connection, waits until the replicator has applied changes up to the stored timestamp.

Note that each connection holds a different timestamp, so a connection may proceed with a read, while another is still waiting.

The basic guarantee that it gives is read your write: a connection is always guaranteed to witness it's write. In fact the guarantee is much stronger because of the underlying consistency of sqlite, the real-time consistency model of sqld is now as strong as `sequential consistency`.
