### PR TITLE
bottomless transaction disk cache

### DIFF
--- a/bottomless/src/lib.rs
+++ b/bottomless/src/lib.rs
@@ -7,6 +7,7 @@ mod ffi;
 mod backup;
 mod read;
 pub mod replicator;
+mod transaction_cache;
 mod wal;
 
 use crate::ffi::{

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -636,6 +636,8 @@ impl Replicator {
         &self,
         timestamp: Option<&DateTime<Utc>>,
     ) -> Option<Uuid> {
+        use chrono::TimeZone;
+
         let mut next_marker: Option<String> = None;
         let prefix = format!("{}-", self.db_name);
         let threshold = timestamp.map(|ts| ts.timestamp() as u64);
@@ -667,6 +669,12 @@ impl Replicator {
                         if let Ok(generation) = Uuid::parse_str(key) {
                             match threshold.as_ref() {
                                 None => return Some(generation),
+<<<<<<< HEAD
+=======
+                                // since our UUIDs have reverse order, we check for first generation
+                                // higher than provided timestamp in order to get the first one that
+                                // happened before it
+>>>>>>> 76012b1 (bottomless: fail if env var parsing fails)
                                 Some(threshold) => match Self::generation_to_timestamp(&generation)
                                 {
                                     None => {

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -667,12 +667,6 @@ impl Replicator {
                         if let Ok(generation) = Uuid::parse_str(key) {
                             match threshold.as_ref() {
                                 None => return Some(generation),
-<<<<<<< HEAD
-=======
-                                // since our UUIDs have reverse order, we check for first generation
-                                // higher than provided timestamp in order to get the first one that
-                                // happened before it
->>>>>>> 76012b1 (bottomless: fail if env var parsing fails)
                                 Some(threshold) => match Self::generation_to_timestamp(&generation)
                                 {
                                     None => {

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -636,8 +636,6 @@ impl Replicator {
         &self,
         timestamp: Option<&DateTime<Utc>>,
     ) -> Option<Uuid> {
-        use chrono::TimeZone;
-
         let mut next_marker: Option<String> = None;
         let prefix = format!("{}-", self.db_name);
         let threshold = timestamp.map(|ts| ts.timestamp() as u64);

--- a/bottomless/src/transaction_cache.rs
+++ b/bottomless/src/transaction_cache.rs
@@ -1,0 +1,144 @@
+use anyhow::Result;
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::io::SeekFrom;
+use tokio::fs::{File, OpenOptions};
+use tokio::io::{AsyncSeekExt, AsyncWriteExt};
+
+const RECOVERY_FILE_PATH: &str = ".bottomless.restore";
+
+#[derive(Debug)]
+pub(crate) struct TransactionPageCache {
+    /// Threshold (in pages) after which, the cache will start flushing pages on disk.
+    restore_page_swap: u32,
+    page_size: u32,
+    /// Recovery file used to flushing pages on disk. Reusable between transactions.
+    cache: Cache,
+}
+
+impl TransactionPageCache {
+    pub fn new(restore_page_swap: u32, page_size: u32) -> Self {
+        TransactionPageCache {
+            restore_page_swap,
+            page_size,
+            cache: Cache::Memory(BTreeMap::new()),
+        }
+    }
+
+    pub async fn insert(&mut self, pgno: u32, page: &[u8]) -> Result<()> {
+        match &mut self.cache {
+            Cache::Memory(map) => {
+                let len = map.len();
+                match map.entry(pgno) {
+                    Entry::Vacant(_) if len > self.restore_page_swap as usize => {
+                        let page_size = self.page_size;
+                        if let Cache::Disk { index, file } = self.swap().await? {
+                            Self::persist(index, file, pgno, page_size, page).await
+                        } else {
+                            Ok(())
+                        }
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert(page.into());
+                        Ok(())
+                    }
+                    Entry::Occupied(mut e) => {
+                        let buf = e.get_mut();
+                        buf.copy_from_slice(page);
+                        Ok(())
+                    }
+                }
+            }
+            Cache::Disk { index, file } => {
+                Self::persist(index, file, pgno, self.page_size, page).await
+            }
+        }
+    }
+
+    async fn persist(
+        index: &mut BTreeMap<u32, u64>,
+        file: &mut File,
+        pgno: u32,
+        page_size: u32,
+        page: &[u8],
+    ) -> Result<()> {
+        let end = (index.len() as u64) * (page_size as u64);
+        match index.entry(pgno) {
+            Entry::Vacant(e) => {
+                file.seek(SeekFrom::End(0)).await?;
+                file.write_all(page).await?;
+                e.insert(end);
+            }
+            Entry::Occupied(e) => {
+                let offset = *e.get();
+                file.seek(SeekFrom::Start(offset)).await?;
+                file.write_all(page).await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Swaps current memory cache onto disk.
+    async fn swap(&mut self) -> Result<&mut Cache> {
+        if let Cache::Disk { .. } = self.cache {
+            return Ok(&mut self.cache); // already swapped
+        }
+        tracing::trace!("Swapping transaction pages to file {}", RECOVERY_FILE_PATH);
+        let mut index = BTreeMap::new();
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .read(true)
+            .truncate(true)
+            .open(RECOVERY_FILE_PATH)
+            .await?;
+        if let Cache::Memory(old) = &self.cache {
+            let mut end = 0u64;
+            for (&pgno, page) in old {
+                file.write_all(page).await?;
+                index.insert(pgno, end);
+                end += page.len() as u64;
+            }
+        }
+        self.cache = Cache::Disk { index, file };
+        Ok(&mut self.cache)
+    }
+
+    pub async fn flush(mut self, db_file: &mut File) -> Result<()> {
+        use tokio::io::AsyncReadExt;
+        match &mut self.cache {
+            Cache::Memory(map) => {
+                for (&pgno, page) in map.iter() {
+                    let offset = (pgno - 1) as u64 * (self.page_size as u64);
+                    db_file.seek(SeekFrom::Start(offset)).await?;
+                    db_file.write_all(page).await?;
+                }
+            }
+            Cache::Disk { index, file } => {
+                for (&pgno, &off) in index.iter() {
+                    let offset = (pgno - 1) as u64 * (self.page_size as u64);
+                    db_file.seek(SeekFrom::Start(offset)).await?;
+                    let mut f = file.try_clone().await?;
+                    f.seek(SeekFrom::Start(off)).await?;
+                    let mut page = f.take(self.page_size as u64);
+                    tokio::io::copy(&mut page, db_file).await?;
+                }
+                file.shutdown().await?;
+                db_file.flush().await?;
+                tokio::fs::remove_file(RECOVERY_FILE_PATH).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+enum Cache {
+    /// Map storing page number and pages themselves in memory.
+    Memory(BTreeMap<u32, Vec<u8>>),
+    /// Map storing page number and offsets in transaction recovery file.
+    Disk {
+        index: BTreeMap<u32, u64>,
+        file: File,
+    },
+}

--- a/sqld/src/test/bottomless.rs
+++ b/sqld/src/test/bottomless.rs
@@ -43,7 +43,7 @@ async fn backup_restore() {
             use_compression: bottomless::replicator::CompressionKind::Gzip,
             bucket_name: BUCKET.to_string(),
             max_batch_interval: Duration::from_millis(250),
-            restore_page_swap: 1, // in this test swap should happen at least once
+            restore_transaction_page_swap_after: 1, // in this test swap should happen at least once
             ..bottomless::replicator::Options::from_env().unwrap()
         }),
         db_path: PATH.into(),

--- a/sqld/src/test/bottomless.rs
+++ b/sqld/src/test/bottomless.rs
@@ -43,6 +43,7 @@ async fn backup_restore() {
             use_compression: bottomless::replicator::CompressionKind::Gzip,
             bucket_name: BUCKET.to_string(),
             max_batch_interval: Duration::from_millis(250),
+            restore_page_swap: 1, // in this test swap should happen at least once
             ..bottomless::replicator::Options::from_env().unwrap()
         }),
         db_path: PATH.into(),


### PR DESCRIPTION
This PR introduces disk swap for restored transaction pages. This is useful, when RAM of the machine we run on is small, while individual restored transaction is large. Since we were caching them in memory, big transactions could cause out of memory failures.