### PR TITLE
trace SQL commands

### DIFF
--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -284,6 +284,8 @@ impl Connection {
     }
 
     fn execute_query_inner(&self, query: &Query) -> QueryResult {
+        tracing::trace!("executing query: {}", query.stmt.stmt);
+
         let mut rows = vec![];
         let mut stmt = self.conn.prepare(&query.stmt.stmt)?;
         let columns = stmt


### PR DESCRIPTION
Log the SQL command being executed with the trace level.

You can filter for log lines with the trace level coming specifically from this module with: `RUST_LOG=sqld::database::libsql=trace`
