### PR TITLE
HTTP replication

### DIFF
--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -497,14 +497,14 @@ async fn start_primary(
             config.rpc_server_key.clone(),
             config.rpc_server_ca_cert.clone(),
             db_factory.clone(),
-            logger,
+            logger.clone(),
             idle_shutdown_layer.clone(),
         ));
     }
 
     if let Some(ref addr) = config.http_replication_addr {
         let auth = get_auth(config)?;
-        join_set.spawn(replication::http::run(auth, *addr));
+        join_set.spawn(replication::http::run(auth, *addr, logger));
     }
 
     run_service(

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -503,8 +503,9 @@ async fn start_primary(
     }
 
     if let Some(ref addr) = config.http_replication_addr {
-        let auth = get_auth(config)?;
-        join_set.spawn(replication::http::run(auth, *addr, logger));
+        // FIXME: let's bring it back once I figure out how Axum works
+        // let auth = get_auth(config)?;
+        join_set.spawn(replication::http::run(*addr, logger));
     }
 
     run_service(

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -183,6 +183,10 @@ struct Cli {
     /// Set a command to execute when a snapshot file is generated.
     #[clap(long, env = "SQLD_SNAPSHOT_EXEC")]
     snapshot_exec: Option<String>,
+
+    /// The address and port for the replication HTTP API.
+    #[clap(long, env = "SQLD_HTTP_REPLICATION_LISTEN_ADDR")]
+    http_replication_listen_addr: Option<SocketAddr>,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -292,6 +296,7 @@ fn config_from_args(args: Cli) -> Result<Config> {
         allow_replica_overwrite: args.allow_replica_overwrite,
         max_response_size: args.max_response_size.0,
         snapshot_exec: args.snapshot_exec,
+        http_replication_addr: args.http_replication_listen_addr,
     })
 }
 

--- a/sqld/src/replication/frame.rs
+++ b/sqld/src/replication/frame.rs
@@ -27,7 +27,7 @@ pub struct FrameHeader {
     pub size_after: u32,
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 /// The owned version of a replication frame.
 /// Cloning this is cheap.
 pub struct Frame {

--- a/sqld/src/replication/http.rs
+++ b/sqld/src/replication/http.rs
@@ -1,0 +1,98 @@
+use crate::Auth;
+use anyhow::{Context, Result};
+use hyper::server::conn::AddrIncoming;
+use hyper::{Body, Method, Request, Response};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tower::ServiceBuilder;
+use tower_http::trace::DefaultOnResponse;
+use tower_http::{compression::CompressionLayer, cors};
+use tracing::{Level, Span};
+
+pub(crate) async fn run(auth: Arc<Auth>, addr: SocketAddr) -> Result<()> {
+    tracing::info!("listening for HTTP requests on {addr}");
+
+    fn trace_request<B>(req: &Request<B>, _span: &Span) {
+        tracing::debug!("got request: {} {}", req.method(), req.uri());
+    }
+    let service = ServiceBuilder::new()
+        .layer(
+            tower_http::trace::TraceLayer::new_for_http()
+                .on_request(trace_request)
+                .on_response(
+                    DefaultOnResponse::new()
+                        .level(Level::DEBUG)
+                        .latency_unit(tower_http::LatencyUnit::Micros),
+                ),
+        )
+        .layer(CompressionLayer::new())
+        .layer(
+            cors::CorsLayer::new()
+                .allow_methods(cors::AllowMethods::any())
+                .allow_headers(cors::Any)
+                .allow_origin(cors::Any),
+        )
+        .service_fn(move |req| {
+            let auth = auth.clone();
+            handle_request(auth, req)
+        });
+
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    let server = hyper::server::Server::builder(AddrIncoming::from_listener(listener)?)
+        .tcp_nodelay(true)
+        .serve(tower::make::Shared::new(service));
+
+    server.await.context("Http server exited with an error")?;
+
+    Ok(())
+}
+
+async fn handle_request(auth: Arc<Auth>, req: Request<Body>) -> Result<Response<Body>> {
+    let auth_header = req.headers().get(hyper::header::AUTHORIZATION);
+    let auth = match auth.authenticate_http(auth_header) {
+        Ok(auth) => auth,
+        Err(err) => {
+            return Ok(Response::builder()
+                .status(hyper::StatusCode::UNAUTHORIZED)
+                .body(err.to_string().into())
+                .unwrap());
+        }
+    };
+
+    match (req.method(), req.uri().path()) {
+        (&Method::POST, "/frames") => handle_query(req, auth).await,
+        _ => Ok(Response::builder().status(404).body(Body::empty()).unwrap()),
+    }
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct FramesRequest {
+    pub next_offset: u64,
+}
+
+fn error(msg: &str, code: hyper::StatusCode) -> Response<Body> {
+    let err = serde_json::json!({ "error": msg });
+    Response::builder()
+        .status(code)
+        .body(Body::from(serde_json::to_vec(&err).unwrap()))
+        .unwrap()
+}
+
+async fn handle_query(
+    mut req: Request<Body>,
+    _auth: crate::auth::Authenticated,
+) -> Result<Response<Body>> {
+    let bytes = hyper::body::to_bytes(req.body_mut()).await?;
+    let FramesRequest { next_offset } = match serde_json::from_slice(&bytes) {
+        Ok(req) => req,
+        Err(resp) => return Ok(error(&resp.to_string(), hyper::StatusCode::BAD_REQUEST)),
+    };
+
+    Ok(Response::builder()
+        .status(hyper::StatusCode::OK)
+        .body(Body::from(format!(
+            "{{\"comment\":\"thx for sending the request\", \"next_offset\":{}}}",
+            next_offset + 1
+        )))
+        .unwrap())
+}

--- a/sqld/src/replication/mod.rs
+++ b/sqld/src/replication/mod.rs
@@ -1,4 +1,5 @@
 pub mod frame;
+pub mod http;
 pub mod primary;
 pub mod replica;
 mod snapshot;

--- a/sqld/src/replication/primary/frame_stream.rs
+++ b/sqld/src/replication/primary/frame_stream.rs
@@ -11,8 +11,8 @@ use crate::replication::{FrameNo, LogReadError, ReplicationLogger};
 /// Streams frames from the replication log starting at `current_frame_no`.
 /// Only stops if the current frame is not in the log anymore.
 pub struct FrameStream {
-    current_frame_no: FrameNo,
-    max_available_frame_no: FrameNo,
+    pub(crate) current_frame_no: FrameNo,
+    pub(crate) max_available_frame_no: FrameNo,
     logger: Arc<ReplicationLogger>,
     state: FrameStreamState,
 }

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -295,7 +295,7 @@ impl ReplicationLoggerHookCtx {
 
     fn commit(&self) -> anyhow::Result<()> {
         let new_frame_no = self.logger.commit()?;
-        let _ = self.logger.new_frame_notifier.send(new_frame_no);
+        self.logger.new_frame_notifier.send_replace(new_frame_no);
         Ok(())
     }
 


### PR DESCRIPTION
This draft adds an experimental endpoint which serves frames for replication purposes. It's capabilities are:
1. Metadata is available at `/hello` endpoint
2. Frames are available at `/frames` endpoint

And that's about it. For simplicity, when frames can't be served from a FrameStream and instead need to be loaded from a snapshot file, the whole contents of the snapshot is sent in a single request. That's a limitation, but it's also why the endpoint is considered experimental. For the same reason, it is right now implemented as a separate service running on a dedicated port (e.g. 8081), so that it's isolated from user workloads.

This endpoint also does not account any reads in the metrics, and it definitely should, as it's very read-heavy. We should also consider having a separate auth path for it, because its main purpose is for being used by replicas (possibly embedded), not for regular direct access to frames.

Testing setup for sqld:
```sh
cargo run -- --http-replication-listen-addr 127.0.0.1:8081
```

```sh
curl localhost:8081/hello
curl -d '{"next_offset": 1}' localhost:8081/frames
```

HTTP replication is also used in [this experimental project](https://github.com/libsql/libsql/tree/main/crates/core), and in particular it can be tested via `cargo run --example replica` from libsql/crates/core source directory.