### PR TITLE
Enable Hrana if only HTTP is active

### DIFF
--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -213,10 +213,7 @@ async fn handle_upgrade(
         Ok(response) => response,
         Err(_) => Response::builder()
             .status(hyper::StatusCode::SERVICE_UNAVAILABLE)
-            .body(
-                "sqld was not able to process the HTTP upgrade (Hrana support may be disabled)"
-                    .into(),
-            )
+            .body("sqld was not able to process the HTTP upgrade".into())
             .unwrap(),
     }
 }

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -133,7 +133,7 @@ impl Cli {
         eprintln!();
         eprintln!("version: {}", env!("VERGEN_BUILD_SEMVER"));
         if let Some(git_sha) = option_env!("VERGEN_GIT_SHA") {
-            eprintln!("commit SHA: {}", git_sha);
+            eprintln!("commit SHA: {git_sha}");
         }
         eprintln!("build date: {}", env!("VERGEN_BUILD_DATE"));
         eprintln!();


### PR DESCRIPTION
Previously, we needed to enable a dedicated Hrana port to enable WebSocket upgrades over HTTP. With this change, enabling HTTP is enough to enable the upgrades.