### PR TITLE
Flush large transaction to shadow WAL when too large

### DIFF
--- a/sqld/src/replication/frame.rs
+++ b/sqld/src/replication/frame.rs
@@ -60,6 +60,10 @@ impl Frame {
         anyhow::ensure!(data.len() == Self::SIZE, "invalid frame size");
         Ok(Self { data })
     }
+
+    pub fn bytes(&self) -> Bytes {
+        self.data.clone()
+    }
 }
 
 /// The borrowed version of Frame
@@ -77,7 +81,7 @@ impl FrameBorrowed {
     }
 
     /// Returns the bytes for this frame. Includes the header bytes.
-    pub fn as_bytes(&self) -> &[u8] {
+    pub fn as_slice(&self) -> &[u8] {
         &self.data
     }
 

--- a/sqld/src/replication/primary/frame_stream.rs
+++ b/sqld/src/replication/primary/frame_stream.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 use std::task::{ready, Poll};
 use std::{pin::Pin, task::Context};
 
-use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::Stream;
 
+use crate::replication::frame::Frame;
 use crate::replication::{FrameNo, LogReadError, ReplicationLogger};
 
 /// Streams frames from the replication log starting at `current_frame_no`.
@@ -52,12 +52,12 @@ enum FrameStreamState {
     Init,
     /// waiting for new frames to replicate
     WaitingFrameNo(BoxFuture<'static, anyhow::Result<FrameNo>>),
-    WaitingFrame(BoxFuture<'static, Result<Bytes, LogReadError>>),
+    WaitingFrame(BoxFuture<'static, Result<Frame, LogReadError>>),
     Closed,
 }
 
 impl Stream for FrameStream {
-    type Item = Result<Bytes, LogReadError>;
+    type Item = Result<Frame, LogReadError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.state {

--- a/sqld/src/replication/replica/snapshot.rs
+++ b/sqld/src/replication/replica/snapshot.rs
@@ -25,7 +25,7 @@ impl TempSnapshot {
         let mut tokio_file = BufWriter::new(tokio_file);
         while let Some(frame) = s.next().await {
             let frame = frame?;
-            tokio_file.write_all(frame.as_bytes()).await?;
+            tokio_file.write_all(frame.as_slice()).await?;
         }
 
         tokio_file.flush().await?;

--- a/sqld/src/rpc/replication_log.rs
+++ b/sqld/src/rpc/replication_log.rs
@@ -7,7 +7,6 @@ use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
 
-use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use tokio::sync::mpsc;
@@ -37,9 +36,13 @@ impl ReplicationLogService {
     }
 }
 
-fn map_frame_stream_output(r: Result<Bytes, LogReadError>) -> Result<Frame, Status> {
+fn map_frame_stream_output(
+    r: Result<crate::replication::frame::Frame, LogReadError>,
+) -> Result<Frame, Status> {
     match r {
-        Ok(data) => Ok(Frame { data }),
+        Ok(frame) => Ok(Frame {
+            data: frame.bytes(),
+        }),
         Err(LogReadError::SnapshotRequired) => Err(Status::new(
             tonic::Code::FailedPrecondition,
             NEED_SNAPSHOT_ERROR_MSG,


### PR DESCRIPTION
sqlite will call `xFrames` in two cases:
- there is a transaction to commit, in which case which case it passes a non-zero `size-after` value to `xFrame`
- the current transaction grew too large and the overflow is flushed to disk, in which case `size-after` is 0
Before, we just buffered the frames until we got a call committing call to `xFrame` or a call to `xUndo`. I overlooked this when I implemented loading from the dump, but since they are loaded in a single transaction, it caused sqld to OOM.

In this PR, I flush the frames to disk on every call to `xFrames`, but only increase the commit index on commit.

Future work:
- I think that the access to the log file can be made mostly lock-less, with the exception of the lock swap. 
- We don't really need a buffer anymore, pages can be written straight to the shadow WAL