### PR TITLE
allow building from source tarball

### DIFF
--- a/sqld/build.rs
+++ b/sqld/build.rs
@@ -3,7 +3,11 @@ use prost_build::Config;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut config = vergen::Config::default();
     *config.build_mut().kind_mut() = vergen::TimestampKind::All;
-    vergen::vergen(config)?;
+    // when building from source, git is not available
+    if vergen::vergen(config.clone()).is_err() {
+        *config.git_mut().enabled_mut() = false;
+        vergen::vergen(config)?;
+    }
 
     let mut config = Config::new();
     config.bytes([".wal_log"]);

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -135,7 +135,9 @@ impl Cli {
         eprintln!("Welcome to sqld!");
         eprintln!();
         eprintln!("version: {}", env!("VERGEN_BUILD_SEMVER"));
-        eprintln!("commit SHA: {}", env!("VERGEN_GIT_SHA"));
+        if let Some(git_sha) = option_env!("VERGEN_GIT_SHA") {
+            eprintln!("commit SHA: {}", git_sha);
+        }
         eprintln!("build date: {}", env!("VERGEN_BUILD_DATE"));
         eprintln!();
         eprintln!("This software is in BETA version.");


### PR DESCRIPTION
vergen by default will try to enable git, which means the build will fail if compiling from a source tarball.

Tools like homebrew have a preference towards building from the git tarball, so let's enable that.