### PR TITLE
A few overload protection mechanisms

### DIFF
--- a/sqld/src/database/factory.rs
+++ b/sqld/src/database/factory.rs
@@ -1,4 +1,10 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use futures::Future;
 use tokio::{sync::Semaphore, time::timeout};
@@ -15,11 +21,16 @@ pub trait DbFactory: Send + Sync + 'static {
 
     async fn create(&self) -> Result<Self::Db, Error>;
 
-    fn throttled(self, conccurency: usize, timeout: Option<Duration>) -> ThrottledDbFactory<Self>
+    fn throttled(
+        self,
+        conccurency: usize,
+        timeout: Option<Duration>,
+        max_total_response_size: u64,
+    ) -> ThrottledDbFactory<Self>
     where
         Self: Sized,
     {
-        ThrottledDbFactory::new(conccurency, self, timeout)
+        ThrottledDbFactory::new(conccurency, self, timeout, max_total_response_size)
     }
 }
 
@@ -38,20 +49,63 @@ where
     }
 }
 
-#[derive(Clone)]
 pub struct ThrottledDbFactory<F> {
     semaphore: Arc<Semaphore>,
     factory: F,
     timeout: Option<Duration>,
+    // Max memory available for responses. High memory pressure
+    // will result in reducing concurrency to prevent out-of-memory errors.
+    max_total_response_size: u64,
+    waiters: AtomicUsize,
 }
 
 impl<F> ThrottledDbFactory<F> {
-    fn new(conccurency: usize, factory: F, timeout: Option<Duration>) -> Self {
+    fn new(
+        conccurency: usize,
+        factory: F,
+        timeout: Option<Duration>,
+        max_total_response_size: u64,
+    ) -> Self {
         Self {
             semaphore: Arc::new(Semaphore::new(conccurency)),
             factory,
             timeout,
+            max_total_response_size,
+            waiters: AtomicUsize::new(0),
         }
+    }
+
+    // How many units should be acquired from the semaphore,
+    // depending on current memory pressure.
+    fn units_to_take(&self) -> u32 {
+        let total_response_size = crate::query_result_builder::TOTAL_RESPONSE_SIZE
+            .load(std::sync::atomic::Ordering::Relaxed) as u64;
+        if total_response_size * 2 > self.max_total_response_size {
+            tracing::trace!("High memory pressure, reducing concurrency");
+            16
+        } else if total_response_size * 4 > self.max_total_response_size {
+            tracing::trace!("Medium memory pressure, reducing concurrency");
+            4
+        } else {
+            1
+        }
+    }
+}
+
+struct WaitersGuard<'a> {
+    pub waiters: &'a AtomicUsize,
+}
+
+impl<'a> WaitersGuard<'a> {
+    fn new(waiters: &'a AtomicUsize) -> Self {
+        waiters.fetch_add(1, Ordering::Relaxed);
+        Self { waiters }
+    }
+}
+
+impl Drop for WaitersGuard<'_> {
+    fn drop(&mut self) {
+        self.waiters.fetch_sub(1, Ordering::Relaxed);
     }
 }
 
@@ -60,12 +114,31 @@ impl<F: DbFactory> DbFactory for ThrottledDbFactory<F> {
     type Db = TrackedDb<F::Db>;
 
     async fn create(&self) -> Result<Self::Db, Error> {
-        let fut = self.semaphore.clone().acquire_owned();
-        let permit = match self.timeout {
+        // If the memory pressure is high, request more units to reduce concurrency.
+        let units = self.units_to_take();
+        let waiters_guard = WaitersGuard::new(&self.waiters);
+        if waiters_guard.waiters.load(Ordering::Relaxed) >= 128 {
+            return Err(Error::TooManyRequests);
+        }
+        let fut = self.semaphore.clone().acquire_many_owned(units);
+        let mut permit = match self.timeout {
             Some(t) => timeout(t, fut).await.map_err(|_| Error::DbCreateTimeout)?,
             None => fut.await,
         }
         .expect("semaphore closed");
+
+        let units = self.units_to_take();
+        if units > 1 {
+            tracing::debug!("Reacquiring {units} units due to high memory pressure");
+            let fut = self.semaphore.clone().acquire_many_owned(64);
+            let mem_permit = match self.timeout {
+                Some(t) => timeout(t, fut).await.map_err(|_| Error::DbCreateTimeout)?,
+                None => fut.await,
+            }
+            .expect("semaphore closed");
+            permit.merge(mem_permit);
+        }
+
         let inner = self.factory.create().await?;
         Ok(TrackedDb { permit, inner })
     }

--- a/sqld/src/database/factory.rs
+++ b/sqld/src/database/factory.rs
@@ -196,7 +196,8 @@ mod test {
 
     #[tokio::test]
     async fn throttle_db_creation() {
-        let factory = (|| async { Ok(DummyDb) }).throttled(10, Some(Duration::from_millis(100)));
+        let factory =
+            (|| async { Ok(DummyDb) }).throttled(10, Some(Duration::from_millis(100)), u64::MAX);
 
         let mut conns = Vec::with_capacity(10);
         for _ in 0..10 {

--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -46,6 +46,7 @@ where
     W: WalHook + 'static + Sync + Send,
     W::Context: Send + 'static,
 {
+    #[allow(clippy::too_many_arguments)]
     pub async fn new<F>(
         db_path: PathBuf,
         hook: &'static WalMethodsHook<W>,

--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -35,6 +35,7 @@ pub struct LibSqlDbFactory<W: WalHook + 'static> {
     config_store: Arc<DatabaseConfigStore>,
     extensions: Vec<PathBuf>,
     max_response_size: u64,
+    max_total_response_size: u64,
     /// In wal mode, closing the last database takes time, and causes other databases creation to
     /// return sqlite busy. To mitigate that, we hold on to one connection
     _db: Option<LibSqlDb>,
@@ -53,6 +54,7 @@ where
         config_store: Arc<DatabaseConfigStore>,
         extensions: Vec<PathBuf>,
         max_response_size: u64,
+        max_total_response_size: u64,
     ) -> Result<Self>
     where
         F: Fn() -> W::Context + Sync + Send + 'static,
@@ -65,6 +67,7 @@ where
             config_store,
             extensions,
             max_response_size,
+            max_total_response_size,
             _db: None,
         };
 
@@ -113,6 +116,7 @@ where
             self.config_store.clone(),
             QueryBuilderConfig {
                 max_size: Some(self.max_response_size),
+                max_total_size: Some(self.max_total_response_size),
             },
         )
         .await

--- a/sqld/src/database/write_proxy.rs
+++ b/sqld/src/database/write_proxy.rs
@@ -35,6 +35,7 @@ pub struct WriteProxyDbFactory {
     config_store: Arc<DatabaseConfigStore>,
     applied_frame_no_receiver: watch::Receiver<FrameNo>,
     max_response_size: u64,
+    max_total_response_size: u64,
 }
 
 impl WriteProxyDbFactory {
@@ -48,6 +49,7 @@ impl WriteProxyDbFactory {
         config_store: Arc<DatabaseConfigStore>,
         applied_frame_no_receiver: watch::Receiver<FrameNo>,
         max_response_size: u64,
+        max_total_response_size: u64,
     ) -> Self {
         let client = ProxyClient::with_origin(channel, uri);
         Self {
@@ -58,6 +60,7 @@ impl WriteProxyDbFactory {
             config_store,
             applied_frame_no_receiver,
             max_response_size,
+            max_total_response_size,
         }
     }
 }
@@ -75,6 +78,7 @@ impl DbFactory for WriteProxyDbFactory {
             self.applied_frame_no_receiver.clone(),
             QueryBuilderConfig {
                 max_size: Some(self.max_response_size),
+                max_total_size: Some(self.max_total_response_size),
             },
         )
         .await?;

--- a/sqld/src/error.rs
+++ b/sqld/src/error.rs
@@ -37,6 +37,8 @@ pub enum Error {
     Blocked(Option<String>),
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+    #[error("Too many concurrent requests")]
+    TooManyRequests,
 }
 
 impl From<tokio::sync::oneshot::error::RecvError> for Error {

--- a/sqld/src/hrana/result_builder.rs
+++ b/sqld/src/hrana/result_builder.rs
@@ -80,7 +80,7 @@ impl SingleStatementBuilder {
         self.current_size += size;
         let total_size = TOTAL_RESPONSE_SIZE.fetch_add(size as usize, Ordering::Relaxed) as u64;
         if total_size + size > self.max_total_response_size {
-            tracing::info!(
+            tracing::debug!(
                 "Total responses exceeded threshold: {}/{}, aborting query",
                 total_size + size,
                 self.max_total_response_size

--- a/sqld/src/hrana/result_builder.rs
+++ b/sqld/src/hrana/result_builder.rs
@@ -1,12 +1,13 @@
 use std::fmt::{self, Write as _};
 use std::io;
+use std::sync::atomic::Ordering;
 
 use bytes::Bytes;
 use rusqlite::types::ValueRef;
 
 use crate::hrana::stmt::{proto_error_from_stmt_error, stmt_error_from_sqld_error};
 use crate::query_result_builder::{
-    Column, QueryBuilderConfig, QueryResultBuilder, QueryResultBuilderError,
+    Column, QueryBuilderConfig, QueryResultBuilder, QueryResultBuilderError, TOTAL_RESPONSE_SIZE,
 };
 
 use super::proto;
@@ -21,6 +22,7 @@ pub struct SingleStatementBuilder {
     last_insert_rowid: Option<i64>,
     current_size: u64,
     max_response_size: u64,
+    max_total_response_size: u64,
 }
 
 struct SizeFormatter(u64);
@@ -61,14 +63,42 @@ fn value_json_size(v: &ValueRef) -> u64 {
     f.0
 }
 
+impl Drop for SingleStatementBuilder {
+    fn drop(&mut self) {
+        TOTAL_RESPONSE_SIZE.fetch_sub(self.current_size as usize, Ordering::Relaxed);
+    }
+}
+
+impl SingleStatementBuilder {
+    fn inc_current_size(&mut self, size: u64) -> Result<(), QueryResultBuilderError> {
+        if self.current_size + size > self.max_response_size {
+            return Err(QueryResultBuilderError::ResponseTooLarge(
+                self.current_size + size,
+            ));
+        }
+
+        self.current_size += size;
+        let total_size = TOTAL_RESPONSE_SIZE.fetch_add(size as usize, Ordering::Relaxed) as u64;
+        if total_size + size > self.max_total_response_size {
+            tracing::info!(
+                "Total responses exceeded threshold: {}/{}, aborting query",
+                total_size + size,
+                self.max_total_response_size
+            );
+            return Err(QueryResultBuilderError::ResponseTooLarge(total_size + size));
+        }
+        Ok(())
+    }
+}
+
 impl QueryResultBuilder for SingleStatementBuilder {
     type Ret = Result<proto::StmtResult, crate::error::Error>;
 
     fn init(&mut self, config: &QueryBuilderConfig) -> Result<(), QueryResultBuilderError> {
-        *self = Self {
-            max_response_size: config.max_size.unwrap_or(u64::MAX),
-            ..Default::default()
-        };
+        let _ = std::mem::take(self);
+
+        self.max_response_size = config.max_size.unwrap_or(u64::MAX);
+        self.max_total_response_size = config.max_total_size.unwrap_or(u64::MAX);
 
         Ok(())
     }
@@ -119,12 +149,7 @@ impl QueryResultBuilder for SingleStatementBuilder {
             }
         }));
 
-        self.current_size += cols_size;
-        if self.current_size > self.max_response_size {
-            return Err(QueryResultBuilderError::ResponseTooLarge(
-                self.max_response_size,
-            ));
-        }
+        self.inc_current_size(cols_size)?;
 
         Ok(())
     }
@@ -150,7 +175,7 @@ impl QueryResultBuilder for SingleStatementBuilder {
             ));
         }
 
-        self.current_size += estimate_size;
+        self.inc_current_size(estimate_size)?;
 
         let val = match v {
             ValueRef::Null => proto::Value::Null,
@@ -188,14 +213,14 @@ impl QueryResultBuilder for SingleStatementBuilder {
         Ok(())
     }
 
-    fn into_ret(self) -> Self::Ret {
-        match self.err {
+    fn into_ret(mut self) -> Self::Ret {
+        match std::mem::take(&mut self.err) {
             Some(err) => Err(err),
             None => Ok(proto::StmtResult {
-                cols: self.cols,
-                rows: self.rows,
-                affected_row_count: self.affected_row_count,
-                last_insert_rowid: self.last_insert_rowid,
+                cols: std::mem::take(&mut self.cols),
+                rows: std::mem::take(&mut self.rows),
+                affected_row_count: std::mem::take(&mut self.affected_row_count),
+                last_insert_rowid: std::mem::take(&mut self.last_insert_rowid),
             }),
         }
     }
@@ -249,12 +274,11 @@ impl QueryResultBuilder for HranaBatchProtoBuilder {
             .finish_step(affected_row_count, last_insert_rowid)?;
         self.current_size += self.stmt_builder.current_size;
 
-        let new_builder = SingleStatementBuilder {
-            current_size: 0,
-            max_response_size: self.max_response_size - self.current_size,
-            ..Default::default()
-        };
-        match std::mem::replace(&mut self.stmt_builder, new_builder).into_ret() {
+        let max_total_response_size = self.stmt_builder.max_total_response_size;
+        let previous_builder = std::mem::take(&mut self.stmt_builder);
+        self.stmt_builder.max_response_size = self.max_response_size - self.current_size;
+        self.stmt_builder.max_total_response_size = max_total_response_size;
+        match previous_builder.into_ret() {
             Ok(res) => {
                 self.step_results.push((!self.step_empty).then_some(res));
                 self.step_errors.push(None);

--- a/sqld/src/http/result_builder.rs
+++ b/sqld/src/http/result_builder.rs
@@ -4,9 +4,11 @@ use std::ops::{Deref, DerefMut};
 use rusqlite::types::ValueRef;
 use serde::{Serialize, Serializer};
 use serde_json::ser::{CompactFormatter, Formatter};
+use std::sync::atomic::Ordering;
 
 use crate::query_result_builder::{
     Column, JsonFormatter, QueryBuilderConfig, QueryResultBuilder, QueryResultBuilderError,
+    TOTAL_RESPONSE_SIZE,
 };
 
 pub struct JsonHttpPayloadBuilder {
@@ -27,14 +29,21 @@ pub struct JsonHttpPayloadBuilder {
 struct LimitBuffer {
     buffer: Vec<u8>,
     limit: u64,
+    global_limit: u64,
 }
 
 impl LimitBuffer {
-    fn new(limit: u64) -> Self {
+    fn new(limit: u64, global_limit: u64) -> Self {
         Self {
             buffer: Vec::new(),
             limit,
+            global_limit,
         }
+    }
+
+    fn into_inner(mut self) -> Vec<u8> {
+        TOTAL_RESPONSE_SIZE.fetch_sub(self.buffer.len(), Ordering::Relaxed);
+        std::mem::take(&mut self.buffer)
     }
 }
 
@@ -54,6 +63,18 @@ impl DerefMut for LimitBuffer {
 
 impl io::Write for LimitBuffer {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let total_size = TOTAL_RESPONSE_SIZE.fetch_add(buf.len(), Ordering::Relaxed);
+        if (total_size + buf.len()) as u64 > self.global_limit {
+            tracing::info!(
+                "Total responses exceeded threshold: {}/{}, aborting query",
+                total_size + buf.len(),
+                self.global_limit
+            );
+            return Err(io::Error::new(
+                io::ErrorKind::OutOfMemory,
+                QueryResultBuilderError::ResponseTooLarge(self.global_limit),
+            ));
+        }
         if (self.buffer.len() + buf.len()) as u64 > self.limit {
             return Err(io::Error::new(
                 io::ErrorKind::OutOfMemory,
@@ -70,13 +91,19 @@ impl io::Write for LimitBuffer {
     }
 }
 
+impl Drop for LimitBuffer {
+    fn drop(&mut self) {
+        TOTAL_RESPONSE_SIZE.fetch_sub(self.buffer.len(), Ordering::Relaxed);
+    }
+}
+
 struct HttpJsonValueSerializer<'a>(&'a ValueRef<'a>);
 
 impl JsonHttpPayloadBuilder {
     pub fn new() -> Self {
         Self {
             formatter: JsonFormatter(CompactFormatter),
-            buffer: LimitBuffer::new(0),
+            buffer: LimitBuffer::new(0, 0),
             checkpoint: 0,
             step_count: 0,
             row_value_count: 0,
@@ -126,7 +153,10 @@ impl QueryResultBuilder for JsonHttpPayloadBuilder {
 
     fn init(&mut self, config: &QueryBuilderConfig) -> Result<(), QueryResultBuilderError> {
         *self = Self {
-            buffer: LimitBuffer::new(config.max_size.unwrap_or(u64::MAX)),
+            buffer: LimitBuffer::new(
+                config.max_size.unwrap_or(u64::MAX),
+                config.max_total_size.unwrap_or(u64::MAX),
+            ),
             ..Self::new()
         };
         // write fragment: `[`
@@ -268,7 +298,7 @@ impl QueryResultBuilder for JsonHttpPayloadBuilder {
     }
 
     fn into_ret(self) -> Self::Ret {
-        self.buffer.buffer
+        self.buffer.into_inner()
     }
 }
 

--- a/sqld/src/http/result_builder.rs
+++ b/sqld/src/http/result_builder.rs
@@ -65,7 +65,7 @@ impl io::Write for LimitBuffer {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let total_size = TOTAL_RESPONSE_SIZE.fetch_add(buf.len(), Ordering::Relaxed);
         if (total_size + buf.len()) as u64 > self.global_limit {
-            tracing::info!(
+            tracing::debug!(
                 "Total responses exceeded threshold: {}/{}, aborting query",
                 total_size + buf.len(),
                 self.global_limit

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -51,7 +51,7 @@ mod test;
 mod utils;
 pub mod version;
 
-const MAX_CONCCURENT_DBS: usize = 128;
+const MAX_CONCCURENT_DBS: usize = 32;
 const DB_CREATE_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
@@ -338,7 +338,11 @@ async fn start_replica(
         config.max_response_size,
         config.max_total_response_size,
     )
-    .throttled(MAX_CONCCURENT_DBS, Some(DB_CREATE_TIMEOUT));
+    .throttled(
+        MAX_CONCCURENT_DBS,
+        Some(DB_CREATE_TIMEOUT),
+        config.max_total_response_size,
+    );
 
     run_service(
         Arc::new(factory),
@@ -490,7 +494,11 @@ async fn start_primary(
         config.max_total_response_size,
     )
     .await?
-    .throttled(MAX_CONCCURENT_DBS, Some(DB_CREATE_TIMEOUT))
+    .throttled(
+        MAX_CONCCURENT_DBS,
+        Some(DB_CREATE_TIMEOUT),
+        config.max_total_response_size,
+    )
     .into();
 
     if let Some(ref addr) = config.rpc_server_addr {

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -103,6 +103,7 @@ pub struct Config {
     pub hard_heap_limit_mb: Option<usize>,
     pub allow_replica_overwrite: bool,
     pub max_response_size: u64,
+    pub max_total_response_size: u64,
     pub snapshot_exec: Option<String>,
     pub http_replication_addr: Option<SocketAddr>,
 }
@@ -142,7 +143,8 @@ impl Default for Config {
             soft_heap_limit_mb: None,
             hard_heap_limit_mb: None,
             allow_replica_overwrite: false,
-            max_response_size: 10 * 1024 * 1024, // 10MiB
+            max_response_size: 10 * 1024 * 1024,       // 10MiB
+            max_total_response_size: 32 * 1024 * 1024, // 32MiB
             snapshot_exec: None,
             http_replication_addr: None,
         }
@@ -334,6 +336,7 @@ async fn start_replica(
         db_config_store.clone(),
         applied_frame_no_receiver,
         config.max_response_size,
+        config.max_total_response_size,
     )
     .throttled(MAX_CONCCURENT_DBS, Some(DB_CREATE_TIMEOUT));
 
@@ -484,6 +487,7 @@ async fn start_primary(
         db_config_store.clone(),
         valid_extensions,
         config.max_response_size,
+        config.max_total_response_size,
     )
     .await?
     .throttled(MAX_CONCCURENT_DBS, Some(DB_CREATE_TIMEOUT))

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -180,6 +180,10 @@ struct Cli {
     #[clap(long, env = "SQLD_MAX_RESPONSE_SIZE", default_value = "10MB")]
     max_response_size: ByteSize,
 
+    /// Set the maximum size for all responses. e.g 5KB, 10MB...
+    #[clap(long, env = "SQLD_MAX_TOTAL_RESPONSE_SIZE", default_value = "32MB")]
+    max_total_response_size: ByteSize,
+
     /// Set a command to execute when a snapshot file is generated.
     #[clap(long, env = "SQLD_SNAPSHOT_EXEC")]
     snapshot_exec: Option<String>,
@@ -295,6 +299,7 @@ fn config_from_args(args: Cli) -> Result<Config> {
         hard_heap_limit_mb: args.hard_heap_limit_mb,
         allow_replica_overwrite: args.allow_replica_overwrite,
         max_response_size: args.max_response_size.0,
+        max_total_response_size: args.max_total_response_size.0,
         snapshot_exec: args.snapshot_exec,
         http_replication_addr: args.http_replication_listen_addr,
     })

--- a/sqld/src/query_result_builder.rs
+++ b/sqld/src/query_result_builder.rs
@@ -6,6 +6,9 @@ use bytesize::ByteSize;
 use rusqlite::types::ValueRef;
 use serde::Serialize;
 use serde_json::ser::Formatter;
+use std::sync::atomic::AtomicUsize;
+
+pub static TOTAL_RESPONSE_SIZE: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug)]
 pub enum QueryResultBuilderError {
@@ -79,6 +82,7 @@ impl<'a> From<&'a rusqlite::Column<'a>> for Column<'a> {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct QueryBuilderConfig {
     pub max_size: Option<u64>,
+    pub max_total_size: Option<u64>,
 }
 
 pub trait QueryResultBuilder: Send + 'static {


### PR DESCRIPTION
This series adds a few overload protection mechanisms, introduced in separate commits.
1. A total response size limit, defaulting to 32MiB, which is the global equivalent of `max_response_size`. My experiments showed that even 16MiB is a much safer choice, but 32MiB is much better than nothing.
2. Concurrency throttling is now dependent on how much memory is currently occupied by response buffers - in high pressure conditions, less concurrency is allowed, and it's done by requiring more semaphore units per request
3. Concurrency throttling also monitors the number of waiters on the semaphore. If the number reaches 128, subsequent requests are refused.
4. There's a pree-OOM panic check, which relies on `sysinfo` crate and reads system memory. If less than 10% memory is available, requests are refused. On Linux, reading system memory stats was empirically measured to cost <40 microseconds, which satisfies the definition of "cheap enough". That would have to be verified for other platforms, esp. virtualized ones.

As for (1.), one substantial problem with it is that the global response size counter is decremented too early, namely right after the response is generated, but before it is sent. Because of that, a sufficiently high number of large requests (e.g. `SELECT *` on a large table) can still overcommit memory, and that problem is alleviated by (2.) and (3.). Ideally we should hold the permit until the memory is actually freed, but I didn't have any idea how to elegantly code it without overhauling lots of interfaces. Suggestions welcome.

Each mechanism is subject to discussion, so please voice your opinions folks. We should add at least 1 of them to make sqld more robust, but in particular, my experiments with highly concurrent large reads showed that only (1.),(2.) and (3.) combined actually prevented OOM.

That said, OOM-ing the process and restarting it is in itself a very nice, though drastic, overload protection mechanism :innocent: 