### PR TITLE
bottomless: local timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3674,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "sqld"
-version = "0.16.0"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/bottomless/src/backup.rs
+++ b/bottomless/src/backup.rs
@@ -85,14 +85,16 @@ impl WalCopier {
         tracing::trace!("Flushing {} frames locally.", frames.len());
 
         for start in frames.clone().step_by(self.max_frames_per_batch) {
+            let timestamp = chrono::Utc::now().timestamp() as u64;
             let end = (start + self.max_frames_per_batch as u32).min(frames.end);
             let len = (end - start) as usize;
             let fdesc = format!(
-                "{}-{}/{:012}-{:012}.{}",
+                "{}-{}/{:012}-{:012}-{}.{}",
                 self.db_name,
                 generation,
                 start,
                 end - 1,
+                timestamp, // generally timestamps fit in 10 chars but don't make assumptions
                 self.use_compression
             );
             let mut out = tokio::fs::File::create(&format!("{}/{}", self.bucket, fdesc)).await?;

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -667,9 +667,6 @@ impl Replicator {
                         if let Ok(generation) = Uuid::parse_str(key) {
                             match threshold.as_ref() {
                                 None => return Some(generation),
-                                // since our UUIDs have reverse order, we check for first generation
-                                // higher than provided timestamp in order to get the first one that
-                                // happened before it
                                 Some(threshold) => match Self::generation_to_timestamp(&generation)
                                 {
                                     None => {

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -260,7 +260,7 @@ fn config_from_args(args: Cli) -> Result<Config> {
         rpc_server_ca_cert: args.grpc_ca_cert_file,
         #[cfg(feature = "bottomless")]
         bottomless_replication: if args.enable_bottomless_replication {
-            Some(bottomless::replicator::Options::from_env())
+            Some(bottomless::replicator::Options::from_env()?)
         } else {
             None
         },

--- a/sqld/src/test/bottomless.rs
+++ b/sqld/src/test/bottomless.rs
@@ -43,7 +43,7 @@ async fn backup_restore() {
             use_compression: bottomless::replicator::CompressionKind::Gzip,
             bucket_name: BUCKET.to_string(),
             max_batch_interval: Duration::from_millis(250),
-            ..bottomless::replicator::Options::from_env()
+            ..bottomless::replicator::Options::from_env().unwrap()
         }),
         db_path: PATH.into(),
         http_addr: Some(listener_addr),


### PR DESCRIPTION
This PR changed point-in-time recovery timestamps to make comparison based on locally generated timestamps rather than AWS S3 Last-Modified field.

The reason is that we don't control Last-Modified timestamps and they are generated by S3 at the point when upload request was accepted. There's a possibility of heavy drift between local backup timestamp and the time when the local file has reached S3, especially when process ended abruptly and during restore phase we also upload the local files that have been waiting for their turn.