### PR TITLE
Switch HTTP request logging to "debug" level

### DIFF
--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -250,7 +250,7 @@ pub async fn run_http<D: Database>(
     tracing::info!("listening for HTTP requests on {addr}");
 
     fn trace_request<B>(req: &Request<B>, _span: &Span) {
-        tracing::info!("got request: {} {}", req.method(), req.uri());
+        tracing::debug!("got request: {} {}", req.method(), req.uri());
     }
     let service = ServiceBuilder::new()
         .option_layer(idle_shutdown_layer)


### PR DESCRIPTION
We currently log every HTTP request at info-level to the logs, which can spam then quite hard. Switch to "debug" instead.