### PR TITLE
bottomless: inject into existing WalHook mechanism

### DIFF
--- a/sqld-libsql-bindings/src/ffi/types.rs
+++ b/sqld-libsql-bindings/src/ffi/types.rs
@@ -15,8 +15,8 @@ pub type XWalDbsizeFn = extern "C" fn(wal: *mut Wal) -> u32;
 pub type XWalBeginWriteTransactionFn = extern "C" fn(wal: *mut Wal) -> c_int;
 pub type XWalEndWriteTransactionFn = extern "C" fn(wal: *mut Wal) -> c_int;
 pub type XWalSavepointFn = extern "C" fn(wal: *mut Wal, wal_data: *mut u32);
-pub type XWalSavePointUndoFn = extern "C" fn(wal: *mut Wal, wal_data: *mut u32) -> c_int;
-pub type XWalCheckpointFn = extern "C" fn(
+pub type XWalSavePointUndoFn = unsafe extern "C" fn(wal: *mut Wal, wal_data: *mut u32) -> c_int;
+pub type XWalCheckpointFn = unsafe extern "C" fn(
     wal: *mut Wal,
     db: *mut rusqlite::ffi::sqlite3,
     emode: c_int,

--- a/sqld-libsql-bindings/src/lib.rs
+++ b/sqld-libsql-bindings/src/lib.rs
@@ -13,12 +13,8 @@ use self::{
     wal_hook::WalHook,
 };
 
-pub fn get_orig_wal_methods(with_bottomless: bool) -> anyhow::Result<*mut libsql_wal_methods> {
-    let orig: *mut libsql_wal_methods = if with_bottomless {
-        unsafe { libsql_wal_methods_find("bottomless\0".as_ptr() as *const _) }
-    } else {
-        unsafe { libsql_wal_methods_find(std::ptr::null()) }
-    };
+pub fn get_orig_wal_methods() -> anyhow::Result<*mut libsql_wal_methods> {
+    let orig: *mut libsql_wal_methods = unsafe { libsql_wal_methods_find(std::ptr::null()) };
     if orig.is_null() {
         anyhow::bail!("no underlying methods");
     }

--- a/sqld/src/database/dump/loader.rs
+++ b/sqld/src/database/dump/loader.rs
@@ -20,12 +20,22 @@ pub struct DumpLoader {
 }
 
 impl DumpLoader {
-    pub async fn new(path: PathBuf, logger: Arc<ReplicationLogger>) -> anyhow::Result<Self> {
+    pub async fn new(
+        path: PathBuf,
+        logger: Arc<ReplicationLogger>,
+        #[cfg(feature = "bottomless")] bottomless_replicator: Option<
+            Arc<bottomless::replicator::Replicator>,
+        >,
+    ) -> anyhow::Result<Self> {
         let (sender, mut receiver) = mpsc::channel::<OpMsg>(1);
 
         let (ok_snd, ok_rcv) = oneshot::channel::<anyhow::Result<()>>();
         tokio::task::spawn_blocking(move || {
-            let mut ctx = ReplicationLoggerHookCtx::new(logger);
+            let mut ctx = ReplicationLoggerHookCtx::new(
+                logger,
+                #[cfg(feature = "bottomless")]
+                bottomless_replicator,
+            );
             let mut retries = 0;
             let db = loop {
                 match open_db(&path, &REPLICATION_METHODS, &mut ctx, None) {

--- a/sqld/src/database/dump/loader.rs
+++ b/sqld/src/database/dump/loader.rs
@@ -24,7 +24,7 @@ impl DumpLoader {
         path: PathBuf,
         logger: Arc<ReplicationLogger>,
         #[cfg(feature = "bottomless")] bottomless_replicator: Option<
-            Arc<bottomless::replicator::Replicator>,
+            Arc<std::sync::Mutex<bottomless::replicator::Replicator>>,
         >,
     ) -> anyhow::Result<Self> {
         let (sender, mut receiver) = mpsc::channel::<OpMsg>(1);

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -386,9 +386,9 @@ async fn start_primary(
 
     #[cfg(feature = "bottomless")]
     let bottomless_replicator = if config.enable_bottomless_replication {
-        Some(Arc::new(
+        Some(Arc::new(std::sync::Mutex::new(
             init_bottomless_replicator(config.db_path.join("data")).await?,
-        ))
+        )))
     } else {
         None
     };

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -333,6 +333,45 @@ fn validate_extensions(extensions_path: Option<PathBuf>) -> anyhow::Result<Vec<P
     Ok(valid_extensions)
 }
 
+#[cfg(feature = "bottomless")]
+pub async fn init_bottomless_replicator(
+    path: impl AsRef<std::path::Path>,
+) -> anyhow::Result<bottomless::replicator::Replicator> {
+    tracing::debug!("Initializing bottomless replication");
+    let mut replicator =
+        bottomless::replicator::Replicator::create(bottomless::replicator::Options {
+            create_bucket_if_not_exists: true,
+            verify_crc: false,
+            use_compression: false,
+        })
+        .await?;
+
+    // NOTICE: LIBSQL_BOTTOMLESS_DATABASE_ID env variable can be used
+    // to pass an additional prefix for the database identifier
+    replicator.register_db(
+        path.as_ref()
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("Invalid db path"))?
+            .to_owned(),
+    );
+
+    match replicator.restore().await? {
+        bottomless::replicator::RestoreAction::None => (),
+        bottomless::replicator::RestoreAction::SnapshotMainDbFile => {
+            replicator.new_generation();
+            replicator.snapshot_main_db_file().await?;
+            // Restoration process only leaves the local WAL file if it was
+            // detected to be newer than its remote counterpart.
+            replicator.maybe_replicate_wal().await?
+        }
+        bottomless::replicator::RestoreAction::ReuseGeneration(gen) => {
+            replicator.set_generation(gen);
+        }
+    }
+
+    Ok(replicator)
+}
+
 async fn start_primary(
     config: &Config,
     join_set: &mut JoinSet<anyhow::Result<()>>,
@@ -345,8 +384,23 @@ async fn start_primary(
         config.max_log_size,
     )?);
 
+    #[cfg(feature = "bottomless")]
+    let bottomless_replicator = if config.enable_bottomless_replication {
+        Some(Arc::new(
+            init_bottomless_replicator(config.db_path.join("data")).await?,
+        ))
+    } else {
+        None
+    };
+
     // load dump is necessary
-    let dump_loader = DumpLoader::new(config.db_path.clone(), logger.clone()).await?;
+    let dump_loader = DumpLoader::new(
+        config.db_path.clone(),
+        logger.clone(),
+        #[cfg(feature = "bottomless")]
+        bottomless_replicator.clone(),
+    )
+    .await?;
     if let Some(ref path) = config.load_from_dump {
         if !is_fresh_db {
             anyhow::bail!("cannot load from a dump if a database already exists.\nIf you're sure you want to load from a dump, delete your database folder at `{}`", config.db_path.display());
@@ -361,7 +415,15 @@ async fn start_primary(
         &REPLICATION_METHODS,
         {
             let logger = logger.clone();
-            move || ReplicationLoggerHookCtx::new(logger.clone())
+            #[cfg(feature = "bottomless")]
+            let bottomless_replicator = bottomless_replicator.clone();
+            move || {
+                ReplicationLoggerHookCtx::new(
+                    logger.clone(),
+                    #[cfg(feature = "bottomless")]
+                    bottomless_replicator.clone(),
+                )
+            }
         },
         stats.clone(),
         valid_extensions,

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -18,8 +18,10 @@ use uuid::Uuid;
 use crate::libsql::ffi::{
     sqlite3,
     types::{XWalCheckpointFn, XWalFrameFn, XWalSavePointUndoFn, XWalUndoFn},
-    PgHdr, Wal,
+    PgHdr, Wal, SQLITE_OK,
 };
+#[cfg(feature = "bottomless")]
+use crate::libsql::ffi::{SQLITE_CHECKPOINT_TRUNCATE, SQLITE_IOERR_WRITE};
 use crate::libsql::{ffi::PageHdrIter, wal_hook::WalHook};
 use crate::replication::frame::{Frame, FrameHeader};
 use crate::replication::snapshot::{find_snapshot_file, LogCompactor, SnapshotFile};
@@ -34,7 +36,7 @@ pub struct ReplicationLoggerHookCtx {
     buffer: Vec<WalPage>,
     logger: Arc<ReplicationLogger>,
     #[cfg(feature = "bottomless")]
-    bottomless_replicator: Option<Arc<bottomless::replicator::Replicator>>,
+    bottomless_replicator: Option<Arc<std::sync::Mutex<bottomless::replicator::Replicator>>>,
 }
 
 /// This implementation of WalHook intercepts calls to `on_frame`, and writes them to a
@@ -63,6 +65,10 @@ unsafe impl WalHook for ReplicationLoggerHook {
     ) -> c_int {
         assert_eq!(page_size, 4096);
         let wal_ptr = wal as *mut _;
+        #[cfg(feature = "bottomless")]
+        let last_valid_frame = wal.hdr.mxFrame;
+        #[cfg(feature = "bottomless")]
+        let frame_checksum = wal.hdr.aFrameCksum;
         let ctx = Self::wal_extract_ctx(wal);
 
         for (page_no, data) in PageHdrIter::new(page_headers, page_size as _) {
@@ -73,6 +79,39 @@ unsafe impl WalHook for ReplicationLoggerHook {
             // returning IO_ERR ensure that xUndo will be called by sqlite.
             return SQLITE_IOERR;
         }
+
+        // FIXME: instead of block_on, we should consider replicating asynchronously in the background,
+        // e.g. by sending the data to another fiber by an unbounded channel (which allows sync insertions).
+        #[allow(clippy::await_holding_lock)] // uncontended -> only gets called under a libSQL write lock
+        #[cfg(feature = "bottomless")]
+        let last_consistent_frame = {
+            let runtime = tokio::runtime::Handle::current();
+            if let Some(replicator) = ctx.bottomless_replicator.as_mut() {
+                match runtime.block_on(async move {
+                    let mut replicator = replicator.lock().unwrap();
+                    replicator.register_last_valid_frame(last_valid_frame);
+                    // In theory it's enough to set the page size only once, but in practice
+                    // it's a very cheap operation anyway, and the page is not always known
+                    // upfront and can change dynamically.
+                    // FIXME: changing the page size in the middle of operation is *not*
+                    // supported by bottomless storage.
+                    replicator.set_page_size(page_size as usize)?;
+                    for (pgno, data) in PageHdrIter::new(page_headers, page_size as usize) {
+                        replicator.write(pgno, data);
+                    }
+
+                    replicator.flush().await
+                }) {
+                    Ok(last_consistent_frame) => last_consistent_frame,
+                    Err(e) => {
+                        tracing::error!("error writing to bottomless: {e}");
+                        return SQLITE_IOERR_WRITE;
+                    }
+                }
+            } else {
+                0
+            }
+        };
 
         let rc = unsafe {
             orig(
@@ -86,6 +125,23 @@ unsafe impl WalHook for ReplicationLoggerHook {
         };
 
         if is_commit != 0 && rc == 0 {
+            #[allow(clippy::await_holding_lock)] // uncontended -> only gets called under a libSQL write lock
+            #[cfg(feature = "bottomless")]
+            {
+                let runtime = tokio::runtime::Handle::current();
+                if let Some(replicator) = ctx.bottomless_replicator.as_mut() {
+                    if let Err(e) = runtime.block_on(async move {
+                        let mut replicator = replicator.lock().unwrap();
+                        replicator
+                            .finalize_commit(last_consistent_frame, frame_checksum)
+                            .await
+                    }) {
+                        tracing::error!("error writing to bottomless: {e}");
+                        return SQLITE_IOERR_WRITE;
+                    }
+                }
+            }
+
             if let Err(e) = ctx.commit() {
                 // If we reach this point, it means that we have commited a transaction to sqlite wal,
                 // but failed to commit it to the shadow WAL, which leaves us in an inconsistent state.
@@ -104,12 +160,6 @@ unsafe impl WalHook for ReplicationLoggerHook {
                 std::process::abort()
             }
         }
-
-        #[cfg(feature = "bottomless")]
-        tracing::error!(
-            "fixme: implement bottomless frames for {:?}",
-            ctx.bottomless_replicator
-        );
 
         rc
     }
@@ -133,12 +183,26 @@ unsafe impl WalHook for ReplicationLoggerHook {
     }
 
     fn on_savepoint_undo(wal: &mut Wal, wal_data: *mut u32, orig: XWalSavePointUndoFn) -> i32 {
+        let rc = unsafe { orig(wal, wal_data) };
+        if rc != SQLITE_OK {
+            return rc;
+        };
+
         #[cfg(feature = "bottomless")]
-        tracing::error!(
-            "fixme: implement bottomless savepoint undo for {:?}",
-            Self::wal_extract_ctx(wal).bottomless_replicator
-        );
-        unsafe { orig(wal, wal_data) }
+        {
+            let ctx = Self::wal_extract_ctx(wal);
+            if let Some(replicator) = ctx.bottomless_replicator.as_mut() {
+                let last_valid_frame = unsafe { *wal_data };
+                let mut replicator = replicator.lock().unwrap();
+                let prev_valid_frame = replicator.peek_last_valid_frame();
+                tracing::trace!(
+                    "Savepoint: rolling back from frame {prev_valid_frame} to {last_valid_frame}",
+                );
+                replicator.rollback_to_frame(last_valid_frame);
+            }
+        }
+
+        rc
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -156,11 +220,22 @@ unsafe impl WalHook for ReplicationLoggerHook {
         orig: XWalCheckpointFn,
     ) -> i32 {
         #[cfg(feature = "bottomless")]
-        tracing::error!(
-            "fixme: implement bottomless checkpoint for {:?}",
-            Self::wal_extract_ctx(wal).bottomless_replicator
-        );
-        unsafe {
+        {
+            tracing::trace!("bottomless checkpoint");
+
+            /* In order to avoid partial checkpoints, passive checkpoint
+             ** mode is not allowed. Only TRUNCATE checkpoints are accepted,
+             ** because these are guaranteed to block writes, copy all WAL pages
+             ** back into the main database file and reset the frame number.
+             ** In order to avoid autocheckpoint on close (that's too often),
+             ** checkpoint attempts weaker than TRUNCATE are ignored.
+             */
+            if emode < SQLITE_CHECKPOINT_TRUNCATE {
+                tracing::trace!("Ignoring a checkpoint request weaker than TRUNCATE");
+                return SQLITE_OK;
+            }
+        }
+        let rc = unsafe {
             orig(
                 wal,
                 db,
@@ -173,7 +248,33 @@ unsafe impl WalHook for ReplicationLoggerHook {
                 frames_in_wal,
                 backfilled_frames,
             )
+        };
+
+        if rc != SQLITE_OK {
+            return rc;
         }
+
+        #[allow(clippy::await_holding_lock)] // uncontended -> only gets called under a libSQL write lock
+        #[cfg(feature = "bottomless")]
+        {
+            let ctx = Self::wal_extract_ctx(wal);
+            let runtime = tokio::runtime::Handle::current();
+            if let Some(replicator) = ctx.bottomless_replicator.as_mut() {
+                let mut replicator = replicator.lock().unwrap();
+                if replicator.commits_in_current_generation == 0 {
+                    tracing::debug!("No commits happened in this generation, not snapshotting");
+                    return SQLITE_OK;
+                }
+                replicator.new_generation();
+                if let Err(e) =
+                    runtime.block_on(async move { replicator.snapshot_main_db_file().await })
+                {
+                    tracing::error!("Failed to snapshot the main db file during checkpoint: {e}");
+                    return SQLITE_IOERR_WRITE;
+                }
+            }
+        }
+        SQLITE_OK
     }
 }
 
@@ -189,7 +290,7 @@ impl ReplicationLoggerHookCtx {
     pub fn new(
         logger: Arc<ReplicationLogger>,
         #[cfg(feature = "bottomless")] bottomless_replicator: Option<
-            Arc<bottomless::replicator::Replicator>,
+            Arc<std::sync::Mutex<bottomless::replicator::Replicator>>,
         >,
     ) -> Self {
         #[cfg(feature = "bottomless")]


### PR DESCRIPTION
From now on, bottomless can be enabled in sqld as a regular WalHook.
TODO: the main functionality, i.e. actually replicating frames is not hooked to anything yet. It will be done, but it should be heavily considered to just queue writes with an unbounded channel (which allows sync insertions), so that everything happens in the background.