### PR TITLE
Enable Shared-Cache Mode for opened database

### DIFF
--- a/sqld-libsql-bindings/src/lib.rs
+++ b/sqld-libsql-bindings/src/lib.rs
@@ -105,6 +105,8 @@ impl<'a> Connection<'a> {
             }
 
             assert!(!db.is_null());
+
+            rusqlite::ffi::sqlite3_enable_shared_cache(1)
         };
 
         let conn = unsafe { rusqlite::Connection::from_handle_owned(db)? };


### PR DESCRIPTION
According to documentation this mode can increase database performance: https://www.sqlite.org/sharedcache.html

My tests showed improvement both when using 1 client and 100 clients.

For sigle client the throughput increased by 14%.
For 100 clients the throughput increased by 27%.
On the same time latencies have been lowered.

The results for sqld running locally:

1 client with no sharedcache:
    Summary:
        Total:        60.0012 secs
        Slowest:      0.0221 secs
        Fastest:      0.0009 secs
        Average:      0.0011 secs
        Requests/sec: 895.4821

    Latency distribution:
        10% in 0.0009 secs
        25% in 0.0010 secs
        50% in 0.0011 secs
        75% in 0.0012 secs
        90% in 0.0013 secs
        95% in 0.0014 secs
        99% in 0.0018 secs

1 client with sharedcache:
    Summary:
        Total:        60.0008 secs
        Slowest:      0.0187 secs
        Fastest:      0.0008 secs
        Average:      0.0010 secs
        Requests/sec: 1042.3534
    Latency distribution:
        10% in 0.0008 secs
        25% in 0.0009 secs
        50% in 0.0009 secs
        75% in 0.0010 secs
        90% in 0.0011 secs
        95% in 0.0012 secs
        99% in 0.0016 secs

100 clients with no sharedcache:
    Summary:
        Total:        60.0359 secs
        Slowest:      0.0962 secs
        Fastest:      0.0103 secs
        Average:      0.0368 secs
        Requests/sec: 2716.9230
    Latency distribution:
        10% in 0.0311 secs
        25% in 0.0338 secs
        50% in 0.0368 secs
        75% in 0.0396 secs
        90% in 0.0422 secs
        95% in 0.0439 secs
        99% in 0.0480 secs

100 clients with sharedcache:
    Summary:
        Total:        60.0218 secs
        Slowest:      0.0828 secs
        Fastest:      0.0075 secs
        Average:      0.0267 secs
        Requests/sec: 3744.2703
    Latency distribution:
        10% in 0.0225 secs
        25% in 0.0242 secs
        50% in 0.0262 secs
        75% in 0.0287 secs
        90% in 0.0314 secs
        95% in 0.0332 secs
        99% in 0.0377 secs