### PR TITLE
sqld: Remove external `protoc` dependency

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,10 +24,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -48,10 +44,6 @@ jobs:
           toolchain: stable
           components: clippy
           override: true
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -72,10 +64,6 @@ jobs:
           toolchain: stable
           components: rustfmt
           override: true
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -114,10 +102,6 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install foundationdb-clients
       run: wget https://github.com/apple/foundationdb/releases/download/7.1.25/foundationdb-clients_7.1.25-1_amd64.deb && sudo dpkg -i foundationdb-clients_7.1.25-1_amd64.deb
     - uses: actions/checkout@v3
@@ -145,10 +129,6 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout
       uses: actions/checkout@v3
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "autotools"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8da1805e028a172334c3b680f93e71126f2327622faef2ec3d893c0a4ad77"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "aws-config"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3045,6 +3054,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf-src"
+version = "1.1.0+21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
+dependencies = [
+ "autotools",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3713,6 +3731,7 @@ dependencies = [
  "proptest",
  "prost",
  "prost-build",
+ "protobuf-src",
  "rand",
  "regex",
  "reqwest",

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -70,6 +70,7 @@ aws-sdk-s3 = "0.28"
 
 [build-dependencies]
 prost-build = "0.11.4"
+protobuf-src = "1.1.0"
 tonic-build = "0.8.4"
 vergen = { version = "8", features = ["build", "git", "gitcl"] }
 

--- a/sqld/build.rs
+++ b/sqld/build.rs
@@ -4,6 +4,8 @@ use vergen::EmitBuilder;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     EmitBuilder::builder().git_sha(false).all_build().emit()?;
 
+    std::env::set_var("PROTOC", protobuf_src::protoc());
+
     let mut config = Config::new();
     config.bytes([".wal_log"]);
     tonic_build::configure()


### PR DESCRIPTION
Let's use the `protobuf-src` crate to remove the dependency to external `protoc` to simplify the build process.