### PR TITLE
sqld-libsql-bindings: run connections in locking_mode=exclusive

### DIFF
--- a/sqld-libsql-bindings/src/lib.rs
+++ b/sqld-libsql-bindings/src/lib.rs
@@ -94,6 +94,7 @@ pub fn open_with_regular_wal(
     }
     drop(opening_lock);
     conn.pragma_update(None, "journal_mode", "wal")?;
+    conn.pragma_update(None, "locking_mode", "exclusive")?;
 
     Ok(Connection {
         conn,


### PR DESCRIPTION
Exclusive locking mode lets libSQL know that it can assume that we're the only OS process that uses the database.
That removes most of the file lock calls, but more importantly, it makes WAL index not use shared memory.