### PR TITLE
truncate stats file before writing to it

### DIFF
--- a/sqld/src/stats.rs
+++ b/sqld/src/stats.rs
@@ -70,6 +70,7 @@ impl Stats {
 fn spawn_stats_persist_thread(stats: Arc<StatsInner>, mut file: File) {
     std::thread::spawn(move || loop {
         if file.rewind().is_ok() {
+            file.set_len(0).unwrap();
             let _ = serde_json::to_writer(&mut file, &stats);
         }
         std::thread::sleep(Duration::from_secs(5));


### PR DESCRIPTION
Athos reports he found a file with the following contents:

```
{"rows_written":0,"rows_read":0,"storage_bytes_used":65536}6}440}}
```

This is because we rewind the file correctly, but do not truncate it. So if we have ever written a buffer bigger than the current buffer, the file will look corrupted