### PR TITLE
whitelist permanent views

### DIFF
--- a/sqld/src/query_analysis.rs
+++ b/sqld/src/query_analysis.rs
@@ -47,7 +47,10 @@ impl StmtKind {
                 | Stmt::Delete { .. }
                 | Stmt::DropTable { .. }
                 | Stmt::AlterTable { .. }
-                | Stmt::CreateIndex { .. },
+                | Stmt::CreateIndex { .. }
+                // only support non-temp views for now. We don't have a mecanism to sync
+                // connection state between the primary and the replica right now.
+                | Stmt::CreateView { temporary: false, .. }
             ) => Some(Self::Write),
             Cmd::Stmt(Stmt::Select { .. }) => Some(Self::Read),
             Cmd::Stmt(Stmt::Pragma { .. }) => Some(Self::Other),


### PR DESCRIPTION
whitelist support for permanent views.

temporary view are still blacklisted, because they are tied to a specitif connection. It requires that we are able to sync the state of the connection on the primary and replica side,  which we are currently unable to do.
