### PR TITLE
overload protection: update total response size on hrana error

### DIFF
--- a/sqld/src/hrana/result_builder.rs
+++ b/sqld/src/hrana/result_builder.rs
@@ -125,8 +125,9 @@ impl QueryResultBuilder for SingleStatementBuilder {
         assert!(self.err.is_none());
         let mut f = SizeFormatter(0);
         write!(&mut f, "{error}").unwrap();
+        TOTAL_RESPONSE_SIZE.fetch_sub(self.current_size as usize, Ordering::Relaxed);
         self.current_size = f.0;
-
+        TOTAL_RESPONSE_SIZE.fetch_add(self.current_size as usize, Ordering::Relaxed);
         self.err = Some(error);
 
         Ok(())


### PR DESCRIPTION
It wasn't properly updated in the error path, and that would cause inconsistent tracking of the total response size.