### PR TITLE
sqld-libsql-bindings: make register+find atomic

### DIFF
--- a/sqld-libsql-bindings/Cargo.toml
+++ b/sqld-libsql-bindings/Cargo.toml
@@ -14,6 +14,8 @@ rusqlite = { version = "0.29.0", git = "https://github.com/psarna/rusqlite", rev
     "bundled-libsql-wasm-experimental",
     "column_decltype"
 ] }
+once_cell = "1.17.0"
+parking_lot = "0.12.1"
 tracing = "0.1.37"
 
 [features]


### PR DESCRIPTION
When registering WAL methods and later opening a connection with them, sqld is currently subject to race condition, where multiple threads can register methods by the same name, and then look up the same instance of them.
That's dangerous, because our methods hold state.
The short-term solution for this problem is to make register+find globally atomic. A proper solution will allow libsql_open() to take a pointer to user state, making any race conditions moot.