### PR TITLE
Debug tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,6 +990,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic 0.9.2",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ab2224a0311582eb03adba4caaf18644f7b1f10a760803a803b9b605187fc7"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures",
+ "hdrhistogram",
+ "humantime",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.9.2",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +1881,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
  "hashbrown",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
 ]
 
 [[package]]
@@ -3776,6 +3825,7 @@ dependencies = [
  "byteorder",
  "bytes 1.4.0",
  "clap",
+ "console-subscriber",
  "crc",
  "crossbeam",
  "enclose",
@@ -3814,7 +3864,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "tonic",
+ "tonic 0.8.3",
  "tonic-build",
  "tower",
  "tower-http",
@@ -4096,6 +4146,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.45.0",
 ]
 
@@ -4219,6 +4270,34 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.0",
+ "bytes 1.4.0",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project 1.0.12",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -36,7 +36,7 @@ rusqlite = { version = "0.29.0", git = "https://github.com/psarna/rusqlite", rev
     "buildtime_bindgen",
     "bundled-libsql-wasm-experimental",
     "column_decltype",
-    "load_extension"
+    "load_extension",
 ] }
 serde = { version = "1.0.149", features = ["derive", "rc"] }
 serde_json = { version = "1.0.91", features = ["preserve_order"] }
@@ -60,6 +60,7 @@ memmap = "0.7.0"
 mimalloc = { version = "0.1.36", default-features = false }
 sha256 = "1.1.3"
 reqwest = { version = "0.11.16", features = ["json", "rustls-tls"], default-features = false }
+console-subscriber = { version = "0.1.9", optional = true }
 
 [dev-dependencies]
 proptest = "1.0.0"
@@ -75,3 +76,4 @@ vergen = "6"
 [features]
 unix-excl-vfs = ["sqld-libsql-bindings/unix-excl-vfs"]
 bottomless = ["dep:bottomless"]
+debug-tools = ["console-subscriber","rusqlite/trace", "tokio/tracing"]


### PR DESCRIPTION
This PR adds some intrusive debug tools to help with debugging and perf, under the `debug-tools` feature. Only two tools are added for now, but more will follow. Those tools are:

- sqlite logging: log sqlite internal messages
- tokio-console: debug the tokio runtime.

To run with the debug tools enabled:

```
RUSTFLAGS="--cfg tokio_unstable" cargo r --features debug-tools
```
