### PR TITLE
sqld: Add `BatchLogEntries` and replication rpc auth

### DIFF
--- a/sqld/proto/replication_log.proto
+++ b/sqld/proto/replication_log.proto
@@ -27,6 +27,6 @@ message Frames {
 service ReplicationLog {
     rpc Hello(HelloRequest) returns (HelloResponse) {}
     rpc LogEntries(LogOffset) returns (stream Frame) {}
-    rpc LogEntriesSnapshot(LogOffset) returns (Frames) {}
+    rpc BatchLogEntries(LogOffset) returns (Frames) {}
     rpc Snapshot(LogOffset) returns (stream Frame) {}
 }

--- a/sqld/proto/replication_log.proto
+++ b/sqld/proto/replication_log.proto
@@ -20,8 +20,13 @@ message Frame {
     bytes data = 1;
 }
 
+message Frames {
+    repeated Frame frames = 1;
+}
+
 service ReplicationLog {
     rpc Hello(HelloRequest) returns (HelloResponse) {}
     rpc LogEntries(LogOffset) returns (stream Frame) {}
+    rpc LogEntriesSnapshot(LogOffset) returns (Frames) {}
     rpc Snapshot(LogOffset) returns (stream Frame) {}
 }

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -229,7 +229,7 @@ pub async fn run_http<D: Database>(
     logger: Option<Arc<ReplicationLogger>>,
 ) -> anyhow::Result<()> {
     let state = AppState {
-        auth,
+        auth: auth.clone(),
         db_factory,
         upgrade_tx,
         hrana_http_srv,
@@ -278,7 +278,7 @@ pub async fn run_http<D: Database>(
 
     // Merge the grpc based axum router into our regular http router
     let router = if let Some(logger) = logger {
-        let logger_rpc = ReplicationLogService::new(logger, idle_shutdown_layer);
+        let logger_rpc = ReplicationLogService::new(logger, idle_shutdown_layer, Some(auth));
         let grpc_router = Server::builder()
             .add_service(crate::rpc::ReplicationLogServer::new(logger_rpc))
             .into_router();

--- a/sqld/src/replication/primary/frame_stream.rs
+++ b/sqld/src/replication/primary/frame_stream.rs
@@ -15,16 +15,22 @@ pub struct FrameStream {
     pub(crate) max_available_frame_no: FrameNo,
     logger: Arc<ReplicationLogger>,
     state: FrameStreamState,
+    wait_for_more: bool,
 }
 
 impl FrameStream {
-    pub fn new(logger: Arc<ReplicationLogger>, current_frameno: FrameNo) -> Self {
+    pub fn new(
+        logger: Arc<ReplicationLogger>,
+        current_frameno: FrameNo,
+        wait_for_more: bool,
+    ) -> Self {
         let max_available_frame_no = *logger.new_frame_notifier.subscribe().borrow();
         Self {
             current_frame_no: current_frameno,
             max_available_frame_no,
             logger,
             state: FrameStreamState::Init,
+            wait_for_more,
         }
     }
 
@@ -84,6 +90,12 @@ impl Stream for FrameStream {
                 }
 
                 Err(LogReadError::Ahead) => {
+                    // If we don't wait to wait for more then lets end this stream
+                    // without subscribing for more frames
+                    if !self.wait_for_more {
+                        return Poll::Ready(None);
+                    }
+
                     let mut notifier = self.logger.new_frame_notifier.subscribe();
                     let max_available_frame_no = *notifier.borrow();
                     // check in case value has already changed, otherwise we'll be notified later

--- a/sqld/src/replication/primary/frame_stream.rs
+++ b/sqld/src/replication/primary/frame_stream.rs
@@ -93,6 +93,7 @@ impl Stream for FrameStream {
                     // If we don't wait to wait for more then lets end this stream
                     // without subscribing for more frames
                     if !self.wait_for_more {
+                        self.state = FrameStreamState::Closed;
                         return Poll::Ready(None);
                     }
 

--- a/sqld/src/rpc/mod.rs
+++ b/sqld/src/rpc/mod.rs
@@ -28,7 +28,7 @@ pub async fn run_rpc_server<D: Database>(
     idle_shutdown_layer: Option<IdleShutdownLayer>,
 ) -> anyhow::Result<()> {
     let proxy_service = ProxyService::new(factory, logger.new_frame_notifier.subscribe());
-    let logger_service = ReplicationLogService::new(logger, idle_shutdown_layer.clone());
+    let logger_service = ReplicationLogService::new(logger, idle_shutdown_layer.clone(), None);
 
     tracing::info!("serving write proxy server at {addr}");
 

--- a/sqld/src/rpc/replication_log.rs
+++ b/sqld/src/rpc/replication_log.rs
@@ -49,10 +49,9 @@ impl ReplicationLogService {
     fn authenticate<T>(&self, req: &tonic::Request<T>) -> Result<(), Status> {
         if let Some(auth) = &self.auth {
             let _ = auth.authenticate_grpc(req)?;
-            Ok(())
-        } else {
-            Ok(())
         }
+
+        Ok(())
     }
 }
 
@@ -142,7 +141,7 @@ impl ReplicationLog for ReplicationLogService {
         Ok(tonic::Response::new(Box::pin(stream)))
     }
 
-    async fn log_entries_snapshot(
+    async fn batch_log_entries(
         &self,
         req: tonic::Request<LogOffset>,
     ) -> Result<tonic::Response<Frames>, Status> {


### PR DESCRIPTION
This PR adds a new rpc endpoint that doesn't stream log entries fit for libsql and additionally adds auth to the replication service rpc code which is only enabled for the public facing http server and not the internal one.