### PR TITLE
limit max response size

### DIFF
--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -162,9 +162,15 @@ impl LibSqlDb {
         let (sender, receiver) = crossbeam::channel::unbounded::<Message>();
 
         tokio::task::spawn_blocking(move || {
-            let mut connection =
-                Connection::new(path.as_ref(), extensions, wal_hook, with_bottomless, stats, max_response_size)
-                    .unwrap();
+            let mut connection = Connection::new(
+                path.as_ref(),
+                extensions,
+                wal_hook,
+                with_bottomless,
+                stats,
+                max_response_size,
+            )
+            .unwrap();
             loop {
                 let message = match connection.state.deadline() {
                     Some(deadline) => match receiver.recv_deadline(deadline) {
@@ -226,7 +232,7 @@ impl Connection {
         wal_hook: impl WalHook + Send + Clone + 'static,
         with_bottomless: bool,
         stats: Stats,
-        max_response_size: usize
+        max_response_size: usize,
     ) -> anyhow::Result<Self> {
         let this = Self {
             conn: open_db(path, wal_hook, with_bottomless)?,
@@ -317,7 +323,6 @@ impl Connection {
 
         let mut qresult = stmt.raw_query();
         while let Some(row) = qresult.next()? {
-
             let mut values = vec![];
             for (i, _) in columns.iter().enumerate() {
                 values.push(row.get::<usize, rusqlite::types::Value>(i)?.into());
@@ -327,7 +332,7 @@ impl Connection {
 
             *size_budget = (*size_budget).saturating_sub(row.size_hint());
             if *size_budget == 0 {
-                return Err(Error::ResponseTooLarge)
+                return Err(Error::ResponseTooLarge);
             }
 
             rows.push(row);

--- a/sqld/src/database/write_proxy.rs
+++ b/sqld/src/database/write_proxy.rs
@@ -27,6 +27,7 @@ pub struct WriteProxyDbFactory {
     extensions: Vec<PathBuf>,
     stats: Stats,
     applied_frame_no_receiver: watch::Receiver<FrameNo>,
+    max_response_size: usize,
 }
 
 impl WriteProxyDbFactory {
@@ -37,6 +38,7 @@ impl WriteProxyDbFactory {
         uri: tonic::transport::Uri,
         stats: Stats,
         applied_frame_no_receiver: watch::Receiver<FrameNo>,
+        max_response_size: usize,
     ) -> Self {
         let client = ProxyClient::with_origin(channel, uri);
         Self {
@@ -45,6 +47,7 @@ impl WriteProxyDbFactory {
             extensions,
             stats,
             applied_frame_no_receiver,
+            max_response_size,
         }
     }
 }
@@ -58,6 +61,7 @@ impl DbFactory for WriteProxyDbFactory {
             self.extensions.clone(),
             self.stats.clone(),
             self.applied_frame_no_receiver.clone(),
+            self.max_response_size,
         )?;
         Ok(Arc::new(db))
     }
@@ -83,8 +87,9 @@ impl WriteProxyDatabase {
         extensions: Vec<PathBuf>,
         stats: Stats,
         applied_frame_no_receiver: watch::Receiver<FrameNo>,
+        max_response_size: usize,
     ) -> Result<Self> {
-        let read_db = LibSqlDb::new(path, extensions, (), false, stats)?;
+        let read_db = LibSqlDb::new(path, extensions, (), false, stats, max_response_size)?;
         Ok(Self {
             read_db,
             write_proxy,

--- a/sqld/src/error.rs
+++ b/sqld/src/error.rs
@@ -29,6 +29,8 @@ pub enum Error {
     ReplicatorExited,
     #[error("Timed out while openning database connection")]
     DbCreateTimeout,
+    #[error("Response payload exceeds the maximum allowed size, consider limiting the retreived results.")]
+    ResponseTooLarge,
 }
 
 impl From<tokio::sync::oneshot::error::RecvError> for Error {

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -267,7 +267,7 @@ async fn start_replica(
         uri,
         stats.clone(),
         applied_frame_no_receiver,
-        config.max_response_size
+        config.max_response_size,
     )
     .throttled(MAX_CONCCURENT_DBS, Some(DB_CREATE_TIMEOUT));
 

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -97,6 +97,7 @@ pub struct Config {
     pub heartbeat_url: Option<String>,
     pub heartbeat_auth: Option<String>,
     pub heartbeat_period: Duration,
+    pub max_response_size: usize,
 }
 
 async fn run_service(
@@ -266,6 +267,7 @@ async fn start_replica(
         uri,
         stats.clone(),
         applied_frame_no_receiver,
+        config.max_response_size
     )
     .throttled(MAX_CONCCURENT_DBS, Some(DB_CREATE_TIMEOUT));
 
@@ -361,6 +363,7 @@ async fn start_primary(
     let valid_extensions = validate_extensions(config.extensions_path.clone())?;
 
     let stats_clone = stats.clone();
+    let max_response_size = config.max_response_size;
     let db_factory = Arc::new(
         (move || {
             let db_path = path_clone.clone();
@@ -374,6 +377,7 @@ async fn start_primary(
                     hook,
                     enable_bottomless,
                     stats_clone,
+                    max_response_size,
                 )
             }
         })

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -149,6 +149,10 @@ struct Cli {
     /// By default, the the period is 30 seconds.
     #[clap(long, env = "SQLD_HEARTBEAT_PERIOD_S", default_value = "30")]
     heartbeat_period_s: u64,
+    /// Maximum allowed response size in bytes. Defaults to 10MB.
+    /// This is a best effort limit based on estimations of the size of the serialized response.
+    #[clap(long, env = "SQLD_MAX_RESPONSE_SIZE", default_value = "10000000")]
+    max_response_size: usize,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -250,6 +254,7 @@ fn config_from_args(args: Cli) -> Result<Config> {
         heartbeat_url: args.heartbeat_url,
         heartbeat_auth: args.heartbeat_auth,
         heartbeat_period: Duration::from_secs(args.heartbeat_period_s),
+        max_response_size: args.max_response_size,
     })
 }
 


### PR DESCRIPTION
This PR adds a limit to the size of the response that sqld can send. This is settable with the `--max-response-size` arg, and defaults to 10MB. If the size for a response would exceed this number, an error is returned to the user. The size of the payload is estimated before the payload is serialized, so it's a best effort approach. We might over or underestimate the actually payload size.
