### PR TITLE
warn when recovering db not in wal mode

### DIFF
--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -906,6 +906,10 @@ fn checkpoint_db(data_path: &Path) -> anyhow::Result<()> {
             std::ptr::null_mut(),
         );
 
+        if num_checkpointed < 0 {
+            tracing::error!("could not checkpoint database, make sure the database is in WAL mode and try again");
+        }
+
         // TODO: ensure correct page size
         ensure!(
             rc == 0 && num_checkpointed >= 0,


### PR DESCRIPTION
When seeding sqld with a database that is not in wal mode, and the replication log needs to be recovered, checkpointing fails with an obscure error. This PR adds a friendlier log message to hint what may have gone wrong.
