### PR TITLE
libsql: allocate a vector for column values once

### DIFF
--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -317,7 +317,7 @@ impl Connection {
                 continue;
             }
 
-            let mut values = vec![];
+            let mut values = Vec::with_capacity(columns.len());
             for (i, _) in columns.iter().enumerate() {
                 values.push(row.get::<usize, rusqlite::types::Value>(i)?.into());
             }


### PR DESCRIPTION
Since the expected size of the values vector is known, let's allocate its memory once instead of relying on reallocations to grow the vector.