### PR TITLE
sqld: Convert http api to axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,6 +620,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes 1.4.0",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "hyper",
@@ -1859,6 +1860,31 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags 1.3.2",
+ "bytes 1.4.0",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,6 +660,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cebbcd90f811f93fc2a993024caecc1e8270d9d1eb9d3359edb3069c2096ea6f"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes 1.4.0",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tokio",
+ "tower",
+ "tower-http 0.4.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3722,6 +3744,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "axum",
+ "axum-extra",
  "base64 0.21.2",
  "bincode",
  "bottomless",
@@ -3771,7 +3794,7 @@ dependencies = [
  "tonic 0.8.3",
  "tonic-build",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -4244,6 +4267,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
+dependencies = [
+ "bitflags 2.3.3",
+ "bytes 1.4.0",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "sqld"
 anyhow = "1.0.66"
 async-lock = "2.6.0"
 async-trait = "0.1.58"
-axum = "0.6.18"
+axum = { version = "0.6.18", features = ["headers"] }
 base64 = "0.21.0"
 bincode = "1.3.3"
 bottomless = { version = "0", path = "../bottomless", features = ["libsql_linked_statically"] }

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1.0.66"
 async-lock = "2.6.0"
 async-trait = "0.1.58"
 axum = { version = "0.6.18", features = ["headers"] }
+axum-extra = "0.7"
 base64 = "0.21.0"
 bincode = "1.3.3"
 bottomless = { version = "0", path = "../bottomless", features = ["libsql_linked_statically"] }

--- a/sqld/src/hrana/http/mod.rs
+++ b/sqld/src/hrana/http/mod.rs
@@ -46,7 +46,7 @@ impl<D: Database> Server<D> {
         req: hyper::Request<hyper::Body>,
     ) -> Result<hyper::Response<hyper::Body>> {
         let res = match route {
-            Route::GetIndex => handle_index(),
+            Route::GetIndex => Ok(handle_index().await),
             Route::PostPipeline => handle_pipeline(self, auth, req).await,
         };
         res.or_else(|err| {
@@ -57,11 +57,11 @@ impl<D: Database> Server<D> {
     }
 }
 
-fn handle_index() -> Result<hyper::Response<hyper::Body>> {
-    Ok(text_response(
+pub(crate) async fn handle_index() -> hyper::Response<hyper::Body> {
+    text_response(
         hyper::StatusCode::OK,
         "Hello, this is HTTP API v2 (Hrana over HTTP)".into(),
-    ))
+    )
 }
 
 async fn handle_pipeline<D: Database>(

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -7,16 +7,20 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::Context;
+use axum::extract::{FromRef, FromRequestParts, State as AxumState};
+use axum::http::request::Parts;
+use axum::response::{Html, IntoResponse};
+use axum::routing::{get, post};
+use axum::Router;
 use base64::prelude::BASE64_STANDARD_NO_PAD;
 use base64::Engine;
-use hyper::body::to_bytes;
+use bytes::Bytes;
 use hyper::server::conn::AddrIncoming;
-use hyper::{Body, Method, Request, Response, StatusCode};
+use hyper::{Body, Request, Response, StatusCode};
 use serde::Serialize;
 use serde_json::Number;
 use tokio::sync::{mpsc, oneshot};
 use tonic::codegen::http;
-use tower::ServiceBuilder;
 use tower_http::trace::DefaultOnResponse;
 use tower_http::{compression::CompressionLayer, cors};
 use tracing::{Level, Span};
@@ -118,48 +122,62 @@ fn parse_payload(data: &[u8]) -> Result<HttpQuery, Response<Body>> {
 }
 
 async fn handle_query<D: Database>(
-    mut req: Request<Body>,
     auth: Authenticated,
-    db_factory: Arc<dyn DbFactory<Db = D>>,
-) -> anyhow::Result<Response<Body>> {
-    let bytes = to_bytes(req.body_mut()).await?;
-    let req = match parse_payload(&bytes) {
+    AxumState(state): AxumState<AppState<D>>,
+    body: Bytes,
+) -> Response<Body> {
+    let AppState { db_factory, .. } = state;
+
+    let req = match parse_payload(&body) {
         Ok(req) => req,
-        Err(resp) => return Ok(resp),
+        Err(resp) => return resp,
     };
 
     let batch = match parse_queries(req.statements) {
         Ok(queries) => queries,
-        Err(e) => return Ok(error(&e.to_string(), StatusCode::BAD_REQUEST)),
+        Err(e) => return error(&e.to_string(), StatusCode::BAD_REQUEST),
     };
 
-    let db = db_factory.create().await?;
+    // TODO(lucio): convert this error into a status
+    let db = db_factory.create().await.unwrap();
 
     let builder = JsonHttpPayloadBuilder::new();
     match db.execute_batch_or_rollback(batch, auth, builder).await {
-        Ok((builder, _)) => Ok(Response::builder()
+        // TODO(lucio): convert these into axum responses
+        Ok((builder, _)) => Response::builder()
             .header("Content-Type", "application/json")
-            .body(Body::from(builder.into_ret()))?),
-        Err(e) => Ok(error(
+            .body(Body::from(builder.into_ret()))
+            .unwrap(),
+        Err(e) => error(
             &format!("internal error: {e}"),
             StatusCode::INTERNAL_SERVER_ERROR,
-        )),
+        ),
     }
 }
 
-async fn show_console() -> anyhow::Result<Response<Body>> {
-    Ok(Response::new(Body::from(std::include_str!("console.html"))))
+async fn show_console<D>(
+    AxumState(AppState { enable_console, .. }): AxumState<AppState<D>>,
+) -> impl IntoResponse {
+    if enable_console {
+        Html(std::include_str!("console.html")).into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
 }
 
-fn handle_health() -> Response<Body> {
+async fn handle_health() -> Response<Body> {
     // return empty OK
     Response::new(Body::empty())
 }
 
-async fn handle_upgrade(
-    upgrade_tx: &mpsc::Sender<hrana::ws::Upgrade>,
+async fn handle_upgrade<D>(
+    AxumState(AppState { upgrade_tx, .. }): AxumState<AppState<D>>,
     req: Request<Body>,
-) -> Response<Body> {
+) -> impl IntoResponse {
+    if !hyper_tungstenite::is_upgrade_request(&req) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
     let (response_tx, response_rx) = oneshot::channel();
     let _: Result<_, _> = upgrade_tx
         .send(hrana::ws::Upgrade {
@@ -169,73 +187,58 @@ async fn handle_upgrade(
         .await;
 
     match response_rx.await {
-        Ok(response) => response,
-        Err(_) => Response::builder()
-            .status(hyper::StatusCode::SERVICE_UNAVAILABLE)
-            .body("sqld was not able to process the HTTP upgrade".into())
-            .unwrap(),
+        Ok(response) => response.into_response(),
+        Err(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "sqld was not able to process the HTTP upgrade",
+        )
+            .into_response(),
     }
 }
 
-async fn handle_request<D: Database>(
-    auth: Arc<Auth>,
-    req: Request<Body>,
-    upgrade_tx: mpsc::Sender<hrana::ws::Upgrade>,
-    hrana_http_srv: Arc<hrana::http::Server<D>>,
-    db_factory: Arc<dyn DbFactory<Db = D>>,
-    enable_console: bool,
-    stats: Stats,
-) -> anyhow::Result<Response<Body>> {
-    if hyper_tungstenite::is_upgrade_request(&req) {
-        return Ok(handle_upgrade(&upgrade_tx, req).await);
-    }
-
-    if req.method() == Method::GET && req.uri().path() == "/health" {
-        return Ok(handle_health());
-    }
-    let auth_header = req.headers().get(hyper::header::AUTHORIZATION);
-    let auth = match auth.authenticate_http(auth_header) {
-        Ok(auth) => auth,
-        Err(err) => {
-            return Ok(Response::builder()
-                .status(hyper::StatusCode::UNAUTHORIZED)
-                .body(err.to_string().into())
-                .unwrap());
-        }
-    };
-
-    match (req.method(), req.uri().path()) {
-        (&Method::POST, "/") => handle_query(req, auth, db_factory.clone()).await,
-        (&Method::GET, "/version") => Ok(handle_version()),
-        (&Method::GET, "/console") if enable_console => show_console().await,
-        (&Method::GET, "/v1/stats") => Ok(stats::handle_stats(&stats)),
-
-        (&Method::GET, "/v1") => hrana_over_http_1::handle_index(req).await,
-        (&Method::POST, "/v1/execute") => {
-            hrana_over_http_1::handle_execute(db_factory, auth, req).await
-        }
-        (&Method::POST, "/v1/batch") => {
-            hrana_over_http_1::handle_batch(db_factory, auth, req).await
-        }
-
-        (&Method::GET, "/v2") => {
-            hrana_http_srv
-                .handle(auth, hrana::http::Route::GetIndex, req)
-                .await
-        }
-        (&Method::POST, "/v2/pipeline") => {
-            hrana_http_srv
-                .handle(auth, hrana::http::Route::PostPipeline, req)
-                .await
-        }
-
-        _ => Ok(Response::builder().status(404).body(Body::empty()).unwrap()),
-    }
-}
-
-fn handle_version() -> Response<Body> {
+async fn handle_version() -> Response<Body> {
     let version = version::version();
     Response::new(Body::from(version))
+}
+
+async fn handle_hrana_v2<D: Database>(
+    AxumState(state): AxumState<AppState<D>>,
+    auth: Authenticated,
+    req: Request<Body>,
+) -> Response<Body> {
+    let server = state.hrana_http_srv;
+
+    // TODO(lucio): handle error
+    server
+        .handle(auth, crate::hrana::http::Route::PostPipeline, req)
+        .await
+        .unwrap()
+}
+
+async fn handle_fallback() -> impl IntoResponse {
+    (StatusCode::NOT_FOUND).into_response()
+}
+
+pub(crate) struct AppState<D> {
+    auth: Arc<Auth>,
+    db_factory: Arc<dyn DbFactory<Db = D>>,
+    upgrade_tx: mpsc::Sender<hrana::ws::Upgrade>,
+    hrana_http_srv: Arc<hrana::http::Server<D>>,
+    enable_console: bool,
+    stats: Stats,
+}
+
+impl<D> Clone for AppState<D> {
+    fn clone(&self) -> Self {
+        Self {
+            auth: self.auth.clone(),
+            db_factory: self.db_factory.clone(),
+            upgrade_tx: self.upgrade_tx.clone(),
+            hrana_http_srv: self.hrana_http_srv.clone(),
+            enable_console: self.enable_console,
+            stats: self.stats.clone(),
+        }
+    }
 }
 
 // TODO: refactor
@@ -247,16 +250,48 @@ pub async fn run_http<D: Database>(
     upgrade_tx: mpsc::Sender<hrana::ws::Upgrade>,
     hrana_http_srv: Arc<hrana::http::Server<D>>,
     enable_console: bool,
-    idle_shutdown_layer: Option<IdleShutdownLayer>,
+    _idle_shutdown_layer: Option<IdleShutdownLayer>,
     stats: Stats,
 ) -> anyhow::Result<()> {
+    let state = AppState {
+        auth,
+        db_factory,
+        upgrade_tx,
+        hrana_http_srv,
+        enable_console,
+        stats,
+    };
+
     tracing::info!("listening for HTTP requests on {addr}");
 
     fn trace_request<B>(req: &Request<B>, _span: &Span) {
         tracing::debug!("got request: {} {}", req.method(), req.uri());
     }
-    let service = ServiceBuilder::new()
-        .option_layer(idle_shutdown_layer)
+
+    let app = Router::new()
+        .route("/", post(handle_query))
+        .route("/", get(handle_upgrade))
+        .route("/version", get(handle_version))
+        .route("/console", get(show_console))
+        .route("/health", get(handle_health))
+        .route("/v1/stats", get(stats::handle_stats))
+        .route("/v1/", get(hrana_over_http_1::handle_index))
+        .route("/v1/execute", post(hrana_over_http_1::handle_execute))
+        .route("/v1/batch", post(hrana_over_http_1::handle_batch))
+        .route("/v2", get(crate::hrana::http::handle_index))
+        .route("/v2/pipeline", post(handle_hrana_v2))
+        .fallback(handle_fallback)
+        .with_state(state);
+
+    let layered_app = app
+        // TODO: error mismatch needs to be fixed
+        // why? the option layer from tower merges the errors by boxing them
+        // and this breaks how axum uses infalliable. Though the option layer
+        // and any surrounding layers here don't really use the error part of tower
+        // we can write an `InfalliableEither` which we can combine with an
+        // `infalliable_option_layer` to correctly get the types to work.
+        // Eventually, we can upstream this into axum as well.
+        // .layer(option_layer(idle_shutdown_layer))
         .layer(
             tower_http::trace::TraceLayer::new_for_http()
                 .on_request(trace_request)
@@ -272,25 +307,47 @@ pub async fn run_http<D: Database>(
                 .allow_methods(cors::AllowMethods::any())
                 .allow_headers(cors::Any)
                 .allow_origin(cors::Any),
-        )
-        .service_fn(move |req| {
-            handle_request(
-                auth.clone(),
-                req,
-                upgrade_tx.clone(),
-                hrana_http_srv.clone(),
-                db_factory.clone(),
-                enable_console,
-                stats.clone(),
-            )
-        });
+        );
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     let server = hyper::server::Server::builder(AddrIncoming::from_listener(listener)?)
         .tcp_nodelay(true)
-        .serve(tower::make::Shared::new(service));
+        .serve(layered_app.into_make_service());
 
     server.await.context("Http server exited with an error")?;
 
     Ok(())
+}
+
+/// Axum authenticated extractor
+#[tonic::async_trait]
+impl<S> FromRequestParts<S> for Authenticated
+where
+    Arc<Auth>: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = axum::response::Response<String>;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let auth = <Arc<Auth> as FromRef<S>>::from_ref(state);
+
+        let auth_header = parts.headers.get(hyper::header::AUTHORIZATION);
+        let auth = match auth.authenticate_http(auth_header) {
+            Ok(auth) => auth,
+            Err(err) => {
+                return Err(Response::builder()
+                    .status(hyper::StatusCode::UNAUTHORIZED)
+                    .body(err.to_string())
+                    .unwrap());
+            }
+        };
+
+        Ok(auth)
+    }
+}
+
+impl<D> FromRef<AppState<D>> for Arc<Auth> {
+    fn from_ref(input: &AppState<D>) -> Self {
+        input.auth.clone()
+    }
 }

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -243,7 +243,7 @@ pub async fn run_http<D: Database>(
         .route("/console", get(show_console))
         .route("/health", get(handle_health))
         .route("/v1/stats", get(stats::handle_stats))
-        .route("/v1/", get(hrana_over_http_1::handle_index))
+        .route("/v1", get(hrana_over_http_1::handle_index))
         .route("/v1/execute", post(hrana_over_http_1::handle_execute))
         .route("/v1/batch", post(hrana_over_http_1::handle_batch))
         .route("/v2", get(crate::hrana::http::handle_index))

--- a/sqld/src/http/stats.rs
+++ b/sqld/src/http/stats.rs
@@ -1,7 +1,11 @@
 use hyper::{Body, Response};
 use serde::Serialize;
 
+use axum::extract::State as AxumState;
+
 use crate::stats::Stats;
+
+use super::AppState;
 
 #[derive(Serialize)]
 pub struct StatsResponse {
@@ -26,7 +30,9 @@ impl From<Stats> for StatsResponse {
     }
 }
 
-pub fn handle_stats(stats: &Stats) -> Response<Body> {
+pub(crate) async fn handle_stats<D>(
+    AxumState(AppState { stats, .. }): AxumState<AppState<D>>,
+) -> Response<Body> {
     let resp: StatsResponse = stats.into();
 
     let payload = serde_json::to_vec(&resp).unwrap();


### PR DESCRIPTION
This PR converts our http api into an axum based one. This allows for more modulairity and will allow easier gRPC integration in the future. This commit is missing some error handling that will get fixed in a follow up.