### PR TITLE
bottomless-cli: added support for namespaces

### DIFF
--- a/bottomless-cli/src/main.rs
+++ b/bottomless-cli/src/main.rs
@@ -19,6 +19,8 @@ struct Cli {
     bucket: Option<String>,
     #[clap(long, short)]
     database: Option<String>,
+    #[clap(long, short)]
+    namespace: Option<String>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -85,16 +87,21 @@ enum Commands {
 
 async fn run() -> Result<()> {
     tracing_subscriber::fmt::init();
-    let options = Cli::parse();
+    let mut options = Cli::parse();
 
     if let Some(ep) = options.endpoint.as_deref() {
         std::env::set_var("LIBSQL_BOTTOMLESS_ENDPOINT", ep)
+    } else {
+        options.endpoint = std::env::var("LIBSQL_BOTTOMLESS_ENDPOINT").ok();
     }
 
     if let Some(bucket) = options.bucket.as_deref() {
         std::env::set_var("LIBSQL_BOTTOMLESS_BUCKET", bucket)
+    } else {
+        options.bucket = std::env::var("LIBSQL_BOTTOMLESS_BUCKET").ok();
     }
-
+    let namespace = options.namespace.as_deref().unwrap_or("ns-default");
+    std::env::set_var("LIBSQL_BOTTOMLESS_DATABASE_ID", namespace);
     let database = match options.database.clone() {
         Some(db) => db,
         None => {
@@ -108,7 +115,7 @@ async fn run() -> Result<()> {
                     .build()
             });
             let bucket = options.bucket.as_deref().unwrap_or("bottomless");
-            match detect_db(&client, bucket, "").await {
+            match detect_db(&client, bucket, namespace.clone()).await {
                 Some(db) => db,
                 None => {
                     println!("Could not autodetect the database. Please pass it explicitly with -d option");
@@ -117,9 +124,10 @@ async fn run() -> Result<()> {
             }
         }
     };
-    tracing::info!("Database: {}", database);
+    let database = database + "/dbs/" + namespace.strip_prefix("ns-").unwrap() + "/data";
+    tracing::info!("Database: '{}' (namespace: {})", database, namespace);
 
-    let mut client = Replicator::new(database).await?;
+    let mut client = Replicator::new(database.clone()).await?;
 
     match options.command {
         Commands::Ls {
@@ -140,6 +148,7 @@ async fn run() -> Result<()> {
             generation,
             utc_time,
         } => {
+            tokio::fs::create_dir_all(&database).await?;
             client.restore(generation, utc_time).await?;
         }
         Commands::Rm {

--- a/bottomless-cli/src/main.rs
+++ b/bottomless-cli/src/main.rs
@@ -115,7 +115,7 @@ async fn run() -> Result<()> {
                     .build()
             });
             let bucket = options.bucket.as_deref().unwrap_or("bottomless");
-            match detect_db(&client, bucket, namespace.clone()).await {
+            match detect_db(&client, bucket, namespace).await {
                 Some(db) => db,
                 None => {
                     println!("Could not autodetect the database. Please pass it explicitly with -d option");

--- a/bottomless-cli/src/replicator_extras.rs
+++ b/bottomless-cli/src/replicator_extras.rs
@@ -23,32 +23,30 @@ impl std::ops::DerefMut for Replicator {
 }
 
 fn uuid_to_datetime(uuid: &uuid::Uuid) -> chrono::NaiveDateTime {
-    let (seconds, nanos) = uuid
-        .get_timestamp()
-        .map(|ts| ts.to_unix())
-        .unwrap_or((0, 0));
-    let (seconds, nanos) = (253370761200 - seconds, 999000000 - nanos);
-    chrono::NaiveDateTime::from_timestamp_opt(seconds as i64, nanos)
-        .unwrap_or(chrono::NaiveDateTime::MIN)
+    let timestamp = bottomless::replicator::Replicator::generation_to_timestamp(uuid);
+    let (seconds, _) = timestamp
+        .as_ref()
+        .map(uuid::Timestamp::to_unix)
+        .unwrap_or_default();
+    chrono::NaiveDateTime::from_timestamp_millis((seconds * 1000) as i64).unwrap()
 }
 
-pub(crate) async fn detect_db(client: &Client, bucket: &str, db_name: &str) -> Option<String> {
-    let response = match client
+pub(crate) async fn detect_db(client: &Client, bucket: &str, namespace: &str) -> Option<String> {
+    let namespace = namespace.to_owned() + ":";
+    let response = client
         .list_objects()
         .bucket(bucket)
         .set_delimiter(Some("/".to_string()))
-        .prefix(db_name)
+        .prefix(namespace.clone())
         .send()
         .await
-    {
-        Ok(resp) => resp,
-        Err(_) => return None,
-    };
+        .ok()?;
 
     let prefix = response.common_prefixes()?.first()?.prefix()?;
     // 38 is the length of the uuid part
     if let Some('-') = prefix.chars().nth(prefix.len().saturating_sub(38)) {
-        Some(prefix[..prefix.len().saturating_sub(38)].to_owned())
+        let ns_db = &prefix[..prefix.len().saturating_sub(38)];
+        Some(ns_db.strip_prefix(&namespace).unwrap_or(ns_db).to_owned())
     } else {
         None
     }
@@ -135,7 +133,7 @@ impl Replicator {
                     if datetime.date() > older_than.unwrap_or(chrono::NaiveDate::MAX) {
                         continue;
                     }
-                    println!("{uuid}");
+                    println!("{} (created: {})", uuid, datetime.and_utc().to_rfc3339());
                     if verbose {
                         let counter = self.get_remote_change_counter(&uuid).await?;
                         let consistent_frame = self.get_last_consistent_frame(&uuid).await?;

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -1,6 +1,7 @@
 use crate::backup::WalCopier;
 use crate::read::BatchReader;
 use crate::transaction_cache::TransactionPageCache;
+use crate::uuid_utils::decode_unix_timestamp;
 use crate::wal::WalFileReader;
 use anyhow::anyhow;
 use arc_swap::ArcSwap;
@@ -239,12 +240,13 @@ impl Replicator {
         let db_path = db_path.into();
         let db_name = {
             let db_id = options.db_id.unwrap_or_default();
-            let name = match db_path.rfind('/') {
-                Some(index) => &db_path[index + 1..],
+            let name = match db_path.find('/') {
+                Some(index) => &db_path[..index],
                 None => &db_path,
             };
-            db_id + name
+            db_id + ":" + name
         };
+        tracing::debug!("Database path: '{}', name: '{}'", db_path, db_name);
 
         let (flush_trigger, mut flush_trigger_rx) = channel(());
         let (last_committed_frame_no_sender, last_committed_frame_no) = channel(Ok(0));
@@ -450,8 +452,8 @@ impl Replicator {
         crate::uuid_utils::new_v7(synthetic_ts)
     }
 
-    fn generation_to_timestamp(generation: &Uuid) -> Option<uuid::Timestamp> {
-        let ts = generation.get_timestamp()?;
+    pub fn generation_to_timestamp(generation: &Uuid) -> Option<uuid::Timestamp> {
+        let ts = decode_unix_timestamp(generation);
         let (seconds, nanos) = ts.to_unix();
         let (seconds, nanos) = (253370761200 - seconds, 999999999 - nanos);
         Some(uuid::Timestamp::from_unix(NoContext, seconds, nanos))

--- a/bottomless/src/uuid_utils.rs
+++ b/bottomless/src/uuid_utils.rs
@@ -60,7 +60,6 @@ mod test {
     fn timestamp_uuid_conversion() {
         let ts = Timestamp::now(NoContext);
         let uuid = new_v7(ts);
-        println!("{}", uuid.get_version_num());
         let actual = decode_unix_timestamp(&uuid);
         //TODO: information loss on encoding?
         let (s1, _) = actual.to_unix();

--- a/bottomless/src/uuid_utils.rs
+++ b/bottomless/src/uuid_utils.rs
@@ -1,7 +1,7 @@
 // Copy-pasted from uuid crate to avoid their uuid_unstable flag guard.
 // Once uuid v7 is standardized and stabilized, we can go back to using uuid::new_v7() directly.
 
-use uuid::{Timestamp, Uuid};
+use uuid::{NoContext, Timestamp, Uuid};
 
 fn bytes() -> [u8; 16] {
     rand::random()
@@ -33,4 +33,38 @@ pub fn new_v7(ts: Timestamp) -> Uuid {
     let millis = (secs * 1000).saturating_add(nanos as u64 / 1_000_000);
 
     encode_unix_timestamp_millis(millis, &bytes()[..10].try_into().unwrap())
+}
+
+pub(crate) fn decode_unix_timestamp(uuid: &Uuid) -> Timestamp {
+    // taken from uuid crate (unsafe features)
+    let bytes = uuid.as_bytes();
+
+    let millis: u64 = (bytes[0] as u64) << 40
+        | (bytes[1] as u64) << 32
+        | (bytes[2] as u64) << 24
+        | (bytes[3] as u64) << 16
+        | (bytes[4] as u64) << 8
+        | (bytes[5] as u64);
+
+    let seconds = millis / 1000;
+    let nanos = ((millis % 1000) * 1_000_000) as u32;
+    Timestamp::from_unix(NoContext, seconds, nanos)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::uuid_utils::{decode_unix_timestamp, new_v7};
+    use uuid::{NoContext, Timestamp};
+
+    #[test]
+    fn timestamp_uuid_conversion() {
+        let ts = Timestamp::now(NoContext);
+        let uuid = new_v7(ts);
+        println!("{}", uuid.get_version_num());
+        let actual = decode_unix_timestamp(&uuid);
+        //TODO: information loss on encoding?
+        let (s1, _) = actual.to_unix();
+        let (s2, _) = ts.to_unix();
+        assert_eq!(s1, s2);
+    }
 }


### PR DESCRIPTION
This PR fixes `bottomless-cli` tool to support namespaces added some time ago (see #575). Changes include:
1. Changed bottomless S3 keyspace prefix: atm its `ns-{namespace}data-{uuid}/`. With this PR it will be: `ns-{namespace}:{db_path}-{uuid}/`. This way we can perform DB recovery directly to its original path and setup required options.
2. `bottomless-cli ls` now correctly infers database path from S3 bucket - previously it was option, but never actually worked.
3. `bottomless-cli ls` now displays not only generations but also their creation times (useful since bottomless supports point-in-time recovery for some time).
4. Point-in-time recovery was broken by #566 (basically library we use was no longer able to decode timestamp from v7 UUIDs we created) and was silently failing. This PR also fixes that.