### PR TITLE
sqld: allow CREATE VIEW and DROP VIEW

### DIFF
--- a/sqld/src/query_analysis.rs
+++ b/sqld/src/query_analysis.rs
@@ -93,6 +93,12 @@ impl StmtKind {
             ) => Some(Self::Write),
             Cmd::Stmt(Stmt::Select { .. }) => Some(Self::Read),
             Cmd::Stmt(Stmt::Pragma(name, body)) => Self::pragma_kind(name, body.as_ref()),
+            // Creating regular views is OK, temporary views are bound to a connection
+            // and thus disallowed in sqld.
+            Cmd::Stmt(Stmt::CreateView {
+                temporary: false, ..
+            }) => Some(Self::Write),
+            Cmd::Stmt(Stmt::DropView { .. }) => Some(Self::Write),
             _ => None,
         }
     }


### PR DESCRIPTION
... but disallow CREATE TEMP VIEW.

Examples:
```
 →  create temp view v as select v from t;
 Error: failed to execute SQL: create temp view v as select v from t;
 unsupported statement
 →  create view v as select v from t;
 →  drop view v;
```

Fixes #563