### PR TITLE
stats: add storage_bytes_used

### DIFF
--- a/sqld/src/heartbeat.rs
+++ b/sqld/src/heartbeat.rs
@@ -13,10 +13,7 @@ pub async fn server_heartbeat(
     let client = reqwest::Client::new();
     loop {
         sleep(update_period).await;
-        let body = StatsResponse {
-            rows_read_count: stats.rows_read(),
-            rows_written_count: stats.rows_written(),
-        };
+        let body = StatsResponse::from(&stats);
         let request = client.post(&url);
         let request = if let Some(ref auth) = auth {
             request.header("Authorization", auth.clone())

--- a/sqld/src/http/stats.rs
+++ b/sqld/src/http/stats.rs
@@ -7,13 +7,27 @@ use crate::stats::Stats;
 pub struct StatsResponse {
     pub rows_read_count: u64,
     pub rows_written_count: u64,
+    pub storage_bytes_used: u64,
+}
+
+impl From<&Stats> for StatsResponse {
+    fn from(stats: &Stats) -> Self {
+        Self {
+            rows_read_count: stats.rows_read(),
+            rows_written_count: stats.rows_written(),
+            storage_bytes_used: stats.storage_bytes_used(),
+        }
+    }
+}
+
+impl From<Stats> for StatsResponse {
+    fn from(stats: Stats) -> Self {
+        (&stats).into()
+    }
 }
 
 pub fn handle_stats(stats: &Stats) -> Response<Body> {
-    let resp = StatsResponse {
-        rows_read_count: stats.rows_read(),
-        rows_written_count: stats.rows_written(),
-    };
+    let resp: StatsResponse = stats.into();
 
     let payload = serde_json::to_vec(&resp).unwrap();
     Response::builder()

--- a/sqld/src/stats.rs
+++ b/sqld/src/stats.rs
@@ -16,6 +16,7 @@ pub struct Stats {
 struct StatsInner {
     rows_written: AtomicU64,
     rows_read: AtomicU64,
+    storage_bytes_used: AtomicU64,
 }
 
 impl Stats {
@@ -46,6 +47,10 @@ impl Stats {
         self.inner.rows_read.fetch_add(n, Ordering::Relaxed);
     }
 
+    pub fn set_storage_bytes_used(&self, n: u64) {
+        self.inner.storage_bytes_used.store(n, Ordering::Relaxed);
+    }
+
     /// returns the total number of rows read since this database was created
     pub fn rows_read(&self) -> u64 {
         self.inner.rows_read.load(Ordering::Relaxed)
@@ -54,6 +59,11 @@ impl Stats {
     /// returns the total number of rows written since this database was created
     pub fn rows_written(&self) -> u64 {
         self.inner.rows_written.load(Ordering::Relaxed)
+    }
+
+    /// returns the total number of bytes used by the database (excluding uncheckpointed WAL entries)
+    pub fn storage_bytes_used(&self) -> u64 {
+        self.inner.storage_bytes_used.load(Ordering::Relaxed)
     }
 }
 


### PR DESCRIPTION
The new metrics track how many storage bytes are used by this sqld instance. It only tracks the main database file, under the assumption that the most interesting metrics for users is "how large is my database after I successfully checkpoint the write-ahead log".

Right now we don't have a separate fiber that performs checkpoints, but that's planned. And once we have it, inspecting storage should happen right after the checkpoint.

For now, the fiber that monitors storage used just runs once every 15 minutes.

Fixes #340