### PR TITLE
proxy frame replication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3727,7 +3727,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sqld"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqld"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 default-run = "sqld"
 

--- a/sqld/src/rpc/mod.rs
+++ b/sqld/src/rpc/mod.rs
@@ -13,6 +13,7 @@ use crate::utils::services::idle_shutdown::IdleShutdownLayer;
 
 pub mod proxy;
 pub mod replication_log;
+pub mod replication_log_proxy;
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run_rpc_server(

--- a/sqld/src/rpc/replication_log_proxy.rs
+++ b/sqld/src/rpc/replication_log_proxy.rs
@@ -1,0 +1,56 @@
+use hyper::Uri;
+use tonic::{transport::Channel, Status};
+
+use super::replication_log::rpc::replication_log_client::ReplicationLogClient;
+use super::replication_log::rpc::replication_log_server::ReplicationLog;
+use super::replication_log::rpc::{Frame, Frames, HelloRequest, HelloResponse, LogOffset};
+
+/// A replication log service that proxies request to the primary.
+pub struct ReplicationLogProxyService {
+    client: ReplicationLogClient<Channel>,
+}
+
+impl ReplicationLogProxyService {
+    pub fn new(channel: Channel, uri: Uri) -> Self {
+        let client = ReplicationLogClient::with_origin(channel, uri);
+        Self { client }
+    }
+}
+
+#[tonic::async_trait]
+impl ReplicationLog for ReplicationLogProxyService {
+    type LogEntriesStream = tonic::codec::Streaming<Frame>;
+    type SnapshotStream = tonic::codec::Streaming<Frame>;
+
+    async fn log_entries(
+        &self,
+        req: tonic::Request<LogOffset>,
+    ) -> Result<tonic::Response<Self::LogEntriesStream>, Status> {
+        let mut client = self.client.clone();
+        client.log_entries(req).await
+    }
+
+    async fn batch_log_entries(
+        &self,
+        req: tonic::Request<LogOffset>,
+    ) -> Result<tonic::Response<Frames>, Status> {
+        let mut client = self.client.clone();
+        client.batch_log_entries(req).await
+    }
+
+    async fn hello(
+        &self,
+        req: tonic::Request<HelloRequest>,
+    ) -> Result<tonic::Response<HelloResponse>, Status> {
+        let mut client = self.client.clone();
+        client.hello(req).await
+    }
+
+    async fn snapshot(
+        &self,
+        req: tonic::Request<LogOffset>,
+    ) -> Result<tonic::Response<Self::SnapshotStream>, Status> {
+        let mut client = self.client.clone();
+        client.snapshot(req).await
+    }
+}


### PR DESCRIPTION
This PR adds the ability to proxy replication request from replica to its primary. Essentially, now, replication requests can hit any instance in a sqld cluster.
