### PR TITLE
move extension loading to debug

### DIFF
--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -237,7 +237,7 @@ impl Connection {
                 this.conn
                     .load_extension(&ext, None)
                     .with_context(|| format!("Could not load extension: {}", &ext.display()))?;
-                tracing::info!("Loaded extension {}", ext.display());
+                tracing::debug!("Loaded extension {}", ext.display());
             }
         }
 


### PR DESCRIPTION
It is really a debug message. I left it as info because I thought this would be printed just once - when we establish the long lived connection to libsql.

However, on requests forwarded to the primary from the replica, this is printed for every request, which is a lot.

This was noticed by athos.

A bigger problem is that extensions being loaded for every request is quite expensive, and this changes the calculation a bit.

But one problem at a time!