### PR TITLE
bottomless: add read-only replicas that read from S3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "bottomless"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "libsqlite3-sys"
 version = "0.26.0"
-source = "git+https://github.com/psarna/rusqlite?rev=63b7aabfccbc21738#63b7aabfccbc217384225604cc419f2cf792b8d1"
+source = "git+https://github.com/psarna/rusqlite?rev=a6332e530f30dc2d47110#a6332e530f30dc2d471103eed96a650407a73c7a"
 dependencies = [
  "bindgen",
  "cc",
@@ -3455,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "rusqlite"
 version = "0.29.0"
-source = "git+https://github.com/psarna/rusqlite?rev=63b7aabfccbc21738#63b7aabfccbc217384225604cc419f2cf792b8d1"
+source = "git+https://github.com/psarna/rusqlite?rev=a6332e530f30dc2d47110#a6332e530f30dc2d471103eed96a650407a73c7a"
 dependencies = [
  "bitflags 2.0.2",
  "fallible-iterator",

--- a/bottomless/Cargo.toml
+++ b/bottomless/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.66"
 async-compression = { version = "0.3.15", features = ["tokio", "gzip"] }
 aws-config = { version = "0.52.0" }
 aws-sdk-s3 = { version = "0.22.0" }
+byteorder = "1.4.3"
 bytes = "1"
 crc = "3.0.0"
 futures = { version = "0.3.25" }
@@ -24,6 +25,7 @@ uuid = { version = "1.3", features = ["v7"] }
 
 [features]
 libsql_linked_statically = []
+init_tracing_statically = []
 
 [lib]
 crate-type = ["rlib", "staticlib"]

--- a/bottomless/Makefile
+++ b/bottomless/Makefile
@@ -1,10 +1,10 @@
 all:	debug
 
 debug:	bottomless.c src/lib.rs
-	cargo build -p bottomless && clang -Wall -fPIC -shared -DLIBSQL_ENABLE_BOTTOMLESS_WAL bottomless.c -I${LIBSQL_DIR} ../target/debug/libbottomless.a -o ../target/debug/bottomless.so
+	cargo build -p bottomless -Finit_tracing_statically && clang -Wall -fPIC -shared -DLIBSQL_ENABLE_BOTTOMLESS_WAL bottomless.c -I${LIBSQL_DIR} ../target/debug/libbottomless.a -o ../target/debug/bottomless.so
 
 release:	bottomless.c src/lib.rs
-	cargo build -p bottomless -j1	--quiet --release && \
+	cargo build -p bottomless -Finit_tracing_statically -j1	--quiet --release && \
 		clang -fPIC -shared -DLIBSQL_ENABLE_BOTTOMLESS_WAL bottomless.c -I${LIBSQL_DIR} ../target/release/libbottomless.a \
 		-o ../target/release/bottomless.so
 

--- a/bottomless/src/ffi.rs
+++ b/bottomless/src/ffi.rs
@@ -1,6 +1,7 @@
 pub use sqld_libsql_bindings::ffi::{
-    libsql_wal_methods, sqlite3, sqlite3_file, sqlite3_vfs, PageHdrIter, PgHdr, Wal, WalIndexHdr,
-    SQLITE_CANTOPEN, SQLITE_CHECKPOINT_TRUNCATE, SQLITE_IOERR_WRITE, SQLITE_OK,
+    libsql_wal, libsql_wal_methods, sqlite3, sqlite3_file, sqlite3_vfs, PageHdrIter, PgHdr, Wal,
+    WalIndexHdr, SQLITE_CANTOPEN, SQLITE_CHECKPOINT_TRUNCATE, SQLITE_IOERR_READ,
+    SQLITE_IOERR_WRITE, SQLITE_OK, SQLITE_READONLY,
 };
 
 #[repr(C)]

--- a/bottomless/test/restore_test.sql
+++ b/bottomless/test/restore_test.sql
@@ -2,5 +2,6 @@
 .echo on
 .load ../../target/debug/bottomless
 .open file:test.db?wal=bottomless&immutable=1
+pragma journal_mode;
 .mode column
 SELECT v, length(v) FROM test;

--- a/bottomless/test/smoke_test.sql
+++ b/bottomless/test/smoke_test.sql
@@ -2,7 +2,6 @@
 .echo on
 .load ../../target/debug/bottomless
 .open file:test.db?wal=bottomless
-PRAGMA page_size=65536;
 PRAGMA journal_mode=wal;
 PRAGMA page_size;
 DROP TABLE IF EXISTS test;

--- a/sqld-libsql-bindings/src/ffi/mod.rs
+++ b/sqld-libsql-bindings/src/ffi/mod.rs
@@ -3,9 +3,10 @@
 pub mod types;
 
 pub use rusqlite::ffi::{
-    libsql_wal_methods, libsql_wal_methods_find, libsql_wal_methods_register, sqlite3,
+    libsql_wal, libsql_wal_methods, libsql_wal_methods_find, libsql_wal_methods_register, sqlite3,
     sqlite3_file, sqlite3_io_methods, sqlite3_vfs, WalIndexHdr, SQLITE_CANTOPEN,
-    SQLITE_CHECKPOINT_FULL, SQLITE_CHECKPOINT_TRUNCATE, SQLITE_IOERR_WRITE, SQLITE_OK,
+    SQLITE_CHECKPOINT_FULL, SQLITE_CHECKPOINT_TRUNCATE, SQLITE_IOERR_READ, SQLITE_IOERR_WRITE,
+    SQLITE_OK, SQLITE_READONLY,
 };
 
 pub use rusqlite::ffi::libsql_pghdr as PgHdr;


### PR DESCRIPTION
This commit adds support for using bottomless in "read-only replica" mode. In this mode, all data is read exclusively from S3 and nothing gets restored to disk.

FIXME: it also contains a terrible, terrible hack in order to work - on startup, the first page of the database is restored from S3, and the database file is truncated to match the original DB size, thus making libSQL think it's a properly structured database file. After that, all data is read only from S3.

A proper solution is to ship bottomless WAL with a bottomless VFS implementation - with the VFS set up to read pages from S3. Effectively, it will only ever read the first db page from there, and from then on it will just read everything from S3.