### PR TITLE
mt store replica applied frameno

### DIFF
--- a/libsqlx-server/src/allocation/mod.rs
+++ b/libsqlx-server/src/allocation/mod.rs
@@ -126,7 +126,7 @@ impl Database {
                 replication_log_compact_interval,
                 transaction_timeout_duration,
             } => {
-                let (sender, receiver) = tokio::sync::watch::channel(0);
+                let (sender, receiver) = tokio::sync::watch::channel(None);
                 let db = LibsqlDatabase::new_primary(
                     path,
                     Compactor::new(
@@ -137,7 +137,7 @@ impl Database {
                     ),
                     false,
                     Box::new(move |fno| {
-                        let _ = sender.send(fno);
+                        let _ = sender.send(Some(fno));
                     }),
                 )
                 .unwrap();

--- a/libsqlx-server/src/allocation/replica.rs
+++ b/libsqlx-server/src/allocation/replica.rs
@@ -16,10 +16,8 @@ use tokio::task::block_in_place;
 use tokio::time::{timeout, Sleep};
 
 use crate::linc::bus::Dispatch;
-use crate::linc::proto::{BuilderStep, ProxyResponse};
-use crate::linc::proto::{Enveloppe, Frames, Message};
-use crate::linc::Inbound;
-use crate::linc::{NodeId, Outbound};
+use crate::linc::proto::{BuilderStep, Enveloppe, Frames, Message, ProxyResponse};
+use crate::linc::{Inbound, NodeId, Outbound};
 use crate::meta::DatabaseId;
 
 use super::{ConnectionHandler, ConnectionMessage};
@@ -166,6 +164,7 @@ impl Replicator {
                         });
                     }
                 }
+                // no news from primary for the past 5 secs, send a request again
                 Err(_) => self.query_replicate().await,
                 Ok(None) => break,
             }

--- a/libsqlx-server/src/main.rs
+++ b/libsqlx-server/src/main.rs
@@ -12,6 +12,7 @@ use hyper::server::conn::AddrIncoming;
 use linc::bus::Bus;
 use manager::Manager;
 use meta::Store;
+use replica_commit_store::ReplicaCommitStore;
 use snapshot_store::SnapshotStore;
 use tokio::fs::create_dir_all;
 use tokio::net::{TcpListener, TcpStream};
@@ -28,6 +29,7 @@ mod http;
 mod linc;
 mod manager;
 mod meta;
+mod replica_commit_store;
 mod snapshot_store;
 
 #[derive(Debug, Parser)]
@@ -123,11 +125,13 @@ async fn main() -> Result<()> {
         snapshot_store,
     )?);
     let store = Arc::new(Store::new(env.clone()));
+    let replica_commit_store = Arc::new(ReplicaCommitStore::new(env.clone()));
     let manager = Arc::new(Manager::new(
         config.db_path.clone(),
         store.clone(),
         100,
         compaction_queue.clone(),
+        replica_commit_store,
     ));
     let bus = Arc::new(Bus::new(config.cluster.id, manager.clone()));
 

--- a/libsqlx-server/src/manager.rs
+++ b/libsqlx-server/src/manager.rs
@@ -14,12 +14,14 @@ use crate::linc::bus::Dispatch;
 use crate::linc::handler::Handler;
 use crate::linc::Inbound;
 use crate::meta::{DatabaseId, Store};
+use crate::replica_commit_store::ReplicaCommitStore;
 
 pub struct Manager {
     cache: Cache<DatabaseId, mpsc::Sender<AllocationMessage>>,
     meta_store: Arc<Store>,
     db_path: PathBuf,
     compaction_queue: Arc<CompactionQueue>,
+    replica_commit_store: Arc<ReplicaCommitStore>,
 }
 
 const MAX_ALLOC_MESSAGE_QUEUE_LEN: usize = 32;
@@ -30,12 +32,14 @@ impl Manager {
         meta_store: Arc<Store>,
         max_conccurent_allocs: u64,
         compaction_queue: Arc<CompactionQueue>,
+        replica_commit_store: Arc<ReplicaCommitStore>,
     ) -> Self {
         Self {
             cache: Cache::new(max_conccurent_allocs),
             meta_store,
             db_path,
             compaction_queue,
+            replica_commit_store,
         }
     }
 
@@ -60,6 +64,7 @@ impl Manager {
                     path,
                     dispatcher.clone(),
                     self.compaction_queue.clone(),
+                    self.replica_commit_store.clone(),
                 ),
                 connections_futs: JoinSet::new(),
                 next_conn_id: 0,

--- a/libsqlx-server/src/meta.rs
+++ b/libsqlx-server/src/meta.rs
@@ -10,8 +10,6 @@ use tokio::task::block_in_place;
 
 use crate::allocation::config::AllocConfig;
 
-type ExecFn = Box<dyn FnOnce(&mut libsqlx::libsql::LibsqlConnection<()>)>;
-
 pub struct Store {
     env: heed::Env,
     alloc_config_db: heed::Database<OwnedType<DatabaseId>, SerdeBincode<AllocConfig>>,

--- a/libsqlx-server/src/replica_commit_store.rs
+++ b/libsqlx-server/src/replica_commit_store.rs
@@ -1,0 +1,34 @@
+use heed_types::OwnedType;
+use libsqlx::FrameNo;
+
+use crate::meta::DatabaseId;
+
+/// Stores replica last injected commit index
+pub struct ReplicaCommitStore {
+    env: heed::Env,
+    database: heed::Database<OwnedType<DatabaseId>, OwnedType<FrameNo>>,
+}
+
+impl ReplicaCommitStore {
+    const DB_NAME: &str = "replica-commit-store";
+    pub fn new(env: heed::Env) -> Self {
+        let mut txn = env.write_txn().unwrap();
+        let database = env.create_database(&mut txn, Some(Self::DB_NAME)).unwrap();
+        txn.commit().unwrap();
+
+        Self { env, database }
+    }
+
+    pub fn commit(&self, database_id: DatabaseId, frame_no: FrameNo) {
+        let mut txn = self.env.write_txn().unwrap();
+        self.database
+            .put(&mut txn, &database_id, &frame_no)
+            .unwrap();
+        txn.commit().unwrap();
+    }
+
+    pub fn get_commit_index(&self, database_id: DatabaseId) -> Option<FrameNo> {
+        let txn = self.env.read_txn().unwrap();
+        self.database.get(&txn, &database_id).unwrap()
+    }
+}


### PR DESCRIPTION
record replica commit index. Drop the post/pre commit method, the commit index is recorded for after every commit. If there is a failure, there is at most 1 transaction that is applied but not recorded, the replica will apply it again, which is idempotent.
