### PR TITLE
Fix the disable-namespace flag

### DIFF
--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -187,9 +187,10 @@ struct Cli {
     #[clap(long)]
     disable_default_namespace: bool,
 
-    /// By default, ignore namespaces and route all requests to the default namespace.
-    #[clap(long, default_value = "true")]
-    disable_namespaces: bool,
+    /// Enable the namespaces features. Namespaces are disabled by default, and all requests target
+    /// the default namespace.
+    #[clap(long)]
+    enable_namespaces: bool,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -302,7 +303,7 @@ fn config_from_args(args: Cli) -> Result<Config> {
         max_total_response_size: args.max_total_response_size.0,
         snapshot_exec: args.snapshot_exec,
         disable_default_namespace: args.disable_default_namespace,
-        disable_namespaces: args.disable_namespaces,
+        disable_namespaces: !args.enable_namespaces,
     })
 }
 


### PR DESCRIPTION
The `--disable-namespace` flag was broken. It was set to `true` by default, which means that passing `--disable-namespace` did nothing, and namespaces could not be enabled.

Instead, the flag is renamed to `--enable-namespace`, so that, by default, namespaces are disabled, unless this flag is passed.
