### PR TITLE
Add HTTP API v2, based on Hrana 2

### DIFF
--- a/docs/HTTP_V2_SPEC.md
+++ b/docs/HTTP_V2_SPEC.md
@@ -1,0 +1,106 @@
+# The sqld HTTP API v2 specification ("Hrana over HTTP")
+
+Version 2 of the HTTP API ("Hrana over HTTP") extends the HTTP API with features
+introduced in Hrana 2.
+
+## Overview
+
+This HTTP API uses data structures and semantics from the Hrana 2 protocol.
+Endpoints in the HTTP API correspond to requests in Hrana. Each request is
+executed as if a fresh Hrana stream was opened for the request.
+
+All request and response bodies are encoded in JSON, with content type
+`application/json`.
+
+## Version check
+
+```
+GET /v2
+```
+
+A server that supports HTTP API v2 must return a success response for requests
+on path `/v2`. This can be used as a crude and unreliable mechanism for clients
+to fall back to version 1 of the protocol if the server does not support version
+2.
+
+## Execute a statement
+
+```
+POST /v2/execute
+
+-> {
+    "stmt": Stmt,
+}
+
+<- {
+    "result": StmtResult,
+}
+```
+
+The `execute` endpoint receives a statement and returns the result of executing
+the statement. The `Stmt` and `StmtResult` structures are from the Hrana
+protocol. The semantics of this endpoint is the same as the `execute` request in
+Hrana.
+
+Note that specifying the SQL text using `sql_id` in `Stmt` is never valid,
+because there is no way to store SQL texts on the server using the HTTP API.
+
+## Execute a batch
+
+```
+POST /v2/batch
+
+-> {
+    "batch": Batch,
+}
+
+<- {
+    "result": BatchResult,
+}
+```
+
+The `batch` endpoint receives a batch and returns the result of executing the
+statement. The `Batch` and `BatchResult` structures are from the Hrana protocol.
+The semantics of this endpoint is the same as the `batch` request in Hrana.
+
+## Execute a sequence
+
+```
+POST /v2/sequence
+
+-> {
+    "sql": string,
+}
+
+<- {
+}
+```
+
+The `sequence` endpoint receives a SQL text with statements separated by
+semicolons and executes it in the same way as the `sequence` request in Hrana.
+
+## Describe a statement
+
+```
+POST /v2/describe
+
+-> {
+    "sql": string,
+}
+
+<- {
+    "result": DescribeResult,
+}
+```
+
+The `describe` endpoint receives a SQL statement and returns information about
+this statement, with the same semantics as the `describe` request in Hrana.
+
+## Errors
+
+Successful responses are indicated by a HTTP status code in range [200, 300).
+Errors are indicated with HTTP status codes in range [400, 600), and the error
+responses should have the format of `Error` from the Hrana protocol. However,
+the clients should be able to handle error responses that don't correspond to
+this format; in particular, the server may produce some error responses with the
+error message as plain text.

--- a/sqld/src/hrana/batch.rs
+++ b/sqld/src/hrana/batch.rs
@@ -11,7 +11,7 @@ use super::handshake::Protocol;
 use super::proto;
 use super::stmt::{
     proto_error_from_stmt_error, proto_stmt_result_from_query_response, proto_stmt_to_query,
-    stmt_error_from_sqld_error,
+    stmt_error_from_sqld_error, StmtError,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -110,7 +110,10 @@ pub async fn execute_batch(
 }
 
 pub fn proto_sequence_to_program(sql: &str) -> Result<Program> {
-    let stmts = Statement::parse(sql).collect::<Result<Vec<_>>>()?;
+    let stmts = Statement::parse(sql)
+        .collect::<Result<Vec<_>>>()
+        .map_err(|err| anyhow!(StmtError::SqlParse { source: err }))?;
+
     let steps = stmts
         .into_iter()
         .enumerate()

--- a/sqld/src/hrana/mod.rs
+++ b/sqld/src/hrana/mod.rs
@@ -8,7 +8,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 
-pub use self::batch::{execute_batch, proto_batch_to_program, BatchError};
+pub use self::batch::{
+    execute_batch, execute_sequence, proto_batch_to_program, proto_sequence_to_program, BatchError,
+};
 pub use self::handshake::Protocol;
 pub use self::stmt::{
     describe_stmt, execute_stmt, proto_sql_to_sql, proto_stmt_to_query, StmtError,

--- a/sqld/src/hrana/session.rs
+++ b/sqld/src/hrana/session.rs
@@ -222,7 +222,7 @@ pub(super) async fn handle_request(
                 &session.sqls,
                 session.protocol,
             )?;
-            let pgm = proto_sequence_to_program(sql).map_err(wrap_batch_error)?;
+            let pgm = proto_sequence_to_program(sql).map_err(wrap_stmt_error)?;
             let auth = session.authenticated;
             stream_respond!(stream_hnd, async move |stream| {
                 let Some(db) = stream.db.as_ref() else {

--- a/sqld/src/http/hrana_over_http.rs
+++ b/sqld/src/http/hrana_over_http.rs
@@ -23,16 +23,16 @@ enum ResponseError {
 pub async fn handle_index(
     _req: hyper::Request<hyper::Body>,
 ) -> Result<hyper::Response<hyper::Body>> {
-    let body = "This is sqld HTTP API v1 (\"Hrana over HTTP\")";
-    let body = hyper::Body::from(body);
+    let body = "This is sqld HTTP API v1 and v2 (\"Hrana over HTTP\")";
     Ok(hyper::Response::builder()
         .header("content-type", "text/plain")
-        .body(body)
+        .body(hyper::Body::from(body))
         .unwrap())
 }
 
 pub async fn handle_execute(
     db_factory: Arc<dyn DbFactory>,
+    protocol: hrana::Protocol,
     auth: Authenticated,
     req: hyper::Request<hyper::Body>,
 ) -> Result<hyper::Response<hyper::Body>> {
@@ -46,31 +46,20 @@ pub async fn handle_execute(
         result: hrana::proto::StmtResult,
     }
 
-    handle_request(
-        db_factory,
-        auth,
-        req,
-        |db, auth: Authenticated, req_body: ReqBody| async move {
-            let query = hrana::proto_stmt_to_query(
-                &req_body.stmt,
-                &HashMap::new(),
-                hrana::Protocol::Hrana1,
-            )?;
-            hrana::execute_stmt(&*db, auth, query)
-                .await
-                .map(|result| RespBody { result })
-                .map_err(|err| match err.downcast::<hrana::StmtError>() {
-                    Ok(stmt_err) => anyhow!(ResponseError::Stmt(stmt_err)),
-                    Err(err) => err,
-                })
-                .context("Could not execute statement")
-        },
-    )
+    handle_request(db_factory, req, |db, req_body: ReqBody| async move {
+        let query = hrana::proto_stmt_to_query(&req_body.stmt, &HashMap::new(), protocol)?;
+        hrana::execute_stmt(&*db, auth, query)
+            .await
+            .map(|result| RespBody { result })
+            .map_err(wrap_stmt_error)
+            .context("Could not execute statement")
+    })
     .await
 }
 
 pub async fn handle_batch(
     db_factory: Arc<dyn DbFactory>,
+    protocol: hrana::Protocol,
     auth: Authenticated,
     req: hyper::Request<hyper::Body>,
 ) -> Result<hyper::Response<hyper::Body>> {
@@ -84,39 +73,75 @@ pub async fn handle_batch(
         result: hrana::proto::BatchResult,
     }
 
-    handle_request(
-        db_factory,
-        auth,
-        req,
-        |db, auth: Authenticated, req_body: ReqBody| async move {
-            let pgm = hrana::proto_batch_to_program(
-                &req_body.batch,
-                &HashMap::new(),
-                hrana::Protocol::Hrana1,
-            )?;
-            hrana::execute_batch(&*db, auth, pgm)
-                .await
-                .map(|result| RespBody { result })
-                .map_err(|err| match err.downcast::<hrana::BatchError>() {
-                    Ok(batch_err) => anyhow!(ResponseError::Batch(batch_err)),
-                    Err(err) => err,
-                })
-                .context("Could not execute batch")
-        },
-    )
+    handle_request(db_factory, req, |db, req_body: ReqBody| async move {
+        let pgm = hrana::proto_batch_to_program(&req_body.batch, &HashMap::new(), protocol)?;
+        hrana::execute_batch(&*db, auth, pgm)
+            .await
+            .map(|result| RespBody { result })
+            .map_err(wrap_batch_error)
+            .context("Could not execute batch")
+    })
+    .await
+}
+
+pub async fn handle_sequence(
+    db_factory: Arc<dyn DbFactory>,
+    auth: Authenticated,
+    req: hyper::Request<hyper::Body>,
+) -> Result<hyper::Response<hyper::Body>> {
+    #[derive(Debug, Deserialize)]
+    struct ReqBody {
+        sql: String,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct RespBody {}
+
+    handle_request(db_factory, req, |db, req_body: ReqBody| async move {
+        let pgm = hrana::proto_sequence_to_program(&req_body.sql).map_err(wrap_stmt_error)?;
+        hrana::execute_sequence(&*db, auth, pgm)
+            .await
+            .map(|_| RespBody {})
+            .map_err(wrap_stmt_error)
+            .context("Could not execute sequence")
+    })
+    .await
+}
+
+pub async fn handle_describe(
+    db_factory: Arc<dyn DbFactory>,
+    auth: Authenticated,
+    req: hyper::Request<hyper::Body>,
+) -> Result<hyper::Response<hyper::Body>> {
+    #[derive(Debug, Deserialize)]
+    struct ReqBody {
+        sql: String,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct RespBody {
+        result: hrana::proto::DescribeResult,
+    }
+
+    handle_request(db_factory, req, |db, req_body: ReqBody| async move {
+        hrana::describe_stmt(&*db, auth, req_body.sql)
+            .await
+            .map(|result| RespBody { result })
+            .map_err(wrap_stmt_error)
+            .context("Could not describe statement")
+    })
     .await
 }
 
 async fn handle_request<ReqBody, RespBody, F, Fut>(
     db_factory: Arc<dyn DbFactory>,
-    auth: Authenticated,
     req: hyper::Request<hyper::Body>,
     f: F,
 ) -> Result<hyper::Response<hyper::Body>>
 where
     ReqBody: DeserializeOwned,
     RespBody: Serialize,
-    F: FnOnce(Arc<dyn Database>, Authenticated, ReqBody) -> Fut,
+    F: FnOnce(Arc<dyn Database>, ReqBody) -> Fut,
     Fut: Future<Output = Result<RespBody>>,
 {
     let res: Result<_> = async move {
@@ -128,7 +153,7 @@ where
             .create()
             .await
             .context("Could not create a database connection")?;
-        let resp_body = f(db, auth, req_body).await?;
+        let resp_body = f(db, req_body).await?;
 
         Ok(json_response(hyper::StatusCode::OK, &resp_body))
     }
@@ -181,6 +206,20 @@ fn json_response<T: Serialize>(
         .header("content-type", "application/json")
         .body(hyper::Body::from(body))
         .unwrap()
+}
+
+fn wrap_stmt_error(err: anyhow::Error) -> anyhow::Error {
+    match err.downcast::<hrana::StmtError>() {
+        Ok(stmt_err) => anyhow!(ResponseError::Stmt(stmt_err)),
+        Err(err) => err,
+    }
+}
+
+fn wrap_batch_error(err: anyhow::Error) -> anyhow::Error {
+    match err.downcast::<hrana::BatchError>() {
+        Ok(batch_err) => anyhow!(ResponseError::Batch(batch_err)),
+        Err(err) => err,
+    }
 }
 
 impl ResponseError {

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -247,12 +247,28 @@ async fn handle_request(
         (&Method::GET, "/version") => Ok(handle_version()),
         (&Method::GET, "/console") if enable_console => show_console().await,
         (&Method::GET, "/health") => Ok(handle_health()),
-        (&Method::GET, "/v1") => hrana_over_http::handle_index(req).await,
-        (&Method::POST, "/v1/execute") => {
-            hrana_over_http::handle_execute(db_factory, auth, req).await
-        }
-        (&Method::POST, "/v1/batch") => hrana_over_http::handle_batch(db_factory, auth, req).await,
         (&Method::GET, "/v1/stats") => Ok(stats::handle_stats(&stats)),
+
+        (&Method::GET, "/v1" | "/v2") => hrana_over_http::handle_index(req).await,
+        (&Method::POST, "/v1/execute") => {
+            hrana_over_http::handle_execute(db_factory, hrana::Protocol::Hrana1, auth, req).await
+        }
+        (&Method::POST, "/v2/execute") => {
+            hrana_over_http::handle_execute(db_factory, hrana::Protocol::Hrana2, auth, req).await
+        }
+        (&Method::POST, "/v1/batch") => {
+            hrana_over_http::handle_batch(db_factory, hrana::Protocol::Hrana1, auth, req).await
+        }
+        (&Method::POST, "/v2/batch") => {
+            hrana_over_http::handle_batch(db_factory, hrana::Protocol::Hrana2, auth, req).await
+        }
+        (&Method::POST, "/v2/sequence") => {
+            hrana_over_http::handle_sequence(db_factory, auth, req).await
+        }
+        (&Method::POST, "/v2/describe") => {
+            hrana_over_http::handle_describe(db_factory, auth, req).await
+        }
+
         _ => Ok(Response::builder().status(404).body(Body::empty()).unwrap()),
     }
 }


### PR DESCRIPTION
Version 2 of the HTTP API ("Hrana over HTTP") extends the HTTP API with features introduced in Hrana 2.