### PR TITLE
query_analysis: allow DROP INDEX

### DIFF
--- a/sqld/src/query_analysis.rs
+++ b/sqld/src/query_analysis.rs
@@ -55,6 +55,7 @@ impl StmtKind {
                 | Stmt::Update { .. }
                 | Stmt::Delete { .. }
                 | Stmt::DropTable { .. }
+                | Stmt::DropIndex { .. }
                 | Stmt::AlterTable { .. }
                 | Stmt::CreateTrigger {
                     temporary: false, ..


### PR DESCRIPTION
We allow creating indexes, so it stands to reason to also validate dropping them.

Fixes #374
Fixes https://github.com/chiselstrike/turso-cli/issues/384