### PR TITLE
Flip default namespace behaviour

### DIFF
--- a/sqld/src/hrana/ws/conn.rs
+++ b/sqld/src/hrana/ws/conn.rs
@@ -54,7 +54,7 @@ pub(super) async fn handle_tcp<F: MakeNamespace>(
     socket: tokio::net::TcpStream,
     conn_id: u64,
 ) -> Result<()> {
-    let (ws, version, ns) = handshake::handshake_tcp(socket, server.allow_default_namespace)
+    let (ws, version, ns) = handshake::handshake_tcp(socket, server.disable_default_namespace)
         .await
         .context("Could not perform the WebSocket handshake on TCP connection")?;
     handle_ws(server, ws, version, conn_id, ns).await
@@ -65,7 +65,7 @@ pub(super) async fn handle_upgrade<F: MakeNamespace>(
     upgrade: Upgrade,
     conn_id: u64,
 ) -> Result<()> {
-    let (ws, version, ns) = handshake::handshake_upgrade(upgrade, server.allow_default_namespace)
+    let (ws, version, ns) = handshake::handshake_upgrade(upgrade, server.disable_default_namespace)
         .await
         .context("Could not perform the WebSocket handshake on HTTP connection")?;
     handle_ws(server, ws, version, conn_id, ns).await

--- a/sqld/src/hrana/ws/handshake.rs
+++ b/sqld/src/hrana/ws/handshake.rs
@@ -19,7 +19,7 @@ pub enum WebSocket {
 
 pub async fn handshake_tcp(
     socket: tokio::net::TcpStream,
-    allow_default_ns: bool,
+    disable_default_ns: bool,
 ) -> Result<(WebSocket, Version, Bytes)> {
     let mut version = None;
     let mut namespace = None;
@@ -29,7 +29,7 @@ pub async fn handshake_tcp(
             .headers
             .insert("server", http::HeaderValue::from_static("sqld-hrana-tcp"));
 
-        namespace = match namespace_from_headers(req.headers(), allow_default_ns) {
+        namespace = match namespace_from_headers(req.headers(), disable_default_ns) {
             Ok(ns) => Some(ns),
             Err(e) => return Err(http::Response::from_parts(resp_parts, Some(e.to_string()))),
         };
@@ -51,11 +51,11 @@ pub async fn handshake_tcp(
 
 pub async fn handshake_upgrade(
     upgrade: Upgrade,
-    allow_default_ns: bool,
+    disable_default_ns: bool,
 ) -> Result<(WebSocket, Version, Bytes)> {
     let mut req = upgrade.request;
 
-    let ns = namespace_from_headers(req.headers(), allow_default_ns)?;
+    let ns = namespace_from_headers(req.headers(), disable_default_ns)?;
     let ws_config = Some(get_ws_config());
     let (mut resp, stream_fut_version_res) = match hyper_tungstenite::upgrade(&mut req, ws_config) {
         Ok((mut resp, stream_fut)) => match negotiate_version(req.headers(), resp.headers_mut()) {

--- a/sqld/src/hrana/ws/mod.rs
+++ b/sqld/src/hrana/ws/mod.rs
@@ -19,7 +19,7 @@ struct Server<F: MakeNamespace> {
     auth: Arc<Auth>,
     idle_kicker: Option<IdleKicker>,
     next_conn_id: AtomicU64,
-    allow_default_namespace: bool,
+    disable_default_namespace: bool,
 }
 
 #[derive(Debug)]
@@ -40,14 +40,14 @@ pub async fn serve<F: MakeNamespace>(
     mut accept_rx: mpsc::Receiver<Accept>,
     mut upgrade_rx: mpsc::Receiver<Upgrade>,
     namespaces: Arc<NamespaceStore<F>>,
-    allow_default_namespace: bool,
+    disable_default_namespace: bool,
 ) -> Result<()> {
     let server = Arc::new(Server {
         auth,
         idle_kicker,
         next_conn_id: AtomicU64::new(0),
         namespaces,
-        allow_default_namespace,
+        disable_default_namespace,
     });
 
     let mut join_set = tokio::task::JoinSet::new();

--- a/sqld/src/http/db_factory.rs
+++ b/sqld/src/http/db_factory.rs
@@ -27,7 +27,7 @@ where
         parts: &mut Parts,
         state: &AppState<F>,
     ) -> Result<Self, Self::Rejection> {
-        let ns = namespace_from_headers(&parts.headers, state.allow_default_namespace)?;
+        let ns = namespace_from_headers(&parts.headers, state.disable_default_namespace)?;
         Ok(Self(
             state
                 .namespaces
@@ -39,7 +39,7 @@ where
 
 pub fn namespace_from_headers(
     headers: &HeaderMap,
-    allow_default_namespace: bool,
+    disable_default_namespace: bool,
 ) -> crate::Result<Bytes> {
     let host = headers
         .get("host")
@@ -50,7 +50,7 @@ pub fn namespace_from_headers(
 
     match split_namespace(host_str) {
         Ok(ns) => Ok(ns),
-        Err(_) if allow_default_namespace => Ok(DEFAULT_NAMESPACE_NAME.into()),
+        Err(_) if !disable_default_namespace => Ok(DEFAULT_NAMESPACE_NAME.into()),
         Err(e) => Err(e),
     }
 }

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -205,7 +205,7 @@ pub(crate) struct AppState<F: MakeNamespace> {
     hrana_http_srv: Arc<hrana::http::Server<<F::Database as Database>::Connection>>,
     enable_console: bool,
     stats: Stats,
-    allow_default_namespace: bool,
+    disable_default_namespace: bool,
 }
 
 impl<F: MakeNamespace> Clone for AppState<F> {
@@ -217,7 +217,7 @@ impl<F: MakeNamespace> Clone for AppState<F> {
             hrana_http_srv: self.hrana_http_srv.clone(),
             enable_console: self.enable_console,
             stats: self.stats.clone(),
-            allow_default_namespace: self.allow_default_namespace,
+            disable_default_namespace: self.disable_default_namespace,
         }
     }
 }
@@ -234,7 +234,7 @@ pub async fn run_http<F, S>(
     idle_shutdown_layer: Option<IdleShutdownLayer>,
     stats: Stats,
     replication_service: Option<S>,
-    allow_default_namespace: bool,
+    disable_default_namespace: bool,
 ) -> anyhow::Result<()>
 where
     F: MakeNamespace,
@@ -252,7 +252,7 @@ where
         enable_console,
         stats,
         namespaces,
-        allow_default_namespace,
+        disable_default_namespace,
     };
 
     tracing::info!("listening for HTTP requests on {addr}");

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -105,7 +105,7 @@ pub struct Config {
     pub max_response_size: u64,
     pub max_total_response_size: u64,
     pub snapshot_exec: Option<String>,
-    pub allow_default_namespace: bool,
+    pub disable_default_namespace: bool,
 }
 
 impl Default for Config {
@@ -145,7 +145,7 @@ impl Default for Config {
             max_response_size: 10 * 1024 * 1024,       // 10MiB
             max_total_response_size: 32 * 1024 * 1024, // 32MiB
             snapshot_exec: None,
-            allow_default_namespace: false,
+            disable_default_namespace: false,
         }
     }
 }
@@ -177,7 +177,7 @@ where
         let namespaces = namespaces.clone();
         let auth = auth.clone();
         let idle_kicker = idle_shutdown_layer.clone().map(|isl| isl.into_kicker());
-        let allow_default_namespace = config.allow_default_namespace;
+        let disable_default_namespace = config.disable_default_namespace;
         join_set.spawn(async move {
             hrana::ws::serve(
                 auth,
@@ -185,7 +185,7 @@ where
                 hrana_accept_rx,
                 hrana_upgrade_rx,
                 namespaces,
-                allow_default_namespace,
+                disable_default_namespace,
             )
             .await
             .context("Hrana server failed")
@@ -204,7 +204,7 @@ where
             idle_shutdown_layer,
             stats.clone(),
             replication_service,
-            config.allow_default_namespace,
+            config.disable_default_namespace,
         ));
         join_set.spawn(async move {
             hrana_http_srv.run_expire().await;

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -182,9 +182,10 @@ struct Cli {
     /// Set a command to execute when a snapshot file is generated.
     #[clap(long, env = "SQLD_SNAPSHOT_EXEC")]
     snapshot_exec: Option<String>,
-    /// All requests whose host cannot be parsed are routed to a default namespace `default`
+    /// By default, all request for which a namespace can't be determined fallaback to the default
+    /// namespace `default`. This flag disables that.
     #[clap(long)]
-    allow_default_namespace: bool,
+    disable_default_namespace: bool,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -296,7 +297,7 @@ fn config_from_args(args: Cli) -> Result<Config> {
         max_response_size: args.max_response_size.0,
         max_total_response_size: args.max_total_response_size.0,
         snapshot_exec: args.snapshot_exec,
-        allow_default_namespace: args.allow_default_namespace,
+        disable_default_namespace: args.disable_default_namespace,
     })
 }
 

--- a/sqld/src/namespace.rs
+++ b/sqld/src/namespace.rs
@@ -125,6 +125,7 @@ impl<F: MakeNamespace> NamespaceStore<F> {
 }
 
 /// A namspace isolates the resources pertaining to a database of type T
+#[derive(Debug)]
 pub struct Namespace<T: Database> {
     pub db: T,
     /// The set of tasks associated with this namespace

--- a/sqld/src/replication/replica/replicator.rs
+++ b/sqld/src/replication/replica/replicator.rs
@@ -149,7 +149,7 @@ impl Replicator {
 
                     let mut lock = self.meta.lock().await;
                     let meta = match *lock {
-                        Some(meta) => match dbg!(meta.merge_from_hello(hello)) {
+                        Some(meta) => match meta.merge_from_hello(hello) {
                             Ok(meta) => meta,
                             Err(e @ ReplicationError::Lagging) => {
                                 tracing::error!("Replica ahead of primary: hard-reseting replica");

--- a/sqld/src/test/bottomless.rs
+++ b/sqld/src/test/bottomless.rs
@@ -48,7 +48,6 @@ async fn backup_restore() {
         }),
         db_path: PATH.into(),
         http_addr: Some(listener_addr),
-        allow_default_namespace: true,
         ..Config::default()
     };
 
@@ -235,7 +234,6 @@ async fn rollback_restore() {
         }),
         db_path: PATH.into(),
         http_addr: Some(listener_addr),
-        allow_default_namespace: true,
         ..Config::default()
     };
 
@@ -246,16 +244,14 @@ async fn rollback_restore() {
 
         sleep(Duration::from_secs(2)).await;
 
-        let _ = dbg!(
-            sql(
-                &conn,
-                [
-                    "CREATE TABLE IF NOT EXISTS t(id INT PRIMARY KEY, name TEXT);",
-                    "INSERT INTO t(id, name) VALUES(1, 'A')",
-                ],
-            )
-            .await
+        let _ = sql(
+            &conn,
+            [
+                "CREATE TABLE IF NOT EXISTS t(id INT PRIMARY KEY, name TEXT);",
+                "INSERT INTO t(id, name) VALUES(1, 'A')",
+            ],
         )
+        .await
         .unwrap();
 
         let _ = sql(


### PR DESCRIPTION
Before this PR, default namespace was an opt-in option with `--allow-default-namespace`. When this was enabled, if not namespace was detected, then sqld would fallback to a default namespace `default`. Now this flag is renamed to `--allow-default-namespace` and the behaviour is flipped.
