### PR TITLE
sqld: bump rusqlite to revision without memory leak for Wasm UDF

### DIFF
--- a/sqld-libsql-bindings/Cargo.toml
+++ b/sqld-libsql-bindings/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0.66"
 mvfs = { git = "https://github.com/psarna/mvsqlite", branch = "mwal", optional = true }
 mwal = { git = "https://github.com/psarna/mvsqlite", branch = "mwal", optional = true }
-rusqlite = { version = "0.29.0", git = "https://github.com/psarna/rusqlite", rev = "a6332e530f30dc2d47110", default-features = false, features = [
+rusqlite = { version = "0.29.0", git = "https://github.com/psarna/rusqlite", rev = "b53d623ce", default-features = false, features = [
     "buildtime_bindgen",
     "bundled-libsql-wasm-experimental",
     "column_decltype"

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -32,7 +32,7 @@ pin-project-lite = "0.2.9"
 postgres-protocol = "0.6.4"
 prost = "0.11.3"
 regex = "1.7.0"
-rusqlite = { version = "0.29.0", git = "https://github.com/psarna/rusqlite", rev = "a6332e530f30dc2d47110", default-features = false, features = [
+rusqlite = { version = "0.29.0", git = "https://github.com/psarna/rusqlite", rev = "b53d623ce", default-features = false, features = [
     "buildtime_bindgen",
     "bundled-libsql-wasm-experimental",
     "column_decltype",


### PR DESCRIPTION
Ref: https://github.com/libsql/libsql/pull/169