### PR TITLE
Hrana protocol version 2

### DIFF
--- a/docs/HRANA_1_SPEC.md
+++ b/docs/HRANA_1_SPEC.md
@@ -1,7 +1,7 @@
-# The Hrana protocol specification
+# The Hrana protocol specification (version 1)
 
-Hrana (from Czech "hrana", which means "edge") is a protocol for connecting to
-SQL database over a WebSocket. It is designed to be used from edge functions,
+Hrana (from Czech "hrana", which means "edge") is a protocol for connecting to a
+SQLite database over a WebSocket. It is designed to be used from edge functions,
 where low latency and small overhead is important.
 
 ## Motivation
@@ -36,8 +36,8 @@ to `sqld` using Hrana, because it has native support for the protocol. This is
 the approach with lowest latency, because no software in the middle is
 necessary.
 
-- Connecting to Postgres or SQLite through a proxy: this allows edge functions
-to efficiently connect to existing SQL databases.
+- Connecting to SQLite through a proxy: this allows edge functions
+to efficiently connect to an existing SQLite databases.
 
 ## Overview
 
@@ -302,9 +302,8 @@ type NamedArg = {
 
 A statement contains the SQL text in `sql` and arguments.
 
-The arguments in `args` are bound to positional parameters in the SQL statement
-(such as `$NNN` in Postgres or `?NNN` in SQLite). The arguments in `named_args`
-are bound to named arguments, such as `:AAAA`, `@AAAA` and `$AAAA` in SQLite.
+The arguments in `args` are bound to parameters in the SQL statement by
+position. The arguments in `named_args` are bound to parameters by name.
 
 For SQLite, the names of arguments include the prefix sign (`:`, `@` or `$`). If
 the name of the argument does not start with this prefix, the server will try to

--- a/docs/HRANA_2_SPEC.md
+++ b/docs/HRANA_2_SPEC.md
@@ -1,0 +1,122 @@
+# The Hrana protocol specification (version 2)
+
+Hrana (from Czech "hrana", which means "edge") is a protocol for connecting to a
+SQLite database over a WebSocket. It is designed to be used from edge functions,
+where low latency and small overhead is important.
+
+In this specification, version 2 of the protocol is described as a set of
+extensions to version 1.
+
+## Version negotiation
+
+The Hrana protocol version 2 uses a WebSocket subprotocol `hrana2`. The
+WebSocket subprotocol negotiation allows the client and server to use version 2
+of the protocol if both peers support it, but fall back to version 1 if the
+client or the server don't support version 2.
+
+## Messages
+
+### Hello
+
+The `hello` message has the same format as in version 1. The client must send it
+as the first message, but in version 2, the client can also send it again
+anytime during the lifetime of the connection to reauthenticate, by providing a
+new JWT.
+
+This feature is needed because in long-living connections, the JWT used to
+authenticate the client may expire and the server may terminate the connection.
+Using this feature, the client can provide a fresh JWT.
+
+## Requests
+
+Version 2 introduces two new requests:
+
+```typescript
+type Request =
+    | ...
+    | DescribeReq
+    | SequenceReq
+
+type Response =
+    | ...
+    | DescribeResp
+    | SequenceResp
+```
+
+### Describe a statement
+
+```typescript
+type DescribeReq = {
+    "type": "describe",
+    "stream_id": int32,
+    "sql": string,
+}
+
+type DescribeResp = {
+    "type": "describe",
+    "params": Array<DescribeParam>,
+    "columns": Array<DescribeColumn>,
+    "is_explain": boolean,
+    "readonly": boolean,
+}
+```
+
+The `describe` request is used to parse and analyze a SQL statement. `stream_id`
+specifies the stream on which the statement is parsed and `sql` specifies the
+SQL text.
+
+In the response, `is_explain` is true if the statement was an `EXPLAIN`
+statement, and `readonly` is true if the statement does not modify the database.
+
+```typescript
+type DescribeParam = {
+    "name": string | null,
+}
+```
+
+Information about parameters of the statement is returned in `params`. SQLite
+indexes parameters from 1, so the first object in the `params` array describes
+parameter 1.
+
+For each parameter, the `name` field specifies the name of the parameter. For
+parameters of the form `?NNN`, `:AAA`, `@AAA` and `$AAA`, the name includes the
+initial `?`, `:`, `@` or `$` character. Parameters of the form `?` are nameless,
+their `name` is `null`.
+
+It is also possible that some parameters are not referenced in the statement, in
+which case the `name` is also `null`.
+
+```typescript
+type DescribeColumn = {
+    "name": string,
+    "decltype": string | null,
+}
+```
+
+Information about columns of the statement is returned in `columns`.
+
+For each column, `name` specifies the name assigned by the SQL `AS` clause. For
+columns without `AS` clause, the name is not specified.
+
+For result columns that directly originate from tables in the database,
+`decltype` specifies the declared type of the column. For other columns (such as
+results of expressions), `decltype` is `null`.
+
+### Execute a sequence of SQL statements
+
+```typescript
+type SequenceReq = {
+    "type": "sequence",
+    "stream_id": int32,
+    "sql": string,
+}
+
+type SequenceResp = {
+    "type": "sequence",
+}
+```
+
+The `sequence` request executes a sequence of SQL statements separated by
+semicolons. The results of these statements are ignored. If any statement fails,
+the server will not execute the following statements and will return an error
+response.


### PR DESCRIPTION
We found that we need some extensions to the Hrana protocol:
- Reauthenticate a living connection (to allow the clients to provide a new JWT before the original JWT expires) #338 
- Analyze parameters and columns of SQL statements #351

We can also use this opportunity to add some features:
- Execute a sequence of SQL statements separated by a semicolon #352

This PR introduces version 2 of the Hrana protocol (`hrana2`). The WebSocket subprotocol negotiation mechanism enables full compatibility with version 1 servers and version 1 clients.