### PR TITLE
Async ResultBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2519,6 +2519,7 @@ dependencies = [
  "bytesize",
  "crc",
  "crossbeam",
+ "either",
  "fallible-iterator 0.3.0",
  "itertools 0.11.0",
  "nix",
@@ -2533,6 +2534,7 @@ dependencies = [
  "sqlite3-parser 0.9.0",
  "tempfile",
  "thiserror",
+ "tokio",
  "tracing",
  "uuid",
 ]
@@ -2549,6 +2551,7 @@ dependencies = [
  "bytes 1.4.0",
  "clap",
  "color-eyre",
+ "either",
  "futures",
  "hmac",
  "hyper",

--- a/libsqlx-server/Cargo.toml
+++ b/libsqlx-server/Cargo.toml
@@ -14,11 +14,12 @@ bincode = "1.3.3"
 bytes = { version =  "1.4.0", features = ["serde"] }
 clap = { version = "4.3.11", features = ["derive"] }
 color-eyre = "0.6.2"
+either = "1.8.1"
 futures = "0.3.28"
 hmac = "0.12.1"
 hyper = { version = "0.14.27", features = ["h2", "server"] }
 itertools = "0.11.0"
-libsqlx = { version = "0.1.0", path = "../libsqlx" }
+libsqlx = { version = "0.1.0", path = "../libsqlx", features = ["tokio"] }
 moka = { version = "0.11.2", features = ["future"] }
 parking_lot = "0.12.1"
 priority-queue = "1.3.2"

--- a/libsqlx/Cargo.toml
+++ b/libsqlx/Cargo.toml
@@ -27,8 +27,13 @@ crc = "3.0.1"
 once_cell = "1.18.0"
 regex = "1.8.4"
 tempfile = "3.6.0"
+either = "1.8.1"
+tokio = { version = "1", optional = true, features = ["sync"] }
 
 [dev-dependencies]
 arbitrary = { version = "1.3.0", features = ["derive"] }
 itertools = "0.11.0"
 rand = "0.8.5"
+
+[features]
+tokio = ["dep:tokio"]

--- a/libsqlx/src/connection.rs
+++ b/libsqlx/src/connection.rs
@@ -1,8 +1,7 @@
-use rusqlite::types::Value;
+use either::Either;
 
-use crate::program::{Program, Step};
-use crate::query::Query;
-use crate::result_builder::{QueryBuilderConfig, QueryResultBuilderError, ResultBuilder};
+use crate::program::Program;
+use crate::result_builder::ResultBuilder;
 
 #[derive(Debug, Clone)]
 pub struct DescribeResponse {
@@ -25,81 +24,36 @@ pub struct DescribeCol {
 
 pub trait Connection {
     /// Executes a query program
-    fn execute_program(
+    fn execute_program<B: ResultBuilder>(
         &mut self,
-        pgm: Program,
-        result_builder: &mut dyn ResultBuilder,
+        pgm: &Program,
+        result_builder: B,
     ) -> crate::Result<()>;
 
     /// Parse the SQL statement and return information about it.
     fn describe(&self, sql: String) -> crate::Result<DescribeResponse>;
-
-    /// execute a single query
-    fn execute(&mut self, query: Query) -> crate::Result<Vec<Vec<Value>>> {
-        #[derive(Default)]
-        struct RowsBuilder {
-            error: Option<crate::error::Error>,
-            rows: Vec<Vec<Value>>,
-            current_row: Vec<Value>,
-        }
-
-        impl ResultBuilder for RowsBuilder {
-            fn init(
-                &mut self,
-                _config: &QueryBuilderConfig,
-            ) -> std::result::Result<(), QueryResultBuilderError> {
-                self.error = None;
-                self.rows.clear();
-                self.current_row.clear();
-
-                Ok(())
-            }
-
-            fn add_row_value(
-                &mut self,
-                v: rusqlite::types::ValueRef,
-            ) -> Result<(), QueryResultBuilderError> {
-                self.current_row.push(v.into());
-                Ok(())
-            }
-
-            fn finish_row(&mut self) -> Result<(), QueryResultBuilderError> {
-                let row = std::mem::take(&mut self.current_row);
-                self.rows.push(row);
-
-                Ok(())
-            }
-
-            fn step_error(
-                &mut self,
-                error: crate::error::Error,
-            ) -> Result<(), QueryResultBuilderError> {
-                self.error.replace(error);
-                Ok(())
-            }
-        }
-
-        let pgm = Program::new(vec![Step { cond: None, query }]);
-        let mut builder = RowsBuilder::default();
-        self.execute_program(pgm, &mut builder)?;
-        if let Some(err) = builder.error.take() {
-            Err(err)
-        } else {
-            Ok(builder.rows)
-        }
-    }
 }
 
-impl Connection for Box<dyn Connection> {
-    fn execute_program(
+impl<T, X> Connection for Either<T, X>
+where
+    T: Connection,
+    X: Connection,
+{
+    fn execute_program<B: ResultBuilder>(
         &mut self,
-        pgm: Program,
-        result_builder: &mut dyn ResultBuilder,
+        pgm: &Program,
+        result_builder: B,
     ) -> crate::Result<()> {
-        self.as_mut().execute_program(pgm, result_builder)
+        match self {
+            Either::Left(c) => c.execute_program(pgm, result_builder),
+            Either::Right(c) => c.execute_program(pgm, result_builder),
+        }
     }
 
     fn describe(&self, sql: String) -> crate::Result<DescribeResponse> {
-        self.as_ref().describe(sql)
+        match self {
+            Either::Left(c) => c.describe(sql),
+            Either::Right(c) => c.describe(sql),
+        }
     }
 }

--- a/libsqlx/src/database/libsql/mod.rs
+++ b/libsqlx/src/database/libsql/mod.rs
@@ -163,21 +163,19 @@ impl<T> LibsqlDatabase<T> {
 }
 
 impl<T: LibsqlDbType> Database for LibsqlDatabase<T> {
-    type Connection = LibsqlConnection<<T::ConnectionHook as WalHook>::Context>;
+    type Connection = LibsqlConnection<T>;
 
     fn connect(&self) -> Result<Self::Connection, Error> {
-        Ok(
-            LibsqlConnection::<<T::ConnectionHook as WalHook>::Context>::new(
-                &self.db_path,
-                self.extensions.clone(),
-                T::hook(),
-                self.ty.hook_context(),
-                self.row_stats_callback.clone(),
-                QueryBuilderConfig {
-                    max_size: Some(self.response_size_limit),
-                },
-            )?,
-        )
+        Ok(LibsqlConnection::<T>::new(
+            &self.db_path,
+            self.extensions.clone(),
+            T::hook(),
+            self.ty.hook_context(),
+            self.row_stats_callback.clone(),
+            QueryBuilderConfig {
+                max_size: Some(self.response_size_limit),
+            },
+        )?)
     }
 }
 

--- a/libsqlx/src/database/libsql/replication_log/logger.rs
+++ b/libsqlx/src/database/libsql/replication_log/logger.rs
@@ -441,7 +441,6 @@ impl LogFile {
     }
 
     pub fn commit(&mut self) -> crate::Result<()> {
-        dbg!(&self);
         self.header.frame_count += self.uncommitted_frame_count;
         self.uncommitted_frame_count = 0;
         self.commited_checksum = self.uncommitted_checksum;
@@ -551,7 +550,6 @@ impl LogFile {
     /// If the requested frame is before the first frame in the log, or after the last frame,
     /// Ok(None) is returned.
     pub fn frame(&self, frame_no: FrameNo) -> std::result::Result<Frame, LogReadError> {
-        dbg!(frame_no);
         if frame_no < self.header.start_frame_no {
             return Err(LogReadError::SnapshotRequired);
         }
@@ -877,7 +875,6 @@ impl ReplicationLogger {
     /// Returns the new frame count and checksum to commit
     fn write_pages(&self, pages: &[WalPage]) -> anyhow::Result<()> {
         let mut log_file = self.log_file.write();
-            dbg!();
         for page in pages.iter() {
             log_file.push_page(page)?;
         }
@@ -906,7 +903,10 @@ impl ReplicationLogger {
     fn commit(&self) -> anyhow::Result<FrameNo> {
         let mut log_file = self.log_file.write();
         log_file.commit()?;
-        Ok(log_file.header().last_frame_no().expect("there should be at least one frame after commit"))
+        Ok(log_file
+            .header()
+            .last_frame_no()
+            .expect("there should be at least one frame after commit"))
     }
 
     pub fn get_snapshot_file(&self, from: FrameNo) -> anyhow::Result<Option<SnapshotFile>> {

--- a/libsqlx/src/database/proxy/mod.rs
+++ b/libsqlx/src/database/proxy/mod.rs
@@ -5,6 +5,7 @@ use super::FrameNo;
 mod connection;
 mod database;
 
+pub use connection::WriteProxyConnection;
 pub use database::WriteProxyDatabase;
 
 // Waits until passed frameno has been replicated back to the database

--- a/libsqlx/src/lib.rs
+++ b/libsqlx/src/lib.rs
@@ -18,4 +18,6 @@ pub use database::proxy;
 pub use database::Frame;
 pub use database::{Database, InjectableDatabase, Injector};
 
+pub use sqld_libsql_bindings::wal_hook::WalHook;
+
 pub use rusqlite;


### PR DESCRIPTION
Refactor `Database` and `ResultBuilder` trait from full async operation.

Instead of taking a mutable reference to a `ResultBuilder`, the `Database` trait takes ownership of the `ResultBuilder`. The `finnalize` method can be used to return the result one way or another, for example with a `oneshot::channel`. This new model allows the Builder to be driven completely asynchronously, in sync and async context.
