### PR TITLE
mimalloc: drop secure mode

### DIFF
--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -57,7 +57,7 @@ uuid = { version = "1.3", features = ["v4", "serde"] }
 nix = { version = "0.26.2", features = ["fs"] }
 tempfile = "3.3.0"
 memmap = "0.7.0"
-mimalloc = "0.1.36"
+mimalloc = { version = "0.1.36", default-features = false }
 sha256 = "1.1.3"
 reqwest = { version = "0.11.16", features = ["json", "rustls-tls"], default-features = false }
 


### PR DESCRIPTION
Secure mode has a performance and overhead penalty, and we don't really need to be robust against memory reuse attacks in sqld.
Simple measurements show that secure mode can bump resident memory usage as much as 250%, plus there's the cpu cost of encrypting freelists and other features that they offer.