### PR TITLE
Improve sqld version reporting

### DIFF
--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -14,7 +14,7 @@ bottomless = { version = "0", path = "../bottomless", features = ["libsql_linked
 bytemuck = { version = "1.13.0", features = ["derive"] }
 bytes = { version = "1.2.1", features = ["serde"] }
 bytesize = "1.2.0"
-clap = { version = "4.0.23", features = [ "derive", "env"] }
+clap = { version = "4.0.23", features = [ "derive", "env", "string" ] }
 console-subscriber = { version = "0.1.9", optional = true }
 crc = "3.0.0"
 crossbeam = "0.8.2"

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -32,6 +32,7 @@ use crate::query_analysis::{predict_final_state, State, Statement};
 use crate::query_result_builder::QueryResultBuilder;
 use crate::stats::Stats;
 use crate::utils::services::idle_shutdown::IdleShutdownLayer;
+use crate::version;
 
 use self::result_builder::JsonHttpPayloadBuilder;
 use self::types::QueryObject;
@@ -231,8 +232,8 @@ async fn handle_request<D: Database>(
 }
 
 fn handle_version() -> Response<Body> {
-    let version = env!("CARGO_PKG_VERSION");
-    Response::new(Body::from(version.as_bytes()))
+    let version = version::version();
+    Response::new(Body::from(version))
 }
 
 // TODO: refactor

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -45,6 +45,7 @@ mod stats;
 #[cfg(test)]
 mod test;
 mod utils;
+pub mod version;
 
 const MAX_CONCCURENT_DBS: usize = 128;
 const DB_CREATE_TIMEOUT: Duration = Duration::from_secs(1);

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::{bail, Context as _, Result};
 use bytesize::ByteSize;
 use clap::Parser;
 use mimalloc::MiMalloc;
-use sqld::{database::dump::exporter::export_dump, Config};
+use sqld::{database::dump::exporter::export_dump, version::Version, Config};
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -21,7 +21,7 @@ static GLOBAL: MiMalloc = MiMalloc;
 /// SQL daemon
 #[derive(Debug, Parser)]
 #[command(name = "sqld")]
-#[command(about = "SQL daemon", version, long_about = None)]
+#[command(about = "SQL daemon", version = Version::default(), long_about = None)]
 struct Cli {
     #[clap(long, short, default_value = "data.sqld", env = "SQLD_DB_PATH")]
     db_path: PathBuf,

--- a/sqld/src/version.rs
+++ b/sqld/src/version.rs
@@ -1,0 +1,17 @@
+use clap::builder::{IntoResettable, Str};
+
+#[derive(Default)]
+pub struct Version;
+
+impl IntoResettable<Str> for Version {
+    fn into_resettable(self) -> clap::builder::Resettable<Str> {
+        version().into_resettable()
+    }
+}
+
+pub fn version() -> String {
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    let git_sha = env!("VERGEN_GIT_SHA");
+    let build_date = env!("VERGEN_BUILD_DATE");
+    format!("sqld {} ({} {})", pkg_version, &git_sha[..8], build_date)
+}


### PR DESCRIPTION
Include git hash and build date like `rustc`, for example, does, to make it easier to determine version of a `sqld` executable:

$ sqld --version
sqld 0.15.0 (acbce3dd 2023-06-12)

Useful when you have access to an executable, but not to the logs.