### PR TITLE
start metric loop after db is initialized

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.69.0"
+channel = "1.70.0"

--- a/sqld-libsql-bindings/src/ffi/types.rs
+++ b/sqld-libsql-bindings/src/ffi/types.rs
@@ -1,4 +1,4 @@
-///! Typedefs for virtual function signatures.
+//! Typedefs for virtual function signatures.
 use std::ffi::{c_char, c_int, c_uint, c_void};
 
 use super::{libsql_wal_methods, sqlite3_file, sqlite3_vfs, PgHdr, Wal};

--- a/sqld/src/database/dump/exporter.rs
+++ b/sqld/src/database/dump/exporter.rs
@@ -1,4 +1,4 @@
-///! port of dump from `shell.c`
+//! port of dump from `shell.c`
 use std::ffi::CString;
 use std::fmt::{Display, Write as _};
 use std::io::Write;


### PR DESCRIPTION
The metric loop can sometimes interfere with the wal recovery process by preventing checkpointing. This is solved by starting the metric loop only after the database has been initialized.
