### PR TITLE
sqld: add optional heap limiting

### DIFF
--- a/sqld-libsql-bindings/src/ffi/mod.rs
+++ b/sqld-libsql-bindings/src/ffi/mod.rs
@@ -4,9 +4,9 @@ pub mod types;
 
 pub use rusqlite::ffi::{
     libsql_wal_methods, libsql_wal_methods_find, libsql_wal_methods_register,
-    libsql_wal_methods_unregister, sqlite3, sqlite3_file, sqlite3_io_methods, sqlite3_vfs,
-    WalIndexHdr, SQLITE_CANTOPEN, SQLITE_CHECKPOINT_FULL, SQLITE_CHECKPOINT_TRUNCATE,
-    SQLITE_IOERR_WRITE, SQLITE_OK,
+    libsql_wal_methods_unregister, sqlite3, sqlite3_file, sqlite3_hard_heap_limit64,
+    sqlite3_io_methods, sqlite3_soft_heap_limit64, sqlite3_vfs, WalIndexHdr, SQLITE_CANTOPEN,
+    SQLITE_CHECKPOINT_FULL, SQLITE_CHECKPOINT_TRUNCATE, SQLITE_IOERR_WRITE, SQLITE_OK,
 };
 
 pub use rusqlite::ffi::libsql_pghdr as PgHdr;

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -149,6 +149,15 @@ struct Cli {
     /// By default, the the period is 30 seconds.
     #[clap(long, env = "SQLD_HEARTBEAT_PERIOD_S", default_value = "30")]
     heartbeat_period_s: u64,
+
+    /// Soft heap size limit in mebibytes - libSQL will try to not go over this limit with memory usage.
+    #[clap(long, env = "SQLD_SOFT_HEAP_LIMIT_MB")]
+    soft_heap_limit_mb: Option<usize>,
+
+    /// Hard heap size limit in mebibytes - libSQL will bail out with SQLITE_NOMEM error
+    /// if it goes over this limit with memory usage.
+    #[clap(long, env = "SQLD_HARD_HEAP_LIMIT_MB")]
+    hard_heap_limit_mb: Option<usize>,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -250,6 +259,8 @@ fn config_from_args(args: Cli) -> Result<Config> {
         heartbeat_url: args.heartbeat_url,
         heartbeat_auth: args.heartbeat_auth,
         heartbeat_period: Duration::from_secs(args.heartbeat_period_s),
+        soft_heap_limit_mb: args.soft_heap_limit_mb,
+        hard_heap_limit_mb: args.hard_heap_limit_mb,
     })
 }
 


### PR DESCRIPTION
libSQL has no notion of checking how much physical memory is available, if there's swap space configured, etc. Normally it limits its own allocations to 2GiB, but on small edge machines it can already prove to be too much to handle. To remedy that, two command-line options are added to sqld - `soft_heap_limit_mb` and `hard_heap_limit_mb`. Soft heap limit hints to libSQL that it should not allocate once the limit is reached and put pressure on shrinking caches, but it will choose to overallocate rather than fail with SQLITE_NOMEM error. Hard limit bails out once an allocation is attempted past the limit.  While we could automatically detect the hardware setup on boot, command-line options are good enough for a start to avoid out-of-memory (OOM) conditions. A good rule of thumb would be to set the soft limit to, say, 70% of available physical memory, and hard limit to 90%, leaving some leeway for the operating system.

Local tests imply that libSQL is really good at keeping allocations above even soft limit, with a negligible error margin.