### PR TITLE
fix sql wal methods leak

### DIFF
--- a/sqld-libsql-bindings/src/mwal/mod.rs
+++ b/sqld-libsql-bindings/src/mwal/mod.rs
@@ -2,6 +2,7 @@
 
 use std::sync::{Arc, Mutex};
 
+use super::Connection;
 pub use mwal::ffi;
 
 /// Opens a database with the virtual wal methods in the directory pointed to by path
@@ -9,7 +10,7 @@ pub fn open_with_virtual_wal(
     path: impl AsRef<std::path::Path>,
     flags: rusqlite::OpenFlags,
     vwal_methods: Arc<Mutex<mwal::ffi::libsql_wal_methods>>,
-) -> anyhow::Result<rusqlite::Connection> {
+) -> anyhow::Result<Connection> {
     let mut vwal_methods = vwal_methods.lock().map_err(|e| anyhow::anyhow!("{}", e))?;
     let path = path.as_ref().join("data");
     unsafe {
@@ -28,5 +29,8 @@ pub fn open_with_virtual_wal(
             .unwrap()
     })?;
     conn.pragma_update(None, "journal_mode", "wal")?;
-    Ok(conn)
+    Ok(Connection {
+        conn,
+        wal_methods: None,
+    })
 }

--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -89,7 +89,7 @@ pub fn open_db(
     path: &Path,
     wal_hook: impl WalHook + Send + Clone + 'static,
     with_bottomless: bool,
-) -> anyhow::Result<rusqlite::Connection> {
+) -> anyhow::Result<sqld_libsql_bindings::Connection> {
     let mut retries = 0;
     loop {
         #[cfg(feature = "mwal_backend")]
@@ -211,7 +211,7 @@ impl LibSqlDb {
 
 struct Connection {
     state: ConnectionState,
-    conn: rusqlite::Connection,
+    conn: sqld_libsql_bindings::Connection,
     timed_out: bool,
     stats: Stats,
 }

--- a/sqld/src/replication/replica/injector.rs
+++ b/sqld/src/replication/replica/injector.rs
@@ -76,7 +76,7 @@ impl FrameInjectorHandle {
 }
 
 pub struct FrameInjector {
-    conn: rusqlite::Connection,
+    conn: sqld_libsql_bindings::Connection,
     hook: InjectorHook,
 }
 


### PR DESCRIPTION
Fixes a leak with the WAL methods.

We should improve that by sharing the wal wal methods rather than creating a new one for each connection.
