### PR TITLE
Make living replica keep primary alive

### DIFF
--- a/sqld/src/rpc/mod.rs
+++ b/sqld/src/rpc/mod.rs
@@ -28,7 +28,7 @@ pub async fn run_rpc_server<D: Database>(
     idle_shutdown_layer: Option<IdleShutdownLayer>,
 ) -> anyhow::Result<()> {
     let proxy_service = ProxyService::new(factory, logger.new_frame_notifier.subscribe());
-    let logger_service = ReplicationLogService::new(logger);
+    let logger_service = ReplicationLogService::new(logger, idle_shutdown_layer.clone());
 
     tracing::info!("serving write proxy server at {addr}");
 


### PR DESCRIPTION
Each request for new frames from a replica to a primary resets the idle timer but such request is a long poll. It won't return until it gets some new frame.
This means that a replica won't send another request for new frames in the mean-time and won't restart the idle timer.

This commit makes primary keep track of replicas waiting for new frames and prevents IdleShutdownLayer from stopping the primary if there is at least one replica still waiting for the new frames.

When a replica is put into sleep, it will drop the connection and the connected_replicas counter will be decreased so only live replicas can prevent primary from going to sleep.

Fixes #506