### PR TITLE
Server heartbeats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3904,6 +3904,7 @@ dependencies = [
  "prost-build",
  "rand",
  "regex",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -59,6 +59,7 @@ tempfile = "3.3.0"
 memmap = "0.7.0"
 mimalloc = "0.1.36"
 sha256 = "1.1.3"
+reqwest = { version = "0.11.16", features = ["json"] }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/sqld/src/heartbeat.rs
+++ b/sqld/src/heartbeat.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::time::Duration;
 use tokio::time::sleep;
 
+use crate::http::stats::StatsResponse;
 use crate::stats::Stats;
 
 pub async fn server_heartbeat(
@@ -13,10 +14,10 @@ pub async fn server_heartbeat(
     let client = reqwest::Client::new();
     loop {
         sleep(update_period).await;
-        let body = serde_json::json!({
-            "rows_read": stats.rows_read(),
-            "rows_written": stats.rows_written(),
-        });
+        let body = StatsResponse {
+            rows_read_count: stats.rows_read(),
+            rows_written_count: stats.rows_written(),
+        };
         let request = client.post(&url);
         let request = if let Some(ref auth) = auth {
             request.header("Authorization", auth.clone())

--- a/sqld/src/heartbeat.rs
+++ b/sqld/src/heartbeat.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -10,7 +9,7 @@ pub async fn server_heartbeat(
     auth: Option<String>,
     update_period: Duration,
     stats: Stats,
-) -> Result<()> {
+) {
     let client = reqwest::Client::new();
     loop {
         sleep(update_period).await;

--- a/sqld/src/heartbeat.rs
+++ b/sqld/src/heartbeat.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use std::time::Duration;
+use tokio::time::sleep;
+
+use crate::stats::Stats;
+
+pub async fn server_heartbeat(
+    url: String,
+    auth: Option<String>,
+    update_period: Duration,
+    stats: Stats,
+) -> Result<()> {
+    let client = reqwest::Client::new();
+    loop {
+        sleep(update_period).await;
+        let body = serde_json::json!({
+            "rows_read": stats.rows_read(),
+            "rows_written": stats.rows_written(),
+        });
+        let request = client.post(&url);
+        let request = if let Some(ref auth) = auth {
+            request.header("Authorization", auth.clone())
+        } else {
+            request
+        };
+        let request = request.json(&body);
+        if let Err(err) = request.send().await {
+            tracing::warn!("Error sending heartbeat: {}", err);
+        }
+    }
+}

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -1,5 +1,5 @@
 mod hrana_over_http;
-mod stats;
+pub mod stats;
 mod types;
 
 use std::net::SocketAddr;

--- a/sqld/src/http/stats.rs
+++ b/sqld/src/http/stats.rs
@@ -4,9 +4,9 @@ use serde::Serialize;
 use crate::stats::Stats;
 
 #[derive(Serialize)]
-struct StatsResponse {
-    rows_read_count: usize,
-    rows_written_count: usize,
+pub struct StatsResponse {
+    pub rows_read_count: usize,
+    pub rows_written_count: usize,
 }
 
 pub fn handle_stats(stats: &Stats) -> Response<Body> {

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -166,8 +166,8 @@ async fn run_service(
                     heartbeat_period,
                     stats.clone(),
                 )
-                .await
-                .context("Heartbeat setup failed")
+                .await;
+                Ok(())
             });
         }
         None => {

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -133,6 +133,22 @@ struct Cli {
 
     #[clap(subcommand)]
     utils: Option<UtilsSubcommands>,
+
+    /// The URL to send a server heartbeat `POST` request to.
+    /// By default, the server doesn't send a heartbeat.
+    #[clap(long, env = "SQLD_HEARTBEAT_URL")]
+    heartbeat_url: Option<String>,
+
+    /// The HTTP "Authornization" header to include in the a server heartbeat
+    /// `POST` request.
+    /// By default, the server doesn't send a heartbeat.
+    #[clap(long, env = "SQLD_HEARTBEAT_AUTH")]
+    heartbeat_auth: Option<String>,
+
+    /// The heartbeat time period in seconds.
+    /// By default, the the period is 30 seconds.
+    #[clap(long, env = "SQLD_HEARTBEAT_PERIOD_S", default_value = "30")]
+    heartbeat_period_s: u64,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -231,6 +247,9 @@ fn config_from_args(args: Cli) -> Result<Config> {
         idle_shutdown_timeout: args.idle_shutdown_timeout_s.map(Duration::from_secs),
         load_from_dump: args.load_from_dump,
         max_log_size: args.max_log_size,
+        heartbeat_url: args.heartbeat_url,
+        heartbeat_auth: args.heartbeat_auth,
+        heartbeat_period: Duration::from_secs(args.heartbeat_period_s),
     })
 }
 


### PR DESCRIPTION
This adds support for server heartbeats.

The patch adds three new command line options:

  `--heartbeat-url URL` is the URL to send a HTTP POST request to
  periodically to indicate server heatbeat.

  `--heartbeat-auth AUTH` is the HTTP "Authorization" header to send
  as part of the HTTP POST request.

  `--heartbeat-period SECS` is the heartbeat period in seconds.

The payload of the HTTP POST request is pretty simple for now:

```json
{"rows_read":1234,"rows_written":8765}
```

Fixes #343