### PR TITLE
sqld-libsql-bindings: deregister methods before freeing them

### DIFF
--- a/sqld-libsql-bindings/src/ffi/mod.rs
+++ b/sqld-libsql-bindings/src/ffi/mod.rs
@@ -3,9 +3,10 @@
 pub mod types;
 
 pub use rusqlite::ffi::{
-    libsql_wal_methods, libsql_wal_methods_find, libsql_wal_methods_register, sqlite3,
-    sqlite3_file, sqlite3_io_methods, sqlite3_vfs, WalIndexHdr, SQLITE_CANTOPEN,
-    SQLITE_CHECKPOINT_FULL, SQLITE_CHECKPOINT_TRUNCATE, SQLITE_IOERR_WRITE, SQLITE_OK,
+    libsql_wal_methods, libsql_wal_methods_find, libsql_wal_methods_register,
+    libsql_wal_methods_unregister, sqlite3, sqlite3_file, sqlite3_io_methods, sqlite3_vfs,
+    WalIndexHdr, SQLITE_CANTOPEN, SQLITE_CHECKPOINT_FULL, SQLITE_CHECKPOINT_TRUNCATE,
+    SQLITE_IOERR_WRITE, SQLITE_OK,
 };
 
 pub use rusqlite::ffi::libsql_pghdr as PgHdr;


### PR DESCRIPTION
If the WAL methods are not deregistered from a global libSQL table before dropping them, we end up with having a dangling pointer in the libSQL structure. It often worked, because the freed memory just didn't manage to get overwritten yet, but it was a time bomb nonetheless.

The scenario was as follows:
1. Fiber A registers WAL methods W1
2. Fiber A frees WAL methods W1, but does not deregister them from the libSQL global data structure
3. Fiber B registers WAL methods W2, and registration involves iterating over the data structure that contains a dangling pointer, after the methods were freed by (2.)