### PR TITLE
replication: allow replica overwrite

### DIFF
--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -91,6 +91,7 @@ pub struct Config {
     pub heartbeat_period: Duration,
     pub soft_heap_limit_mb: Option<usize>,
     pub hard_heap_limit_mb: Option<usize>,
+    pub allow_replica_overwrite: bool,
 }
 
 async fn run_service<D: Database>(
@@ -251,7 +252,12 @@ async fn start_replica(
     stats: Stats,
 ) -> anyhow::Result<()> {
     let (channel, uri) = configure_rpc(config)?;
-    let replicator = Replicator::new(config.db_path.clone(), channel.clone(), uri.clone());
+    let replicator = Replicator::new(
+        config.db_path.clone(),
+        channel.clone(),
+        uri.clone(),
+        config.allow_replica_overwrite,
+    );
     let applied_frame_no_receiver = replicator.current_frame_no_notifier.subscribe();
 
     join_set.spawn(replicator.run());

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -155,6 +155,11 @@ struct Cli {
     /// if it goes over this limit with memory usage.
     #[clap(long, env = "SQLD_HARD_HEAP_LIMIT_MB")]
     hard_heap_limit_mb: Option<usize>,
+
+    /// Allow the replica to overwrite its data if the primary starts replicating a different
+    /// database. This is often the case when the primary goes through a recovery process.
+    #[clap(long, env = "SQLD_ALLOW_REPLICA_OVERWRITE")]
+    allow_replica_overwrite: bool,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -253,6 +258,7 @@ fn config_from_args(args: Cli) -> Result<Config> {
         heartbeat_period: Duration::from_secs(args.heartbeat_period_s),
         soft_heap_limit_mb: args.soft_heap_limit_mb,
         hard_heap_limit_mb: args.hard_heap_limit_mb,
+        allow_replica_overwrite: args.allow_replica_overwrite,
     })
 }
 


### PR DESCRIPTION
This PR adds the `--allow-replica-overwrite` that allows the replica to overwrite itself when it detects that the primary has changed database. This mostly happens when the primary had to perform a replication log recovery, but remaions a opt-in feature since it protects against configuration mistakes
