### PR TITLE
Switch to 64-bit counters for rows read/written

### DIFF
--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -332,9 +332,9 @@ impl Connection {
 
     fn update_stats(&self, stmt: &rusqlite::Statement) {
         self.stats
-            .inc_rows_read(stmt.get_status(StatementStatus::RowsRead) as usize);
+            .inc_rows_read(stmt.get_status(StatementStatus::RowsRead) as u64);
         self.stats
-            .inc_rows_written(stmt.get_status(StatementStatus::RowsWritten) as usize);
+            .inc_rows_written(stmt.get_status(StatementStatus::RowsWritten) as u64);
     }
 }
 

--- a/sqld/src/http/stats.rs
+++ b/sqld/src/http/stats.rs
@@ -5,8 +5,8 @@ use crate::stats::Stats;
 
 #[derive(Serialize)]
 pub struct StatsResponse {
-    pub rows_read_count: usize,
-    pub rows_written_count: usize,
+    pub rows_read_count: u64,
+    pub rows_written_count: u64,
 }
 
 pub fn handle_stats(stats: &Stats) -> Response<Body> {

--- a/sqld/src/stats.rs
+++ b/sqld/src/stats.rs
@@ -1,7 +1,7 @@
 use std::fs::{File, OpenOptions};
 use std::io::Seek;
 use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -14,8 +14,8 @@ pub struct Stats {
 
 #[derive(Serialize, Deserialize, Default)]
 struct StatsInner {
-    rows_written: AtomicUsize,
-    rows_read: AtomicUsize,
+    rows_written: AtomicU64,
+    rows_read: AtomicU64,
 }
 
 impl Stats {
@@ -37,22 +37,22 @@ impl Stats {
     }
 
     /// increments the number of written rows by n
-    pub fn inc_rows_written(&self, n: usize) {
+    pub fn inc_rows_written(&self, n: u64) {
         self.inner.rows_written.fetch_add(n, Ordering::Relaxed);
     }
 
     /// increments the number of read rows by n
-    pub fn inc_rows_read(&self, n: usize) {
+    pub fn inc_rows_read(&self, n: u64) {
         self.inner.rows_read.fetch_add(n, Ordering::Relaxed);
     }
 
     /// returns the total number of rows read since this database was created
-    pub fn rows_read(&self) -> usize {
+    pub fn rows_read(&self) -> u64 {
         self.inner.rows_read.load(Ordering::Relaxed)
     }
 
     /// returns the total number of rows written since this database was created
-    pub fn rows_written(&self) -> usize {
+    pub fn rows_written(&self) -> u64 {
         self.inner.rows_written.load(Ordering::Relaxed)
     }
 }


### PR DESCRIPTION
The size of "usize" depends on the platform. On a 32-bit machine, the maximum number is 4294967295, which can easily be overflown with enough sustained throughput. Let's switch to explicit 64-bit counters, which means the counter never wraps around in practice.