### PR TITLE
turn off sqlite auto_checkpoint and introduce period-based checkpoint calls

### DIFF
--- a/bottomless/src/lib.rs
+++ b/bottomless/src/lib.rs
@@ -15,6 +15,7 @@ use crate::ffi::{
     bottomless_methods, libsql_wal_methods, sqlite3, sqlite3_file, sqlite3_vfs, PgHdr, Wal,
 };
 use std::ffi::{c_char, c_void};
+use tokio::time::Instant;
 
 // Just heuristics, but should work for ~100% of cases
 fn is_regular(vfs: *const sqlite3_vfs) -> bool {
@@ -300,6 +301,7 @@ pub extern "C" fn xCheckpoint(
     backfilled_frames: *mut i32,
 ) -> i32 {
     tracing::trace!("Checkpoint");
+    let start = Instant::now();
 
     /* In order to avoid partial checkpoints, passive checkpoint
      ** mode is not allowed. Only TRUNCATE checkpoints are accepted,
@@ -366,6 +368,7 @@ pub extern "C" fn xCheckpoint(
         );
         return ffi::SQLITE_IOERR_WRITE;
     }
+    tracing::debug!("Checkpoint completed in {:?}", Instant::now() - start);
 
     ffi::SQLITE_OK
 }

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -112,17 +112,16 @@ impl Options {
         if let Some(region) = self.region.as_deref() {
             loader = loader.region(Region::new(region.to_string()));
         }
-        match (&self.access_key_id, &self.secret_access_key) {
-            (Some(access_key_id), Some(secret_access_key)) => {
-                loader = loader.credentials_provider(Credentials::new(
-                    access_key_id,
-                    secret_access_key,
-                    None,
-                    None,
-                    "Static",
-                ));
-            }
-            _ => {}
+        if let (Some(access_key_id), Some(secret_access_key)) =
+            (&self.access_key_id, &self.secret_access_key)
+        {
+            loader = loader.credentials_provider(Credentials::new(
+                access_key_id,
+                secret_access_key,
+                None,
+                None,
+                "Static",
+            ));
         }
         if let Some(endpoint) = self.aws_endpoint.as_deref() {
             loader = loader.endpoint_url(endpoint);

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -363,7 +363,7 @@ impl Replicator {
                         } else {
                             tokio::fs::remove_file(&fpath).await.unwrap();
                             let elapsed = Instant::now() - start;
-                            tracing::trace!("Uploaded to S3: {} in {:?}", fpath, elapsed);
+                            tracing::debug!("Uploaded to S3: {} in {:?}", fpath, elapsed);
                         }
                         drop(permit);
                     });

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+profile = "default"
+channel = "1.70.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-profile = "default"
-channel = "1.70.0"

--- a/sqld/src/connection/dump/loader.rs
+++ b/sqld/src/connection/dump/loader.rs
@@ -29,10 +29,11 @@ impl DumpLoader {
 
         let (ok_snd, ok_rcv) = oneshot::channel::<anyhow::Result<()>>();
         tokio::task::spawn_blocking(move || {
+            let auto_checkpoint = logger.auto_checkpoint;
             let mut ctx = ReplicationLoggerHookCtx::new(logger, bottomless_replicator);
             let mut retries = 0;
             let db = loop {
-                match open_db(&path, &REPLICATION_METHODS, &mut ctx, None) {
+                match open_db(&path, &REPLICATION_METHODS, &mut ctx, None, auto_checkpoint) {
                     Ok(db) => {
                         if ok_snd.send(Ok(())).is_ok() {
                             break db;

--- a/sqld/src/connection/libsql.rs
+++ b/sqld/src/connection/libsql.rs
@@ -15,7 +15,7 @@ use crate::query::Query;
 use crate::query_analysis::{State, StmtKind};
 use crate::query_result_builder::{QueryBuilderConfig, QueryResultBuilder};
 use crate::stats::Stats;
-use crate::{Result, DEFAULT_AUTO_CHECKPOINT};
+use crate::Result;
 
 use super::config::DatabaseConfigStore;
 use super::program::{Cond, DescribeCol, DescribeParam, DescribeResponse, DescribeResult};
@@ -33,6 +33,7 @@ pub struct LibSqlDbFactory<W: WalHook + 'static> {
     extensions: Vec<PathBuf>,
     max_response_size: u64,
     max_total_response_size: u64,
+    auto_checkpoint: u32,
     /// In wal mode, closing the last database takes time, and causes other databases creation to
     /// return sqlite busy. To mitigate that, we hold on to one connection
     _db: Option<LibSqlConnection>,
@@ -53,6 +54,7 @@ where
         extensions: Vec<PathBuf>,
         max_response_size: u64,
         max_total_response_size: u64,
+        auto_checkpoint: u32,
     ) -> Result<Self>
     where
         F: Fn() -> W::Context + Sync + Send + 'static,
@@ -66,6 +68,7 @@ where
             extensions,
             max_response_size,
             max_total_response_size,
+            auto_checkpoint,
             _db: None,
         };
 
@@ -115,7 +118,7 @@ where
             QueryBuilderConfig {
                 max_size: Some(self.max_response_size),
                 max_total_size: Some(self.max_total_response_size),
-                auto_checkpoint: DEFAULT_AUTO_CHECKPOINT,
+                auto_checkpoint: self.auto_checkpoint,
             },
         )
         .await

--- a/sqld/src/connection/libsql.rs
+++ b/sqld/src/connection/libsql.rs
@@ -154,7 +154,6 @@ where
             | OpenFlags::SQLITE_OPEN_URI
             | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     );
-
     sqld_libsql_bindings::Connection::open(path, flags, wal_methods, hook_ctx)
 }
 

--- a/sqld/src/connection/write_proxy.rs
+++ b/sqld/src/connection/write_proxy.rs
@@ -21,7 +21,7 @@ use crate::rpc::proxy::rpc::proxy_client::ProxyClient;
 use crate::rpc::proxy::rpc::query_result::RowResult;
 use crate::rpc::proxy::rpc::{DisconnectMessage, ExecuteResults};
 use crate::stats::Stats;
-use crate::Result;
+use crate::{Result, DEFAULT_AUTO_CHECKPOINT};
 
 use super::config::DatabaseConfigStore;
 use super::libsql::LibSqlConnection;
@@ -85,6 +85,7 @@ impl MakeConnection for MakeWriteProxyConnection {
             QueryBuilderConfig {
                 max_size: Some(self.max_response_size),
                 max_total_size: Some(self.max_total_response_size),
+                auto_checkpoint: DEFAULT_AUTO_CHECKPOINT,
             },
             self.namespace.clone(),
         )

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -745,7 +745,9 @@ pub async fn run_server(config: Config) -> anyhow::Result<()> {
         }
 
         if let Some(interval) = config.checkpoint_interval {
-            join_set.spawn(run_checkpoint_cron(config.db_path.clone(), interval));
+            if config.bottomless_replication.is_some() {
+                join_set.spawn(run_checkpoint_cron(config.db_path.clone(), interval));
+            }
         }
 
         let reset = HARD_RESET.clone();

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -64,7 +64,11 @@ pub mod version;
 
 const MAX_CONCURRENT_DBS: usize = 128;
 const DB_CREATE_TIMEOUT: Duration = Duration::from_secs(1);
+<<<<<<< HEAD
 const DEFAULT_NAMESPACE_NAME: &str = "default";
+=======
+const DEFAULT_AUTO_CHECKPOINT: u32 = 1000;
+>>>>>>> f5e8cc6 (made auto_checkpoint configurable at Connection::open level)
 
 #[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
 pub enum Backend {
@@ -535,7 +539,7 @@ async fn run_storage_monitor(db_path: PathBuf, stats: Stats) -> anyhow::Result<(
             // initialize a connection here, and keep it alive for the entirety of the program. If we
             // fail to open it, we wait for `duration` and try again later.
             let ctx = &mut ();
-            let maybe_conn = match open_db(&db_path, &TRANSPARENT_METHODS, ctx, Some(rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)) {
+            let maybe_conn = match open_db(&db_path, &TRANSPARENT_METHODS, ctx, Some(rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY), DEFAULT_AUTO_CHECKPOINT) {
                 Ok(conn) => Some(conn),
                 Err(e) => {
                     tracing::warn!("failed to open connection for storager monitor: {e}, trying again in {duration:?}");

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -61,16 +61,8 @@ pub mod version;
 
 const MAX_CONCURRENT_DBS: usize = 128;
 const DB_CREATE_TIMEOUT: Duration = Duration::from_secs(1);
-<<<<<<< HEAD
-<<<<<<< HEAD
 const DEFAULT_NAMESPACE_NAME: &str = "default";
-=======
 const DEFAULT_AUTO_CHECKPOINT: u32 = 1000;
->>>>>>> f5e8cc6 (made auto_checkpoint configurable at Connection::open level)
-=======
-const DEFAULT_AUTO_CHECKPOINT: u32 = 1000;
-const DEFAULT_NAMESPACE_NAME: &str = "default";
->>>>>>> 9d3ce22 (fixing mess after merge with main)
 
 #[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
 pub enum Backend {
@@ -115,16 +107,9 @@ pub struct Config {
     pub max_response_size: u64,
     pub max_total_response_size: u64,
     pub snapshot_exec: Option<String>,
-<<<<<<< HEAD
     pub disable_default_namespace: bool,
     pub disable_namespaces: bool,
-    pub http_replication_addr: Option<SocketAddr>,
     pub checkpoint_interval: Option<Duration>,
-=======
-    pub http_replication_addr: Option<SocketAddr>,
-    pub checkpoint_interval: Option<Duration>,
-    pub disable_default_namespace: bool,
->>>>>>> 9d3ce22 (fixing mess after merge with main)
 }
 
 impl Default for Config {
@@ -164,16 +149,9 @@ impl Default for Config {
             max_response_size: 10 * 1024 * 1024,       // 10MiB
             max_total_response_size: 32 * 1024 * 1024, // 32MiB
             snapshot_exec: None,
-<<<<<<< HEAD
             disable_default_namespace: false,
             disable_namespaces: true,
-            http_replication_addr: None,
             checkpoint_interval: None,
-=======
-            http_replication_addr: None,
-            checkpoint_interval: None,
-            disable_default_namespace: false,
->>>>>>> 9d3ce22 (fixing mess after merge with main)
         }
     }
 }
@@ -554,6 +532,8 @@ async fn run_storage_monitor(db_path: PathBuf, stats: Stats) -> anyhow::Result<(
             // initialize a connection here, and keep it alive for the entirety of the program. If we
             // fail to open it, we wait for `duration` and try again later.
             let ctx = &mut ();
+            // We can safely open db with DEFAULT_AUTO_CHECKPOINT, since monitor is read-only: it 
+            // won't produce new updates, frames or generate checkpoints.
             let maybe_conn = match open_db(&db_path, &TRANSPARENT_METHODS, ctx, Some(rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY), DEFAULT_AUTO_CHECKPOINT) {
                 Ok(conn) => Some(conn),
                 Err(e) => {

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -196,7 +196,7 @@ struct Cli {
     http_replication_listen_addr: Option<SocketAddr>,
     /// Interval in seconds, in which WAL checkpoint is being called.
     /// By default, the interval is 1 hour.
-    #[clap(long, env = "SQLD_CHECKPOINT_INTERVAL_S", default_value = "3600")]
+    #[clap(long, env = "SQLD_CHECKPOINT_INTERVAL_S")]
     checkpoint_interval_s: Option<u64>,
 }
 

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -182,10 +182,6 @@ struct Cli {
     #[clap(long, env = "SQLD_SNAPSHOT_EXEC")]
     snapshot_exec: Option<String>,
 
-    /// The address and port for the replication HTTP API.
-    #[clap(long, env = "SQLD_HTTP_REPLICATION_LISTEN_ADDR")]
-    http_replication_listen_addr: Option<SocketAddr>,
-
     /// Interval in seconds, in which WAL checkpoint is being called.
     /// By default, the interval is 1 hour.
     #[clap(long, env = "SQLD_CHECKPOINT_INTERVAL_S")]
@@ -200,13 +196,6 @@ struct Cli {
     /// the default namespace.
     #[clap(long)]
     enable_namespaces: bool,
-    /// The address and port for the replication HTTP API.
-    #[clap(long, env = "SQLD_HTTP_REPLICATION_LISTEN_ADDR")]
-    http_replication_listen_addr: Option<SocketAddr>,
-    /// Interval in seconds, in which WAL checkpoint is being called.
-    /// By default, the interval is 1 hour.
-    #[clap(long, env = "SQLD_CHECKPOINT_INTERVAL_S")]
-    checkpoint_interval_s: Option<u64>,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -320,7 +309,6 @@ fn config_from_args(args: Cli) -> Result<Config> {
         snapshot_exec: args.snapshot_exec,
         disable_default_namespace: args.disable_default_namespace,
         disable_namespaces: !args.enable_namespaces,
-        http_replication_addr: args.http_replication_listen_addr,
         checkpoint_interval: args.checkpoint_interval_s.map(Duration::from_secs),
     })
 }

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -191,6 +191,13 @@ struct Cli {
     /// the default namespace.
     #[clap(long)]
     enable_namespaces: bool,
+    /// The address and port for the replication HTTP API.
+    #[clap(long, env = "SQLD_HTTP_REPLICATION_LISTEN_ADDR")]
+    http_replication_listen_addr: Option<SocketAddr>,
+    /// Interval in seconds, in which WAL checkpoint is being called.
+    /// By default, the interval is 1 hour.
+    #[clap(long, env = "SQLD_CHECKPOINT_INTERVAL_S", default_value = "3600")]
+    checkpoint_interval_s: Option<u64>,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -304,6 +311,8 @@ fn config_from_args(args: Cli) -> Result<Config> {
         snapshot_exec: args.snapshot_exec,
         disable_default_namespace: args.disable_default_namespace,
         disable_namespaces: !args.enable_namespaces,
+        http_replication_addr: args.http_replication_listen_addr,
+        checkpoint_interval: args.checkpoint_interval_s.map(Duration::from_secs),
     })
 }
 

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -182,6 +182,15 @@ struct Cli {
     #[clap(long, env = "SQLD_SNAPSHOT_EXEC")]
     snapshot_exec: Option<String>,
 
+    /// The address and port for the replication HTTP API.
+    #[clap(long, env = "SQLD_HTTP_REPLICATION_LISTEN_ADDR")]
+    http_replication_listen_addr: Option<SocketAddr>,
+
+    /// Interval in seconds, in which WAL checkpoint is being called.
+    /// By default, the interval is 1 hour.
+    #[clap(long, env = "SQLD_CHECKPOINT_INTERVAL_S")]
+    checkpoint_interval_s: Option<u64>,
+
     /// By default, all request for which a namespace can't be determined fallaback to the default
     /// namespace `default`. This flag disables that.
     #[clap(long)]

--- a/sqld/src/namespace.rs
+++ b/sqld/src/namespace.rs
@@ -296,6 +296,7 @@ impl Namespace<PrimaryDatabase> {
             config.extensions.clone(),
             config.max_response_size,
             config.max_total_response_size,
+            auto_checkpoint,
         )
         .await?
         .throttled(

--- a/sqld/src/namespace.rs
+++ b/sqld/src/namespace.rs
@@ -22,7 +22,7 @@ use crate::replication::{NamespacedSnapshotCallback, ReplicationLogger};
 use crate::stats::Stats;
 use crate::{
     check_fresh_db, init_bottomless_replicator, run_periodic_compactions, DB_CREATE_TIMEOUT,
-    MAX_CONCURRENT_DBS,
+    DEFAULT_AUTO_CHECKPOINT, MAX_CONCURRENT_DBS,
 };
 
 /// Creates a new `Namespace` for database of the `Self::Database` type.
@@ -222,6 +222,7 @@ pub struct PrimaryNamespaceConfig {
     pub max_response_size: u64,
     pub load_from_dump: Option<PathBuf>,
     pub max_total_response_size: u64,
+    pub checkpoint_interval: Option<Duration>,
 }
 
 impl Namespace<PrimaryDatabase> {
@@ -246,11 +247,19 @@ impl Namespace<PrimaryDatabase> {
 
         tokio::fs::create_dir_all(&db_path).await?;
         let is_fresh_db = check_fresh_db(&db_path);
+        // switch frame-count checkpoint to time-based one
+        let auto_checkpoint =
+            if config.checkpoint_interval.is_some() && config.bottomless_replication.is_some() {
+                0
+            } else {
+                DEFAULT_AUTO_CHECKPOINT
+            };
         let logger = Arc::new(ReplicationLogger::open(
             &db_path,
             config.max_log_size,
             config.max_log_duration,
             is_dirty,
+            auto_checkpoint,
             Box::new({
                 let name = name.clone();
                 let cb = config.snapshot_callback.clone();

--- a/sqld/src/query_result_builder.rs
+++ b/sqld/src/query_result_builder.rs
@@ -83,6 +83,7 @@ impl<'a> From<&'a rusqlite::Column<'a>> for Column<'a> {
 pub struct QueryBuilderConfig {
     pub max_size: Option<u64>,
     pub max_total_size: Option<u64>,
+    pub auto_checkpoint: u32,
 }
 
 pub trait QueryResultBuilder: Send + 'static {

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -923,7 +923,6 @@ fn checkpoint_db(data_path: &Path, disable_auto_checkpoint: bool) -> anyhow::Res
             if num_checkpointed == -1 {
                 bail!("Checkpoint failed: database journal_mode is not WAL")
             } else {
-                conn.execute("VACUUM", ())?;
                 Ok(())
             }
         } else {

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -770,7 +770,7 @@ impl ReplicationLogger {
 
         let (new_frame_notifier, _) = watch::channel(generation_start_frame_no);
         unsafe {
-            let conn = rusqlite::Connection::open(&db_path)?;
+            let conn = rusqlite::Connection::open(&db_path.join("data"))?;
             let rc = rusqlite::ffi::sqlite3_wal_autocheckpoint(conn.handle(), auto_checkpoint as _);
             if rc != 0 {
                 bail!(

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -770,7 +770,7 @@ impl ReplicationLogger {
 
         let (new_frame_notifier, _) = watch::channel(generation_start_frame_no);
         unsafe {
-            let conn = rusqlite::Connection::open(&db_path.join("data"))?;
+            let conn = rusqlite::Connection::open(db_path.join("data"))?;
             let rc = rusqlite::ffi::sqlite3_wal_autocheckpoint(conn.handle(), auto_checkpoint as _);
             if rc != 0 {
                 bail!(

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -889,6 +889,8 @@ impl ReplicationLogger {
 fn checkpoint_db(data_path: &Path) -> anyhow::Result<()> {
     unsafe {
         let conn = rusqlite::Connection::open(data_path)?;
+        conn.query_row("PRAGMA journal_mode=WAL", (), |_| Ok(()))?;
+        tracing::info!("initialized journal_mode=WAL");
         conn.pragma_query(None, "page_size", |row| {
             let page_size = row.get::<_, i32>(0).unwrap();
             assert_eq!(

--- a/sqld/src/replication/replica/injector.rs
+++ b/sqld/src/replication/replica/injector.rs
@@ -21,6 +21,7 @@ impl<'a> FrameInjector<'a> {
                 | OpenFlags::SQLITE_OPEN_NO_MUTEX,
             &INJECTOR_METHODS,
             hook_ctx,
+            // It's ok to leave auto-checkpoint to default, since replicas don't use bottomless.
             DEFAULT_AUTO_CHECKPOINT,
         )?;
 

--- a/sqld/src/replication/replica/injector.rs
+++ b/sqld/src/replication/replica/injector.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use crate::DEFAULT_AUTO_CHECKPOINT;
 use rusqlite::OpenFlags;
 
 use crate::replication::replica::hook::{SQLITE_CONTINUE_REPLICATION, SQLITE_EXIT_REPLICATION};
@@ -20,6 +21,7 @@ impl<'a> FrameInjector<'a> {
                 | OpenFlags::SQLITE_OPEN_NO_MUTEX,
             &INJECTOR_METHODS,
             hook_ctx,
+            DEFAULT_AUTO_CHECKPOINT,
         )?;
 
         Ok(Self { conn })


### PR DESCRIPTION
This PR turns off auto_checkpoint in sqld-embed SQLite instance (which by default is every 1000 pages) and introduces a fiber loop, which checkpoints given configured time interval (by default it's every 1h).