### PR TITLE
Fix the number of semaphore units taken

### DIFF
--- a/sqld/src/database/factory.rs
+++ b/sqld/src/database/factory.rs
@@ -115,6 +115,10 @@ impl<F: DbFactory> DbFactory for ThrottledDbFactory<F> {
 
     async fn create(&self) -> Result<Self::Db, Error> {
         // If the memory pressure is high, request more units to reduce concurrency.
+        tracing::trace!(
+            "Available semaphore units: {}",
+            self.semaphore.available_permits()
+        );
         let units = self.units_to_take();
         let waiters_guard = WaitersGuard::new(&self.waiters);
         if waiters_guard.waiters.load(Ordering::Relaxed) >= 128 {

--- a/sqld/src/database/factory.rs
+++ b/sqld/src/database/factory.rs
@@ -130,7 +130,7 @@ impl<F: DbFactory> DbFactory for ThrottledDbFactory<F> {
         let units = self.units_to_take();
         if units > 1 {
             tracing::debug!("Reacquiring {units} units due to high memory pressure");
-            let fut = self.semaphore.clone().acquire_many_owned(64);
+            let fut = self.semaphore.clone().acquire_many_owned(units);
             let mem_permit = match self.timeout {
                 Some(t) => timeout(t, fut).await.map_err(|_| Error::DbCreateTimeout)?,
                 None => fut.await,

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -51,7 +51,7 @@ mod test;
 mod utils;
 pub mod version;
 
-const MAX_CONCCURENT_DBS: usize = 32;
+const MAX_CONCURRENT_DBS: usize = 128;
 const DB_CREATE_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
@@ -339,7 +339,7 @@ async fn start_replica(
         config.max_total_response_size,
     )
     .throttled(
-        MAX_CONCCURENT_DBS,
+        MAX_CONCURRENT_DBS,
         Some(DB_CREATE_TIMEOUT),
         config.max_total_response_size,
     );
@@ -496,7 +496,7 @@ async fn start_primary(
     )
     .await?
     .throttled(
-        MAX_CONCCURENT_DBS,
+        MAX_CONCURRENT_DBS,
         Some(DB_CREATE_TIMEOUT),
         config.max_total_response_size,
     )


### PR DESCRIPTION
In manual tests, the value was mistakenly updated to 64,
in order to easily trigger an error - unfortunately, it also
somehow made it to the main branch...

It also interacted badly with another unintended change,
which was reducing the number of allowed concurrent
database connections -- reduced to 32 in order to easily
test overloaded conditions.

Both values are now properly restored to what they were meant to be.