### PR TITLE
Fix corruption on replicating transactions with duplicated pages

### DIFF
--- a/sqld/src/replication/replica/hook.rs
+++ b/sqld/src/replication/replica/hook.rs
@@ -213,7 +213,7 @@ fn make_page_header<'a>(
             pPager: std::ptr::null_mut(),
             pgno: frame.header().page_no,
             pageHash: 0,
-            flags: 0,
+            flags: 0x02, // PGHDR_DIRTY - it works without the flag, but why risk it
             nRef: 0,
             pDirtyNext: std::ptr::null_mut(),
             pDirtyPrev: std::ptr::null_mut(),

--- a/sqld/src/replication/replica/hook.rs
+++ b/sqld/src/replication/replica/hook.rs
@@ -193,11 +193,13 @@ unsafe impl WalHook for InjectorHook {
 fn make_page_header<'a>(
     frames: impl Iterator<Item = &'a FrameBorrowed>,
 ) -> (Headers<'a>, u64, u32) {
-    let mut current_pg = std::ptr::null_mut();
+    let mut first_pg: *mut PgHdr = std::ptr::null_mut();
+    let mut current_pg;
     let mut last_frame_no = 0;
     let mut size_after = 0;
 
     let mut headers_count = 0;
+    let mut prev_pg: *mut PgHdr = std::ptr::null_mut();
     for frame in frames {
         if frame.header().frame_no > last_frame_no {
             last_frame_no = frame.header().frame_no;
@@ -209,7 +211,7 @@ fn make_page_header<'a>(
             pData: frame.page().as_ptr() as _,
             pExtra: std::ptr::null_mut(),
             pCache: std::ptr::null_mut(),
-            pDirty: current_pg,
+            pDirty: std::ptr::null_mut(),
             pPager: std::ptr::null_mut(),
             pgno: frame.header().page_no,
             pageHash: 0,
@@ -220,11 +222,20 @@ fn make_page_header<'a>(
         };
         headers_count += 1;
         current_pg = Box::into_raw(Box::new(page));
+        if first_pg.is_null() {
+            first_pg = current_pg;
+        }
+        if !prev_pg.is_null() {
+            unsafe {
+                (*prev_pg).pDirty = current_pg;
+            }
+        }
+        prev_pg = current_pg;
     }
 
     tracing::trace!("built {headers_count} page headers");
 
-    let headers = unsafe { Headers::new(current_pg) };
+    let headers = unsafe { Headers::new(first_pg) };
     (headers, last_frame_no, size_after)
 }
 


### PR DESCRIPTION
This series fixes a page corruption error for large transactions -- and more specifically, large transactions that manage to mutate a page more than once.

The prelude was that our injection code failed to set `writable_schema=on` before hacking page 1 of the database, which holds the schema, and then `writable_schema=reset` right after the injection, to apply the changes in memory. @MarinPostma came up with that one and that unblocked the whole debugging process. Cheers!!!

The main problem was that page headers are added in the dirty list in the order of arrival. A database corruption was observed after a sufficiently large transaction actually had two versions of a single page in a batch. Frames are applied in dirty-list order, so due to the fact that we previously appended new frames to the beginning on the list, we ended up writing the newest version of the page first, and then rewriting it with the old one, hence the inconsistency. Such duplication does not normally happen, **but**, large transactions are split into multiple batches in order to save memory, so it's entirely possible that a page modification first occurred in one batch, and then, a newer modification occurred in another batch. Whew.