### PR TITLE
WAL hook functions now invoke generic T:WalHook methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3727,7 +3727,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sqld"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "arbitrary",


### PR DESCRIPTION
This PR fixes an issue when some of our custom `WalHook` trait implementation (namely `ReplicationLoggerHook`) methods were not called by C function callbacks registered in SQLite. This specifically points to `WalHook::on_checkpoint` and `WalHook::on_savepoint_undo` which were never called.

I only did this for missing methods that were defined in `WalHook` trait. There are many functions that don't have corresponding trait methods, but it looks like we don't need them atm.