### PR TITLE
Additions to Hrana 2

### DIFF
--- a/docs/HRANA_1_SPEC.md
+++ b/docs/HRANA_1_SPEC.md
@@ -94,6 +94,10 @@ type ServerMsg =
 The client sends messages of type `ClientMsg`, and the server sends messages of
 type `ServerMsg`. The type of the message is determined by its `type` field.
 
+To maintain backwards compatibility, the recipient must ignore any unrecognized
+fields in the JSON messages. However, if the recipient receives a message with
+unrecognized `type`, it must abort the connection.
+
 ### Hello
 
 ```typescript
@@ -311,7 +315,7 @@ guess the correct prefix. If an argument is specified both as a positional
 argument and as a named argument, the named argument should take precedence.
 
 It is an error if the request specifies an argument that is not expected by the
-SQL statement, or if the request does not specify and argument that is expected
+SQL statement, or if the request does not specify an argument that is expected
 by the SQL statement. Some servers may not support specifying both positional
 and named arguments.
 

--- a/sqld/proto/proxy.proto
+++ b/sqld/proto/proxy.proto
@@ -72,6 +72,7 @@ enum Type {
 message Column {
     string          name = 1;
     optional Type   ty = 2;
+    optional string decltype = 3;
 }
 
 message DisconnectMessage {

--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -297,6 +297,7 @@ impl Connection {
                     .transpose()
                     .ok()
                     .flatten(),
+                decltype: col.decl_type().map(|t| t.into()),
             })
             .collect::<Vec<_>>();
 
@@ -343,7 +344,7 @@ impl Connection {
 
     fn rollback(&self) {
         self.conn
-            .execute("rollback transaction;", ())
+            .execute("ROLLBACK", ())
             .expect("failed to rollback");
     }
 

--- a/sqld/src/database/mod.rs
+++ b/sqld/src/database/mod.rs
@@ -148,7 +148,7 @@ pub trait Database: Send + Sync {
         Ok(())
     }
 
-    /// Parse the SQL statements and return information about it.
+    /// Parse the SQL statement and return information about it.
     async fn describe(&self, sql: String, auth: Authenticated) -> Result<DescribeResult>;
 }
 

--- a/sqld/src/hrana/proto.rs
+++ b/sqld/src/hrana/proto.rs
@@ -29,6 +29,7 @@ pub enum Request {
     CloseStream(CloseStreamReq),
     Execute(ExecuteReq),
     Batch(BatchReq),
+    Sequence(SequenceReq),
     Describe(DescribeReq),
     StoreSql(StoreSqlReq),
     CloseSql(CloseSqlReq),
@@ -41,6 +42,7 @@ pub enum Response {
     CloseStream(CloseStreamResp),
     Execute(ExecuteResp),
     Batch(BatchResp),
+    Sequence(SequenceResp),
     Describe(DescribeResp),
     StoreSql(StoreSqlResp),
     CloseSql(CloseSqlResp),
@@ -84,6 +86,17 @@ pub struct BatchResp {
     pub result: BatchResult,
 }
 
+#[derive(Deserialize, Debug)]
+pub struct SequenceReq {
+    pub stream_id: i32,
+    #[serde(default)]
+    pub sql: Option<String>,
+    #[serde(default)]
+    pub sql_id: Option<i32>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct SequenceResp {}
 #[derive(Deserialize, Debug)]
 pub struct DescribeReq {
     pub stream_id: i32,
@@ -153,6 +166,7 @@ pub struct StmtResult {
 #[derive(Serialize, Debug)]
 pub struct Col {
     pub name: Option<String>,
+    pub decltype: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/sqld/src/hrana/stmt.rs
+++ b/sqld/src/hrana/stmt.rs
@@ -142,6 +142,7 @@ pub fn proto_stmt_result_from_query_response(query_response: QueryResponse) -> p
         .into_iter()
         .map(|col| proto::Col {
             name: Some(col.name),
+            decltype: col.decltype,
         })
         .collect();
     let proto_rows = result_set

--- a/sqld/src/query.rs
+++ b/sqld/src/query.rs
@@ -23,6 +23,7 @@ pub type QueryResult = Result<QueryResponse, Error>;
 pub struct Column {
     pub name: String,
     pub ty: Option<Type>,
+    pub decltype: Option<String>,
 }
 
 impl From<Column> for RpcColumn {
@@ -30,6 +31,7 @@ impl From<Column> for RpcColumn {
         RpcColumn {
             name: other.name,
             ty: other.ty.map(|ty| RpcType::from(ty).into()),
+            decltype: other.decltype,
         }
     }
 }
@@ -241,6 +243,7 @@ impl From<ResultRows> for ResultSet {
             .map(|c| Column {
                 ty: Some(c.ty().into()),
                 name: c.name,
+                decltype: c.decltype,
             })
             .collect();
 
@@ -296,8 +299,6 @@ pub enum Params {
     Named(HashMap<String, Value>),
     Positional(Vec<Value>),
 }
-
-impl Params {}
 
 impl Params {
     pub fn empty() -> Self {


### PR DESCRIPTION
Profusion's new Python client has highlighted the need to add two more features to Hrana 2:

- Include decltype of every column in statement response.
- Add a `sequence` request to execute a sequence of SQL statements separated by semicolons.