### PR TITLE
Don't return rows when `want_rows` is false

### DIFF
--- a/sqld/proto/proxy.proto
+++ b/sqld/proto/proxy.proto
@@ -13,6 +13,7 @@ message Query {
         Positional positional = 2;
         Named named = 3;
     }
+    bool skip_rows = 4;
 }
 
 message Positional {

--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -308,6 +308,13 @@ impl Connection {
 
         let mut qresult = stmt.raw_query();
         while let Some(row) = qresult.next()? {
+            if !query.want_rows {
+                // if the caller does not want rows, we keep `rows` empty, but we still iterate the
+                // statement to completion to make sure that we don't miss any errors or side
+                // effects
+                continue;
+            }
+
             let mut values = vec![];
             for (i, _) in columns.iter().enumerate() {
                 values.push(row.get::<usize, rusqlite::types::Value>(i)?.into());

--- a/sqld/src/database/mod.rs
+++ b/sqld/src/database/mod.rs
@@ -102,6 +102,7 @@ pub trait Database: Send + Sync {
                 query: Query {
                     stmt: Statement::parse("ROLLBACK").next().unwrap().unwrap(),
                     params: Params::empty(),
+                    want_rows: false,
                 },
                 cond: Some(Cond::Not {
                     cond: Box::new(Cond::Ok {
@@ -138,6 +139,7 @@ pub trait Database: Send + Sync {
                 Query {
                     stmt: Statement::parse("ROLLBACK").next().unwrap().unwrap(),
                     params: Params::empty(),
+                    want_rows: false,
                 },
                 auth,
             )

--- a/sqld/src/hrana/batch.rs
+++ b/sqld/src/hrana/batch.rs
@@ -122,6 +122,7 @@ pub fn proto_sequence_to_program(sql: &str) -> Result<Program> {
             let query = Query {
                 stmt,
                 params: Params::empty(),
+                want_rows: false,
             };
             Step { cond, query }
         })

--- a/sqld/src/hrana/stmt.rs
+++ b/sqld/src/hrana/stmt.rs
@@ -105,7 +105,12 @@ pub fn proto_stmt_to_query(
         bail!(StmtError::ArgsBothPositionalAndNamed)
     };
 
-    Ok(Query { stmt, params })
+    let want_rows = proto_stmt.want_rows.unwrap_or(true);
+    Ok(Query {
+        stmt,
+        params,
+        want_rows,
+    })
 }
 
 pub fn proto_sql_to_sql<'s>(

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -134,6 +134,7 @@ fn parse_queries(queries: Vec<QueryObject>) -> anyhow::Result<Vec<Query>> {
         let query = Query {
             stmt,
             params: query.params.0,
+            want_rows: true,
         };
 
         out.push(query);

--- a/sqld/src/postgres/handlers.rs
+++ b/sqld/src/postgres/handlers.rs
@@ -77,6 +77,7 @@ impl SimpleQueryHandler for QueryHandler {
                 s.map(|stmt| Query {
                     stmt,
                     params: Params::empty(),
+                    want_rows: true,
                 })
             })
             .collect::<anyhow::Result<Vec<_>>>();
@@ -124,7 +125,11 @@ impl ExtendedQueryHandler for QueryHandler {
 
         let params = parse_params(portal.statement().parameter_types(), portal.parameters());
 
-        let query = Query { stmt, params };
+        let query = Query {
+            stmt,
+            params,
+            want_rows: true,
+        };
         let include_col_defs = client.metadata_mut().remove(REQUEST_DESCRIBE).is_some();
         self.handle_queries(vec![query], include_col_defs)
             .await

--- a/sqld/src/query.rs
+++ b/sqld/src/query.rs
@@ -278,6 +278,7 @@ pub enum QueryResponse {
 pub struct Query {
     pub stmt: Statement,
     pub params: Params,
+    pub want_rows: bool,
 }
 
 impl ToSql for Value {

--- a/sqld/src/rpc/proxy.rs
+++ b/sqld/src/rpc/proxy.rs
@@ -214,6 +214,7 @@ pub mod rpc {
                     .params
                     .context("missing params in query")?
                     .try_into()?,
+                want_rows: !query.skip_rows,
             })
         }
     }
@@ -237,6 +238,7 @@ pub mod rpc {
             Self {
                 stmt: query.stmt.stmt,
                 params: Some(query.params.try_into().unwrap()),
+                skip_rows: !query.want_rows,
             }
         }
     }


### PR DESCRIPTION
Hrana statements can set `want_rows` to false to indicate that the caller is not interested in rows returned by the statement. However, I forgot to actually implement this in sqld! Time to fix this :)