### PR TITLE
Add --snapshot-exec to execute script for every generated snapshot file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3674,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "sqld"
-version = "0.16.0"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -94,6 +94,7 @@ pub struct Config {
     pub idle_shutdown_timeout: Option<Duration>,
     pub load_from_dump: Option<PathBuf>,
     pub max_log_size: u64,
+    pub max_log_duration: Option<f32>,
     pub heartbeat_url: Option<String>,
     pub heartbeat_auth: Option<String>,
     pub heartbeat_period: Duration,
@@ -132,6 +133,7 @@ impl Default for Config {
             idle_shutdown_timeout: None,
             load_from_dump: None,
             max_log_size: 200,
+            max_log_duration: None,
             heartbeat_url: None,
             heartbeat_auth: None,
             heartbeat_period: Duration::from_secs(30),
@@ -437,6 +439,7 @@ async fn start_primary(
     let logger = Arc::new(ReplicationLogger::open(
         &config.db_path,
         config.max_log_size,
+        config.max_log_duration.map(Duration::from_secs_f32),
         db_is_dirty,
         snapshot_callback,
     )?);

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -132,6 +132,11 @@ struct Cli {
     /// defaults to 200MB.
     #[clap(long, env = "SQLD_MAX_LOG_SIZE", default_value = "200")]
     max_log_size: u64,
+    /// Maximum duration before the replication log is compacted (in seconds).
+    /// By default, the log is compacted only if it grows above the limit specified with
+    /// `--max-log-size`.
+    #[clap(long, env = "SQLD_MAX_LOG_DURATION")]
+    max_log_duration: Option<f32>,
 
     #[clap(subcommand)]
     utils: Option<UtilsSubcommands>,
@@ -271,6 +276,7 @@ fn config_from_args(args: Cli) -> Result<Config> {
         idle_shutdown_timeout: args.idle_shutdown_timeout_s.map(Duration::from_secs),
         load_from_dump: args.load_from_dump,
         max_log_size: args.max_log_size,
+        max_log_duration: args.max_log_duration,
         heartbeat_url: args.heartbeat_url,
         heartbeat_auth: args.heartbeat_auth,
         heartbeat_period: Duration::from_secs(args.heartbeat_period_s),

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -169,6 +169,10 @@ struct Cli {
     /// Set the maximum size for a response. e.g 5KB, 10MB...
     #[clap(long, env = "SQLD_MAX_RESPONSE_SIZE", default_value = "10MB")]
     max_response_size: ByteSize,
+
+    /// Set a command to execute when a snapshot file is generated.
+    #[clap(long, env = "SQLD_SNAPSHOT_EXEC")]
+    snapshot_exec: Option<String>,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -274,6 +278,7 @@ fn config_from_args(args: Cli) -> Result<Config> {
         hard_heap_limit_mb: args.hard_heap_limit_mb,
         allow_replica_overwrite: args.allow_replica_overwrite,
         max_response_size: args.max_response_size.0,
+        snapshot_exec: args.snapshot_exec,
     })
 }
 

--- a/sqld/src/replication/mod.rs
+++ b/sqld/src/replication/mod.rs
@@ -5,6 +5,7 @@ mod snapshot;
 
 use crc::Crc;
 pub use primary::logger::{LogReadError, ReplicationLogger, ReplicationLoggerHook};
+pub use snapshot::SnapshotCallback;
 
 pub const WAL_PAGE_SIZE: i32 = 4096;
 pub const WAL_MAGIC: u64 = u64::from_le_bytes(*b"SQLDWAL\0");

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -912,10 +912,7 @@ impl ReplicationLogger {
         };
 
         let size_after = last_frame.header().size_after;
-        if size_after == 0 {
-            // last frame does not seem to be a commit boundary, so we can't do a compaction
-            return Ok(false);
-        }
+        assert!(size_after != 0);
 
         log_file.do_compaction(self.compactor.clone(), size_after, &self.db_path)?;
         Ok(true)

--- a/sqld/src/replication/snapshot.rs
+++ b/sqld/src/replication/snapshot.rs
@@ -165,8 +165,10 @@ pub struct LogCompactor {
     sender: crossbeam::channel::Sender<(LogFile, PathBuf, u32)>,
 }
 
+pub type SnapshotCallback = Box<dyn Fn(&Path) -> anyhow::Result<()> + Send>;
+
 impl LogCompactor {
-    pub fn new(db_path: &Path, db_id: u128) -> anyhow::Result<Self> {
+    pub fn new(db_path: &Path, db_id: u128, callback: SnapshotCallback) -> anyhow::Result<Self> {
         // we create a 0 sized channel, in order to create backpressure when we can't
         // keep up with snapshop creation: if there isn't any ongoind comptaction task processing,
         // the compact does not block, and the log is compacted in the background. Otherwise, the
@@ -174,11 +176,19 @@ impl LogCompactor {
         let (sender, receiver) = bounded::<(LogFile, PathBuf, u32)>(0);
         let mut merger = SnapshotMerger::new(db_path, db_id)?;
         let db_path = db_path.to_path_buf();
+        let snapshot_dir_path = snapshot_dir_path(&db_path);
         let _handle = std::thread::spawn(move || {
             while let Ok((file, log_path, size_after)) = receiver.recv() {
                 match perform_compaction(&db_path, file, db_id) {
                     Ok((snapshot_name, snapshot_frame_count)) => {
                         tracing::info!("snapshot `{snapshot_name}` successfully created");
+
+                        let snapshot_file = snapshot_dir_path.join(&snapshot_name);
+                        if let Err(e) = (*callback)(&snapshot_file) {
+                            tracing::error!("failed to call snapshot callback: {e}");
+                            break;
+                        }
+
                         if let Err(e) = merger.register_snapshot(
                             snapshot_name,
                             snapshot_frame_count,
@@ -485,7 +495,8 @@ mod test {
         log_file.commit().unwrap();
 
         let dump_dir = tempdir().unwrap();
-        let compactor = LogCompactor::new(dump_dir.path(), db_id.as_u128()).unwrap();
+        let compactor =
+            LogCompactor::new(dump_dir.path(), db_id.as_u128(), Box::new(|_| Ok(()))).unwrap();
         compactor
             .compact(log_file, temp.path().to_path_buf(), 25)
             .unwrap();

--- a/sqld/src/replication/snapshot.rs
+++ b/sqld/src/replication/snapshot.rs
@@ -474,7 +474,7 @@ mod test {
     #[test]
     fn compact_file_create_snapshot() {
         let temp = tempfile::NamedTempFile::new().unwrap();
-        let mut log_file = LogFile::new(temp.as_file().try_clone().unwrap(), 0).unwrap();
+        let mut log_file = LogFile::new(temp.as_file().try_clone().unwrap(), 0, None).unwrap();
         let db_id = Uuid::new_v4();
         log_file.header.db_id = db_id.as_u128();
         log_file.write_header().unwrap();


### PR DESCRIPTION
Every time that sqld produces a snapshot file, the `--snapshot-exec` program will be executed with a path to this file. This provides a hook for external replication.