### PR TITLE
sqld: move HTTP replication under the regular HTTP server

### DIFF
--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -185,8 +185,8 @@ struct Cli {
     snapshot_exec: Option<String>,
 
     /// The address and port for the replication HTTP API.
-    #[clap(long, env = "SQLD_HTTP_REPLICATION_LISTEN_ADDR")]
-    http_replication_listen_addr: Option<SocketAddr>,
+    #[clap(long, env = "SQLD_ENABLE_HTTP_REPLICATION")]
+    enable_http_replication: bool,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -296,7 +296,7 @@ fn config_from_args(args: Cli) -> Result<Config> {
         allow_replica_overwrite: args.allow_replica_overwrite,
         max_response_size: args.max_response_size.0,
         snapshot_exec: args.snapshot_exec,
-        http_replication_addr: args.http_replication_listen_addr,
+        enable_http_replication: args.enable_http_replication,
     })
 }
 


### PR DESCRIPTION
It is now available at /replication/hello and /replication/frames endpoints, when run with `--enable-http-replication`.

```
$ curl -s http://localhost:8080/replication/hello | jq
{
  "generation_id": "f2d7378b-1cc0-48a2-a20e-15e618cf77d7",
  "generation_start_index": 5,
  "database_id": "645410a9-a9b1-4950-8d12-368233bd9a88"
}
```
```
$ curl -s -d '{"next_offset": 2}' http://localhost:8080/replication/frames | jq '.frames[].data | length'
4120
4120
4120
4120
```