### PR TITLE
bottomless: drop uuid v7 dependency

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg", "uuid_unstable"]

--- a/bottomless-cli/Cargo.toml
+++ b/bottomless-cli/Cargo.toml
@@ -20,4 +20,4 @@ clap = { version = "4.0.29", features = ["derive"] }
 tokio = { version = "1.23.0", features = ["macros", "rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
-uuid = { version = "1.3", features = ["v7"] }
+uuid = "1.4.1"

--- a/bottomless/Cargo.toml
+++ b/bottomless/Cargo.toml
@@ -21,9 +21,10 @@ tokio = { version = "1.22.2", features = ["rt-multi-thread", "net", "io-std", "i
 tokio-util = "0.7"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
-uuid = { version = "1.3", features = ["v7"] }
 arc-swap = "1.6"
 chrono = "0.4.23"
+uuid = "1.4.1"
+rand = "0.8.5"
 
 [features]
 libsql_linked_statically = []

--- a/bottomless/src/lib.rs
+++ b/bottomless/src/lib.rs
@@ -8,6 +8,7 @@ mod backup;
 mod read;
 pub mod replicator;
 mod transaction_cache;
+pub mod uuid_utils;
 mod wal;
 
 use crate::ffi::{

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -447,7 +447,7 @@ impl Replicator {
         let (seconds, nanos) = ts.to_unix();
         let (seconds, nanos) = (253370761200 - seconds, 999999999 - nanos);
         let synthetic_ts = uuid::Timestamp::from_unix(uuid::NoContext, seconds, nanos);
-        Uuid::new_v7(synthetic_ts)
+        crate::uuid_utils::new_v7(synthetic_ts)
     }
 
     fn generation_to_timestamp(generation: &Uuid) -> Option<uuid::Timestamp> {

--- a/bottomless/src/uuid_utils.rs
+++ b/bottomless/src/uuid_utils.rs
@@ -1,0 +1,36 @@
+// Copy-pasted from uuid crate to avoid their uuid_unstable flag guard.
+// Once uuid v7 is standardized and stabilized, we can go back to using uuid::new_v7() directly.
+
+use uuid::{Timestamp, Uuid};
+
+fn bytes() -> [u8; 16] {
+    rand::random()
+}
+
+pub(crate) const fn encode_unix_timestamp_millis(millis: u64, random_bytes: &[u8; 10]) -> Uuid {
+    let millis_high = ((millis >> 16) & 0xFFFF_FFFF) as u32;
+    let millis_low = (millis & 0xFFFF) as u16;
+
+    let random_and_version =
+        (random_bytes[1] as u16 | ((random_bytes[0] as u16) << 8) & 0x0FFF) | (0x7 << 12);
+
+    let mut d4 = [0; 8];
+
+    d4[0] = (random_bytes[2] & 0x3F) | 0x80;
+    d4[1] = random_bytes[3];
+    d4[2] = random_bytes[4];
+    d4[3] = random_bytes[5];
+    d4[4] = random_bytes[6];
+    d4[5] = random_bytes[7];
+    d4[6] = random_bytes[8];
+    d4[7] = random_bytes[9];
+
+    Uuid::from_fields(millis_high, millis_low, random_and_version, &d4)
+}
+
+pub fn new_v7(ts: Timestamp) -> Uuid {
+    let (secs, nanos) = ts.to_unix();
+    let millis = (secs * 1000).saturating_add(nanos as u64 / 1_000_000);
+
+    encode_unix_timestamp_millis(millis, &bytes()[..10].try_into().unwrap())
+}


### PR DESCRIPTION
... by copy-pasting the implementation from the uuid crate. Months ago I decided to wait until v7 gets stabilized, but it hasn't happened yet, so let's just use the implementation directly.