### PR TITLE
Cleanup S3 bucket after bottomless test

### DIFF
--- a/sqld/src/test/bottomless.rs
+++ b/sqld/src/test/bottomless.rs
@@ -45,6 +45,7 @@ async fn backup_restore() {
                 bucket_name: BUCKET.to_string(),
                 max_batch_interval: Duration::from_millis(250),
                 restore_transaction_page_swap_after: 1, // in this test swap should happen at least once
+                aws_endpoint: Some(S3_URL.to_string()),
                 ..bottomless::replicator::Options::from_env().unwrap()
             }),
             db_path: PATH.into(),
@@ -233,6 +234,7 @@ async fn rollback_restore() {
                 bucket_name: BUCKET.to_string(),
                 max_batch_interval: Duration::from_millis(250),
                 restore_transaction_page_swap_after: 1, // in this test swap should happen at least once
+                aws_endpoint: Some(S3_URL.to_string()),
                 ..bottomless::replicator::Options::from_env().unwrap()
             }),
             db_path: PATH.into(),

--- a/sqld/src/test/bottomless.rs
+++ b/sqld/src/test/bottomless.rs
@@ -1,6 +1,7 @@
 use crate::{run_server, Config};
 use anyhow::Result;
 use libsql_client::{Connection, QueryResult, Statement, Value};
+use std::future::Future;
 use std::net::ToSocketAddrs;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -27,169 +28,171 @@ async fn backup_restore() {
     const PORT: u16 = 15001;
     const OPS: usize = 100;
 
-    let _ = S3BucketCleaner::new(BUCKET).await;
-    assert_bucket_occupancy(BUCKET, true).await;
+    with_s3_bucket_cleanup(BUCKET, async {
+        assert_bucket_occupancy(BUCKET, true).await;
 
-    let listener_addr = format!("0.0.0.0:{}", PORT)
-        .to_socket_addrs()
-        .unwrap()
-        .next()
-        .unwrap();
-    let connection_addr = Url::parse(&format!("http://localhost:{}", PORT)).unwrap();
-    let db_config = Config {
-        bottomless_replication: Some(bottomless::replicator::Options {
-            create_bucket_if_not_exists: true,
-            verify_crc: true,
-            use_compression: bottomless::replicator::CompressionKind::Gzip,
-            bucket_name: BUCKET.to_string(),
-            max_batch_interval: Duration::from_millis(250),
-            restore_transaction_page_swap_after: 1, // in this test swap should happen at least once
-            ..bottomless::replicator::Options::from_env().unwrap()
-        }),
-        db_path: PATH.into(),
-        http_addr: Some(listener_addr),
-        ..Config::default()
-    };
+        let listener_addr = format!("0.0.0.0:{}", PORT)
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap();
+        let connection_addr = Url::parse(&format!("http://localhost:{}", PORT)).unwrap();
+        let db_config = Config {
+            bottomless_replication: Some(bottomless::replicator::Options {
+                create_bucket_if_not_exists: true,
+                verify_crc: true,
+                use_compression: bottomless::replicator::CompressionKind::Gzip,
+                bucket_name: BUCKET.to_string(),
+                max_batch_interval: Duration::from_millis(250),
+                restore_transaction_page_swap_after: 1, // in this test swap should happen at least once
+                ..bottomless::replicator::Options::from_env().unwrap()
+            }),
+            db_path: PATH.into(),
+            http_addr: Some(listener_addr),
+            ..Config::default()
+        };
 
-    {
-        tracing::info!(
-            "---STEP 1: create a local database, fill it with data, wait for WAL backup---"
-        );
-        let cleaner = DbFileCleaner::new(PATH);
-        let db_job = start_db(1, &db_config);
+        {
+            tracing::info!(
+                "---STEP 1: create a local database, fill it with data, wait for WAL backup---"
+            );
+            let cleaner = DbFileCleaner::new(PATH);
+            let db_job = start_db(1, &db_config);
 
-        sleep(Duration::from_secs(2)).await;
+            sleep(Duration::from_secs(2)).await;
 
-        let _ = sql(
-            &connection_addr,
-            ["CREATE TABLE IF NOT EXISTS t(id INT PRIMARY KEY, name TEXT);"],
-        )
-        .await
-        .unwrap();
-
-        let stmts: Vec<_> = (0u32..OPS as u32)
-            .map(|i| {
-                format!(
-                    "INSERT INTO t(id, name) VALUES({}, '{}') ON CONFLICT (id) DO UPDATE SET name = '{}';",
-                    i % 10,
-                    i,
-                    i
-                )
-            })
-            .collect();
-        let _ = sql(&connection_addr, stmts).await.unwrap();
-
-        sleep(Duration::from_secs(2)).await;
-
-        db_job.abort();
-        drop(cleaner);
-    }
-
-    // make sure that db file doesn't exist, and that the bucket contains backup
-    assert!(!std::path::Path::new(PATH).exists());
-    assert_bucket_occupancy(BUCKET, false).await;
-
-    {
-        tracing::info!(
-            "---STEP 2: recreate the database from WAL - create a snapshot at the end---"
-        );
-        let cleaner = DbFileCleaner::new(PATH);
-        let db_job = start_db(2, &db_config);
-
-        sleep(Duration::from_secs(2)).await;
-
-        let result = sql(&connection_addr, ["SELECT id, name FROM t ORDER BY id;"])
+            let _ = sql(
+                &connection_addr,
+                ["CREATE TABLE IF NOT EXISTS t(id INT PRIMARY KEY, name TEXT);"],
+            )
             .await
             .unwrap();
-        let rs = result
-            .into_iter()
-            .next()
-            .unwrap()
-            .into_result_set()
-            .unwrap();
-        const OPS_CEIL: usize = (OPS + 9) / 10;
-        assert_eq!(rs.rows.len(), OPS_CEIL, "unexpected number of rows");
-        let base = if OPS < 10 { 0 } else { OPS - 10 } as i64;
-        for (i, row) in rs.rows.iter().enumerate() {
-            let i = i as i64;
-            let id = row.cells["id"].clone();
-            let name = row.cells["name"].clone();
-            assert_eq!(
-                (id, name),
-                (Value::Integer(i), Value::Text((base + i).to_string())),
-                "unexpected values for row {}",
-                i
-            );
+
+            let stmts: Vec<_> = (0u32..OPS as u32)
+                .map(|i| {
+                    format!(
+                        "INSERT INTO t(id, name) VALUES({}, '{}') ON CONFLICT (id) DO UPDATE SET name = '{}';",
+                        i % 10,
+                        i,
+                        i
+                    )
+                })
+                .collect();
+            let _ = sql(&connection_addr, stmts).await.unwrap();
+
+            sleep(Duration::from_secs(2)).await;
+
+            db_job.abort();
+            drop(cleaner);
         }
 
-        db_job.abort();
-        drop(cleaner);
-    }
+        // make sure that db file doesn't exist, and that the bucket contains backup
+        assert!(!std::path::Path::new(PATH).exists());
+        assert_bucket_occupancy(BUCKET, false).await;
 
-    assert!(!std::path::Path::new(PATH).exists());
+        {
+            tracing::info!(
+                "---STEP 2: recreate the database from WAL - create a snapshot at the end---"
+            );
+            let cleaner = DbFileCleaner::new(PATH);
+            let db_job = start_db(2, &db_config);
 
-    {
-        tracing::info!("---STEP 3: recreate database from snapshot alone---");
-        let cleaner = DbFileCleaner::new(PATH);
-        let db_job = start_db(3, &db_config);
+            sleep(Duration::from_secs(2)).await;
 
-        sleep(Duration::from_secs(2)).await;
-
-        // override existing entries, this will generate WAL
-        let stmts: Vec<_> = (0u32..OPS as u32)
-            .map(|i| {
-                format!(
-                    "INSERT INTO t(id, name) VALUES({}, '{}-x') ON CONFLICT (id) DO UPDATE SET name = '{}-x';",
-                    i % 10,
-                    i,
+            let result = sql(&connection_addr, ["SELECT id, name FROM t ORDER BY id;"])
+                .await
+                .unwrap();
+            let rs = result
+                .into_iter()
+                .next()
+                .unwrap()
+                .into_result_set()
+                .unwrap();
+            const OPS_CEIL: usize = (OPS + 9) / 10;
+            assert_eq!(rs.rows.len(), OPS_CEIL, "unexpected number of rows");
+            let base = if OPS < 10 { 0 } else { OPS - 10 } as i64;
+            for (i, row) in rs.rows.iter().enumerate() {
+                let i = i as i64;
+                let id = row.cells["id"].clone();
+                let name = row.cells["name"].clone();
+                assert_eq!(
+                    (id, name),
+                    (Value::Integer(i), Value::Text((base + i).to_string())),
+                    "unexpected values for row {}",
                     i
-                )
-            })
-            .collect();
-        let _ = sql(&connection_addr, stmts).await.unwrap();
+                );
+            }
 
-        // wait for WAL to backup
-        sleep(Duration::from_secs(2)).await;
-        db_job.abort();
-        drop(cleaner);
-    }
-
-    assert!(!std::path::Path::new(PATH).exists());
-
-    {
-        tracing::info!("---STEP 4: recreate the database from snapshot + WAL---");
-        let cleaner = DbFileCleaner::new(PATH);
-        let db_job = start_db(4, &db_config);
-
-        sleep(Duration::from_secs(2)).await;
-
-        let result = sql(&connection_addr, ["SELECT id, name FROM t ORDER BY id;"])
-            .await
-            .unwrap();
-        let rs = result
-            .into_iter()
-            .next()
-            .unwrap()
-            .into_result_set()
-            .unwrap();
-        const OPS_CEIL: usize = (OPS + 9) / 10;
-        assert_eq!(rs.rows.len(), OPS_CEIL, "unexpected number of rows");
-        let base = if OPS < 10 { 0 } else { OPS - 10 } as i64;
-        for (i, row) in rs.rows.iter().enumerate() {
-            let i = i as i64;
-            let id = row.cells["id"].clone();
-            let name = row.cells["name"].clone();
-            assert_eq!(
-                (id, name),
-                (Value::Integer(i), Value::Text(format!("{}-x", base + i))),
-                "unexpected values for row {}",
-                i
-            );
+            db_job.abort();
+            drop(cleaner);
         }
 
-        db_job.abort();
-        drop(cleaner);
-    }
+        assert!(!std::path::Path::new(PATH).exists());
+
+        {
+            tracing::info!("---STEP 3: recreate database from snapshot alone---");
+            let cleaner = DbFileCleaner::new(PATH);
+            let db_job = start_db(3, &db_config);
+
+            sleep(Duration::from_secs(2)).await;
+
+            // override existing entries, this will generate WAL
+            let stmts: Vec<_> = (0u32..OPS as u32)
+                .map(|i| {
+                    format!(
+                        "INSERT INTO t(id, name) VALUES({}, '{}-x') ON CONFLICT (id) DO UPDATE SET name = '{}-x';",
+                        i % 10,
+                        i,
+                        i
+                    )
+                })
+                .collect();
+            let _ = sql(&connection_addr, stmts).await.unwrap();
+
+            // wait for WAL to backup
+            sleep(Duration::from_secs(2)).await;
+            db_job.abort();
+            drop(cleaner);
+        }
+
+        assert!(!std::path::Path::new(PATH).exists());
+
+        {
+            tracing::info!("---STEP 4: recreate the database from snapshot + WAL---");
+            let cleaner = DbFileCleaner::new(PATH);
+            let db_job = start_db(4, &db_config);
+
+            sleep(Duration::from_secs(2)).await;
+
+            let result = sql(&connection_addr, ["SELECT id, name FROM t ORDER BY id;"])
+                .await
+                .unwrap();
+            let rs = result
+                .into_iter()
+                .next()
+                .unwrap()
+                .into_result_set()
+                .unwrap();
+            const OPS_CEIL: usize = (OPS + 9) / 10;
+            assert_eq!(rs.rows.len(), OPS_CEIL, "unexpected number of rows");
+            let base = if OPS < 10 { 0 } else { OPS - 10 } as i64;
+            for (i, row) in rs.rows.iter().enumerate() {
+                let i = i as i64;
+                let id = row.cells["id"].clone();
+                let name = row.cells["name"].clone();
+                assert_eq!(
+                    (id, name),
+                    (Value::Integer(i), Value::Text(format!("{}-x", base + i))),
+                    "unexpected values for row {}",
+                    i
+                );
+            }
+
+            db_job.abort();
+            drop(cleaner);
+        }
+    })
+    .await;
 }
 
 #[tokio::test]
@@ -213,105 +216,107 @@ async fn rollback_restore() {
         Ok(rows)
     }
 
-    let _ = S3BucketCleaner::new(BUCKET).await;
-    assert_bucket_occupancy(BUCKET, true).await;
+    with_s3_bucket_cleanup(BUCKET, async {
+        assert_bucket_occupancy(BUCKET, true).await;
 
-    let listener_addr = format!("0.0.0.0:{}", PORT)
-        .to_socket_addrs()
-        .unwrap()
-        .next()
-        .unwrap();
-    let conn = Url::parse(&format!("http://localhost:{}", PORT)).unwrap();
-    let db_config = Config {
-        bottomless_replication: Some(bottomless::replicator::Options {
-            create_bucket_if_not_exists: true,
-            verify_crc: true,
-            use_compression: bottomless::replicator::CompressionKind::Gzip,
-            bucket_name: BUCKET.to_string(),
-            max_batch_interval: Duration::from_millis(250),
-            restore_transaction_page_swap_after: 1, // in this test swap should happen at least once
-            ..bottomless::replicator::Options::from_env().unwrap()
-        }),
-        db_path: PATH.into(),
-        http_addr: Some(listener_addr),
-        ..Config::default()
-    };
+        let listener_addr = format!("0.0.0.0:{}", PORT)
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap();
+        let conn = Url::parse(&format!("http://localhost:{}", PORT)).unwrap();
+        let db_config = Config {
+            bottomless_replication: Some(bottomless::replicator::Options {
+                create_bucket_if_not_exists: true,
+                verify_crc: true,
+                use_compression: bottomless::replicator::CompressionKind::Gzip,
+                bucket_name: BUCKET.to_string(),
+                max_batch_interval: Duration::from_millis(250),
+                restore_transaction_page_swap_after: 1, // in this test swap should happen at least once
+                ..bottomless::replicator::Options::from_env().unwrap()
+            }),
+            db_path: PATH.into(),
+            http_addr: Some(listener_addr),
+            ..Config::default()
+        };
 
-    {
-        tracing::info!("---STEP 1: create db, write row, rollback---");
-        let cleaner = DbFileCleaner::new(PATH);
-        let db_job = start_db(1, &db_config);
+        {
+            tracing::info!("---STEP 1: create db, write row, rollback---");
+            let cleaner = DbFileCleaner::new(PATH);
+            let db_job = start_db(1, &db_config);
 
-        sleep(Duration::from_secs(2)).await;
+            sleep(Duration::from_secs(2)).await;
 
-        let _ = sql(
-            &conn,
-            [
-                "CREATE TABLE IF NOT EXISTS t(id INT PRIMARY KEY, name TEXT);",
-                "INSERT INTO t(id, name) VALUES(1, 'A')",
-            ],
-        )
-        .await
-        .unwrap();
+            let _ = sql(
+                &conn,
+                [
+                    "CREATE TABLE IF NOT EXISTS t(id INT PRIMARY KEY, name TEXT);",
+                    "INSERT INTO t(id, name) VALUES(1, 'A')",
+                ],
+            )
+            .await
+            .unwrap();
 
-        let _ = sql(
-            &conn,
-            [
-                "BEGIN",
-                "UPDATE t SET name = 'B' WHERE id = 1",
-                "ROLLBACK",
-                "INSERT INTO t(id, name) VALUES(2, 'B')",
-            ],
-        )
-        .await
-        .unwrap();
+            let _ = sql(
+                &conn,
+                [
+                    "BEGIN",
+                    "UPDATE t SET name = 'B' WHERE id = 1",
+                    "ROLLBACK",
+                    "INSERT INTO t(id, name) VALUES(2, 'B')",
+                ],
+            )
+            .await
+            .unwrap();
 
-        // wait for backup
-        sleep(Duration::from_secs(2)).await;
-        assert_bucket_occupancy(BUCKET, false).await;
+            // wait for backup
+            sleep(Duration::from_secs(2)).await;
+            assert_bucket_occupancy(BUCKET, false).await;
 
-        let rs = get_data(&conn).await.unwrap();
-        assert_eq!(
-            rs,
-            vec![
-                (Value::Integer(1), Value::Text("A".into())),
-                (Value::Integer(2), Value::Text("B".into()))
-            ],
-            "rollback value should not be updated"
-        );
+            let rs = get_data(&conn).await.unwrap();
+            assert_eq!(
+                rs,
+                vec![
+                    (Value::Integer(1), Value::Text("A".into())),
+                    (Value::Integer(2), Value::Text("B".into()))
+                ],
+                "rollback value should not be updated"
+            );
 
-        db_job.abort();
-        drop(cleaner);
-    }
+            db_job.abort();
+            drop(cleaner);
+        }
 
-    {
-        tracing::info!("---STEP 2: recreate database, read modify, read again ---");
-        let cleaner = DbFileCleaner::new(PATH);
-        let db_job = start_db(2, &db_config);
-        sleep(Duration::from_secs(2)).await;
+        {
+            tracing::info!("---STEP 2: recreate database, read modify, read again ---");
+            let cleaner = DbFileCleaner::new(PATH);
+            let db_job = start_db(2, &db_config);
+            sleep(Duration::from_secs(2)).await;
 
-        let rs = get_data(&conn).await.unwrap();
-        assert_eq!(
-            rs,
-            vec![
-                (Value::Integer(1), Value::Text("A".into())),
-                (Value::Integer(2), Value::Text("B".into()))
-            ],
-            "restored value should not contain rollbacked update"
-        );
-        let _ = sql(&conn, ["UPDATE t SET name = 'C'"]).await.unwrap();
-        let rs = get_data(&conn).await.unwrap();
-        assert_eq!(
-            rs,
-            vec![
-                (Value::Integer(1), Value::Text("C".into())),
-                (Value::Integer(2), Value::Text("C".into()))
-            ]
-        );
+            let rs = get_data(&conn).await.unwrap();
+            assert_eq!(
+                rs,
+                vec![
+                    (Value::Integer(1), Value::Text("A".into())),
+                    (Value::Integer(2), Value::Text("B".into()))
+                ],
+                "restored value should not contain rollbacked update"
+            );
+            let _ = sql(&conn, ["UPDATE t SET name = 'C'"]).await.unwrap();
+            let rs = get_data(&conn).await.unwrap();
+            assert_eq!(
+                rs,
+                vec![
+                    (Value::Integer(1), Value::Text("C".into())),
+                    (Value::Integer(2), Value::Text("C".into()))
+                ]
+            );
 
-        db_job.abort();
-        drop(cleaner);
-    }
+            db_job.abort();
+            drop(cleaner);
+        }
+    })
+    .await;
 }
 
 async fn sql<I, S>(url: &Url, stmts: I) -> Result<Vec<QueryResult>>
@@ -374,49 +379,39 @@ impl Drop for DbFileCleaner {
     }
 }
 
-/// Guardian struct used for cleaning up the test data from
-/// S3 bucket dir at the beginning and end of a test.
-struct S3BucketCleaner(&'static str);
-
-impl S3BucketCleaner {
-    async fn new(bucket: &'static str) -> Self {
-        let _ = Self::cleanup(bucket).await; // cleanup the bucket before test
-        S3BucketCleaner(bucket)
-    }
-
-    /// Delete all objects from S3 bucket with provided name (doesn't delete bucket itself).
-    async fn cleanup(bucket: &str) -> Result<()> {
-        use aws_sdk_s3::types::{Delete, ObjectIdentifier};
-        use aws_sdk_s3::Client;
-
-        let loader = aws_config::from_env().endpoint_url(S3_URL);
-        let conf = aws_sdk_s3::config::Builder::from(&loader.load().await)
-            .force_path_style(true)
-            .build();
-        let client = Client::from_conf(conf);
-        let objects = client.list_objects().bucket(bucket).send().await?;
-        let mut delete_keys = Vec::new();
-        for o in objects.contents().unwrap_or_default() {
-            let id = ObjectIdentifier::builder()
-                .set_key(o.key().map(String::from))
-                .build();
-            delete_keys.push(id);
-        }
-
-        let _ = client
-            .delete_objects()
-            .bucket(bucket)
-            .delete(Delete::builder().set_objects(Some(delete_keys)).build())
-            .send()
-            .await?;
-
-        Ok(())
-    }
+/// Clean up the test data from S3 bucket dir at the beginning and end of a test.
+async fn with_s3_bucket_cleanup<T>(bucket: &'static str, fut: impl Future<Output = T>) -> T {
+    let _ = cleanup_s3_bucket(bucket).await;
+    let res = fut.await;
+    let _ = cleanup_s3_bucket(bucket).await;
+    res
 }
 
-impl Drop for S3BucketCleaner {
-    fn drop(&mut self) {
-        //FIXME: running line below on tokio::test runtime will hang.
-        //let _ = block_on(Self::cleanup(self.0));
+/// Delete all objects from S3 bucket with provided name (doesn't delete bucket itself).
+async fn cleanup_s3_bucket(bucket: &str) -> Result<()> {
+    use aws_sdk_s3::types::{Delete, ObjectIdentifier};
+    use aws_sdk_s3::Client;
+
+    let loader = aws_config::from_env().endpoint_url(S3_URL);
+    let conf = aws_sdk_s3::config::Builder::from(&loader.load().await)
+        .force_path_style(true)
+        .build();
+    let client = Client::from_conf(conf);
+    let objects = client.list_objects().bucket(bucket).send().await?;
+    let mut delete_keys = Vec::new();
+    for o in objects.contents().unwrap_or_default() {
+        let id = ObjectIdentifier::builder()
+            .set_key(o.key().map(String::from))
+            .build();
+        delete_keys.push(id);
     }
+
+    let _ = client
+        .delete_objects()
+        .bucket(bucket)
+        .delete(Delete::builder().set_objects(Some(delete_keys)).build())
+        .send()
+        .await?;
+
+    Ok(())
 }


### PR DESCRIPTION
Since we cannot rely on `S3BucketCleaner`'s drop guard to cleanup the S3 bucket after the test execution, I moved the cleanup into a function that takes a `Future` instead.

Also changed the bottomless options to use S3_URL instead of relying on configured environment variables.