### PR TITLE
sqld: no free queries

### DIFF
--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -401,10 +401,15 @@ impl<'a> Connection<'a> {
     }
 
     fn update_stats(&self, stmt: &rusqlite::Statement) {
-        self.stats
-            .inc_rows_read(stmt.get_status(StatementStatus::RowsRead) as u64);
-        self.stats
-            .inc_rows_written(stmt.get_status(StatementStatus::RowsWritten) as u64);
+        let rows_read = stmt.get_status(StatementStatus::RowsRead);
+        let rows_written = stmt.get_status(StatementStatus::RowsWritten);
+        let rows_read = if rows_read == 0 && rows_written == 0 {
+            1
+        } else {
+            rows_read
+        };
+        self.stats.inc_rows_read(rows_read as u64);
+        self.stats.inc_rows_written(rows_written as u64);
     }
 
     fn describe(&self, sql: &str) -> DescribeResult {


### PR DESCRIPTION
When a query is reported to bump rows_read and rows_written by 0, we increase the rows_read count by 1. That prevents abuse, as no query is free anymore.

Tested manually by sending a `SELECT 42` query a few times and consulting the /v1/stats endpoint.