### PR TITLE
Namespace deletion

### DIFF
--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -14,7 +14,6 @@ use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::{Client, Config};
 use bytes::{Buf, Bytes, BytesMut};
 use chrono::{DateTime, LocalResult, NaiveDateTime, TimeZone, Utc};
-use tokio::task::JoinSet;
 use std::io::SeekFrom;
 use std::ops::Deref;
 use std::path::Path;
@@ -23,6 +22,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::sync::watch::{channel, Receiver, Sender};
+use tokio::task::JoinSet;
 use tokio::time::{timeout_at, Instant};
 use uuid::{NoContext, Uuid};
 

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -14,6 +14,7 @@ use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::{Client, Config};
 use bytes::{Buf, Bytes, BytesMut};
 use chrono::{DateTime, LocalResult, NaiveDateTime, TimeZone, Utc};
+use tokio::task::JoinSet;
 use std::io::SeekFrom;
 use std::ops::Deref;
 use std::path::Path;
@@ -54,6 +55,7 @@ pub struct Replicator {
     use_compression: CompressionKind,
     max_frames_per_batch: usize,
     s3_upload_max_parallelism: usize,
+    _join_set: JoinSet<()>,
 }
 
 #[derive(Debug)]
@@ -260,6 +262,8 @@ impl Replicator {
         let last_sent_frame_no = Arc::new(AtomicU32::new(0));
         let commits_in_current_generation = Arc::new(AtomicU32::new(0));
 
+        let mut _join_set = JoinSet::new();
+
         let (frames_outbox, mut frames_inbox) = tokio::sync::mpsc::channel(64);
         let _local_backup = {
             let mut copier = WalCopier::new(
@@ -274,7 +278,7 @@ impl Replicator {
             let next_frame_no = next_frame_no.clone();
             let last_sent_frame_no = last_sent_frame_no.clone();
             let batch_interval = options.max_batch_interval;
-            tokio::spawn(async move {
+            _join_set.spawn(async move {
                 loop {
                     let timeout = Instant::now() + batch_interval;
                     let trigger = match timeout_at(timeout, flush_trigger_rx.changed()).await {
@@ -309,8 +313,9 @@ impl Replicator {
             let client = client.clone();
             let bucket = options.bucket_name.clone();
             let max_parallelism = options.s3_upload_max_parallelism;
-            tokio::spawn(async move {
+            _join_set.spawn(async move {
                 let sem = Arc::new(tokio::sync::Semaphore::new(max_parallelism));
+                let mut join_set = JoinSet::new();
                 while let Some(fdesc) = frames_inbox.recv().await {
                     tracing::trace!("Received S3 upload request: {}", fdesc);
                     let start = Instant::now();
@@ -318,7 +323,7 @@ impl Replicator {
                     let permit = sem.acquire_owned().await.unwrap();
                     let client = client.clone();
                     let bucket = bucket.clone();
-                    tokio::spawn(async move {
+                    join_set.spawn(async move {
                         let fpath = format!("{}/{}", bucket, fdesc);
                         let body = ByteStream::from_path(&fpath).await.unwrap();
                         if let Err(e) = client
@@ -358,6 +363,7 @@ impl Replicator {
             use_compression: options.use_compression,
             max_frames_per_batch: options.max_frames_per_batch,
             s3_upload_max_parallelism: options.s3_upload_max_parallelism,
+            _join_set,
         })
     }
 

--- a/sqld/src/admin_api.rs
+++ b/sqld/src/admin_api.rs
@@ -31,6 +31,7 @@ pub async fn run_admin_api<F: MakeNamespace>(
             "/v1/namespaces/:namespace/create",
             post(handle_create_namespace),
         )
+        .route("/v1/namespaces/:namespace", delete(handle_delete_namespace))    
         .with_state(Arc::new(AppState {
             db_config_store,
             namespaces,
@@ -93,7 +94,7 @@ async fn handle_create_namespace<F: MakeNamespace>(
     State(app_state): State<Arc<AppState<F>>>,
     Path(namespace): Path<String>,
     Json(req): Json<CreateNamespaceReq>,
-) -> Result<(), crate::error::Error> {
+) -> create::Result<()> {
     let maybe_dump = match req.dump_url {
         Some(ref url) => Some(dump_stream_from_url(url).await?),
         None => None,
@@ -138,4 +139,11 @@ async fn dump_stream_from_url(url: &Url) -> Result<DumpStream, LoadDumpError> {
         }
         scheme => Err(LoadDumpError::UnsupportedUrlScheme(scheme.to_string())),
     }
+}
+
+async fn handle_delete_namespace<F: MakeNamespace>(
+    State(app_state): State<Arc<AppState<F>>>,
+    Path(namespace): Path<String>,
+) -> crate::Result<()> {
+    todo!();
 }

--- a/sqld/src/admin_api.rs
+++ b/sqld/src/admin_api.rs
@@ -1,6 +1,7 @@
 use anyhow::Context as _;
 use axum::extract::{Path, State};
 use axum::Json;
+use axum::routing::delete;
 use futures::TryStreamExt;
 use serde::Deserialize;
 use std::sync::Arc;
@@ -145,5 +146,6 @@ async fn handle_delete_namespace<F: MakeNamespace>(
     State(app_state): State<Arc<AppState<F>>>,
     Path(namespace): Path<String>,
 ) -> crate::Result<()> {
-    todo!();
+    app_state.namespaces.destroy(namespace.into()).await?;
+    Ok(())
 }

--- a/sqld/src/admin_api.rs
+++ b/sqld/src/admin_api.rs
@@ -32,7 +32,7 @@ pub async fn run_admin_api<F: MakeNamespace>(
             "/v1/namespaces/:namespace/create",
             post(handle_create_namespace),
         )
-        .route("/v1/namespaces/:namespace", delete(handle_delete_namespace))    
+        .route("/v1/namespaces/:namespace", delete(handle_delete_namespace))
         .with_state(Arc::new(AppState {
             db_config_store,
             namespaces,
@@ -95,7 +95,7 @@ async fn handle_create_namespace<F: MakeNamespace>(
     State(app_state): State<Arc<AppState<F>>>,
     Path(namespace): Path<String>,
     Json(req): Json<CreateNamespaceReq>,
-) -> create::Result<()> {
+) -> crate::Result<()> {
     let maybe_dump = match req.dump_url {
         Some(ref url) => Some(dump_stream_from_url(url).await?),
         None => None,

--- a/sqld/src/admin_api.rs
+++ b/sqld/src/admin_api.rs
@@ -1,7 +1,7 @@
 use anyhow::Context as _;
 use axum::extract::{Path, State};
-use axum::Json;
 use axum::routing::delete;
+use axum::Json;
 use futures::TryStreamExt;
 use serde::Deserialize;
 use std::sync::Arc;

--- a/sqld/src/database.rs
+++ b/sqld/src/database.rs
@@ -10,6 +10,7 @@ pub trait Database: Sync + Send + 'static {
     type Connection: Connection;
 
     fn connection_maker(&self) -> Arc<dyn MakeConnection<Connection = Self::Connection>>;
+    fn shutdown(&self);
 }
 
 pub struct ReplicaDatabase {
@@ -23,6 +24,8 @@ impl Database for ReplicaDatabase {
     fn connection_maker(&self) -> Arc<dyn MakeConnection<Connection = Self::Connection>> {
         self.connection_maker.clone()
     }
+
+    fn shutdown(&self) {}
 }
 
 pub struct PrimaryDatabase {
@@ -35,5 +38,9 @@ impl Database for PrimaryDatabase {
 
     fn connection_maker(&self) -> Arc<dyn MakeConnection<Connection = Self::Connection>> {
         self.connection_maker.clone()
+    }
+
+    fn shutdown(&self) {
+        self.logger.closed_signal.send_replace(true);
     }
 }

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -352,10 +352,10 @@ async fn start_replica(
                             std::str::from_utf8(&ns).ok()
                         );
                         namespaces.reset(ns).await?;
-                    },
+                    }
                     ResetOp::Destroy(ns) => {
                         namespaces.destroy(ns).await?;
-                    },
+                    }
                 }
             }
 

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -311,6 +311,11 @@ fn configure_rpc(config: &Config) -> anyhow::Result<(Channel, tonic::transport::
     Ok((channel, uri))
 }
 
+pub enum ResetOp {
+    Reset(Bytes),
+    Destroy(Bytes),
+}
+
 async fn start_replica(
     config: &Config,
     join_set: &mut JoinSet<anyhow::Result<()>>,
@@ -339,12 +344,19 @@ async fn start_replica(
     join_set.spawn({
         let namespaces = namespaces.clone();
         async move {
-            while let Some(ns) = hard_reset_rcv.recv().await {
-                tracing::warn!(
-                    "received reset signal for: {:?}",
-                    std::str::from_utf8(&ns).ok()
-                );
-                namespaces.reset(ns).await?;
+            while let Some(op) = hard_reset_rcv.recv().await {
+                match op {
+                    ResetOp::Reset(ns) => {
+                        tracing::warn!(
+                            "received reset signal for: {:?}",
+                            std::str::from_utf8(&ns).ok()
+                        );
+                        namespaces.reset(ns).await?;
+                    },
+                    ResetOp::Destroy(ns) => {
+                        namespaces.destroy(ns).await?;
+                    },
+                }
             }
 
             Ok(())

--- a/sqld/src/namespace.rs
+++ b/sqld/src/namespace.rs
@@ -27,7 +27,7 @@ use crate::replication::{NamespacedSnapshotCallback, ReplicationLogger};
 use crate::stats::Stats;
 use crate::{
     check_fresh_db, init_bottomless_replicator, run_periodic_compactions, DB_CREATE_TIMEOUT,
-    DEFAULT_AUTO_CHECKPOINT, DEFAULT_NAMESPACE_NAME, MAX_CONCURRENT_DBS,
+    DEFAULT_AUTO_CHECKPOINT, DEFAULT_NAMESPACE_NAME, MAX_CONCURRENT_DBS, ResetOp,
 };
 
 /// Creates a new `Namespace` for database of the `Self::Database` type.
@@ -255,7 +255,7 @@ pub struct ReplicaNamespaceConfig {
     /// hard reset sender.
     /// When a replica need to be wiped and recovered from scratch, its namespace
     /// is sent to this channel
-    pub hard_reset: mpsc::Sender<Bytes>,
+    pub hard_reset: mpsc::Sender<ResetOp>,
 }
 
 impl Namespace<ReplicaDatabase> {

--- a/sqld/src/namespace.rs
+++ b/sqld/src/namespace.rs
@@ -253,6 +253,7 @@ pub struct Namespace<T: Database> {
 
 impl<T: Database> Namespace<T> {
     async fn destroy(mut self) -> anyhow::Result<()> {
+        self.db.shutdown();
         self.tasks.shutdown().await;
 
         Ok(())

--- a/sqld/src/namespace.rs
+++ b/sqld/src/namespace.rs
@@ -394,6 +394,7 @@ impl Namespace<PrimaryDatabase> {
             } else {
                 DEFAULT_AUTO_CHECKPOINT
             };
+
         let logger = Arc::new(ReplicationLogger::open(
             &db_path,
             config.max_log_size,

--- a/sqld/src/replication/primary/frame_stream.rs
+++ b/sqld/src/replication/primary/frame_stream.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::Weak;
 use std::task::{ready, Poll};
 use std::{pin::Pin, task::Context};
 
@@ -13,25 +13,27 @@ use crate::replication::{FrameNo, LogReadError, ReplicationLogger};
 pub struct FrameStream {
     pub(crate) current_frame_no: FrameNo,
     pub(crate) max_available_frame_no: FrameNo,
-    logger: Arc<ReplicationLogger>,
+    logger: Weak<ReplicationLogger>,
     state: FrameStreamState,
     wait_for_more: bool,
 }
 
 impl FrameStream {
     pub fn new(
-        logger: Arc<ReplicationLogger>,
+        logger: Weak<ReplicationLogger>,
         current_frameno: FrameNo,
         wait_for_more: bool,
-    ) -> Self {
-        let max_available_frame_no = *logger.new_frame_notifier.subscribe().borrow();
-        Self {
+    ) -> crate::Result<Self> {
+        let Some(logger_arc) = logger.upgrade() else { todo!("logger closed") };
+        let max_available_frame_no = *logger_arc.new_frame_notifier.subscribe().borrow();
+
+        Ok(Self {
             current_frame_no: current_frameno,
             max_available_frame_no,
             logger,
             state: FrameStreamState::Init,
             wait_for_more,
-        }
+        })
     }
 
     fn transition_state_next_frame(&mut self) {
@@ -42,6 +44,7 @@ impl FrameStream {
         let next_frameno = self.current_frame_no;
         let logger = self.logger.clone();
         let fut = async move {
+            let Some(logger) = logger.upgrade() else { return Err(LogReadError::Error(anyhow::anyhow!("logger closed"))) };
             let res = tokio::task::spawn_blocking(move || logger.get_frame(next_frameno)).await;
             match res {
                 Ok(Ok(frame)) => Ok(frame),
@@ -97,7 +100,11 @@ impl Stream for FrameStream {
                         return Poll::Ready(None);
                     }
 
-                    let mut notifier = self.logger.new_frame_notifier.subscribe();
+                    let Some(logger) = self.logger.upgrade() else {
+                        return Poll::Ready(Some(Err(LogReadError::Error(anyhow::anyhow!("logger closed")))));
+                    };
+
+                    let mut notifier = logger.new_frame_notifier.subscribe();
                     let max_available_frame_no = *notifier.borrow();
                     // check in case value has already changed, otherwise we'll be notified later
                     if max_available_frame_no > self.max_available_frame_no {

--- a/sqld/src/replication/primary/frame_stream.rs
+++ b/sqld/src/replication/primary/frame_stream.rs
@@ -24,7 +24,7 @@ impl FrameStream {
         current_frameno: FrameNo,
         wait_for_more: bool,
     ) -> crate::Result<Self> {
-        let Some(logger_arc) = logger.upgrade() else { todo!("logger closed") };
+        let Some(logger_arc) = logger.upgrade() else { return Err(crate::error::Error::Internal("logger closed.".into())) };
         let max_available_frame_no = *logger_arc.new_frame_notifier.subscribe().borrow();
 
         Ok(Self {

--- a/sqld/src/replication/primary/frame_stream.rs
+++ b/sqld/src/replication/primary/frame_stream.rs
@@ -1,9 +1,9 @@
-use std::sync::Weak;
+use std::sync::Arc;
 use std::task::{ready, Poll};
 use std::{pin::Pin, task::Context};
 
 use futures::future::BoxFuture;
-use futures::Stream;
+use futures::{FutureExt, Stream};
 
 use crate::replication::frame::Frame;
 use crate::replication::{FrameNo, LogReadError, ReplicationLogger};
@@ -13,19 +13,24 @@ use crate::replication::{FrameNo, LogReadError, ReplicationLogger};
 pub struct FrameStream {
     pub(crate) current_frame_no: FrameNo,
     pub(crate) max_available_frame_no: FrameNo,
-    logger: Weak<ReplicationLogger>,
+    logger: Arc<ReplicationLogger>,
     state: FrameStreamState,
     wait_for_more: bool,
+    /// a future that resolves when the logger was closed.
+    logger_closed_fut: BoxFuture<'static, ()>,
 }
 
 impl FrameStream {
     pub fn new(
-        logger: Weak<ReplicationLogger>,
+        logger: Arc<ReplicationLogger>,
         current_frameno: FrameNo,
         wait_for_more: bool,
     ) -> crate::Result<Self> {
-        let Some(logger_arc) = logger.upgrade() else { return Err(crate::error::Error::Internal("logger closed.".into())) };
-        let max_available_frame_no = *logger_arc.new_frame_notifier.subscribe().borrow();
+        let max_available_frame_no = *logger.new_frame_notifier.subscribe().borrow();
+        let mut sub = logger.closed_signal.subscribe();
+        let logger_closed_fut = Box::pin(async move {
+            let _ = sub.wait_for(|x| *x).await;
+        });
 
         Ok(Self {
             current_frame_no: current_frameno,
@@ -33,6 +38,7 @@ impl FrameStream {
             logger,
             state: FrameStreamState::Init,
             wait_for_more,
+            logger_closed_fut,
         })
     }
 
@@ -44,7 +50,6 @@ impl FrameStream {
         let next_frameno = self.current_frame_no;
         let logger = self.logger.clone();
         let fut = async move {
-            let Some(logger) = logger.upgrade() else { return Err(LogReadError::Error(anyhow::anyhow!("logger closed"))) };
             let res = tokio::task::spawn_blocking(move || logger.get_frame(next_frameno)).await;
             match res {
                 Ok(Ok(frame)) => Ok(frame),
@@ -69,6 +74,12 @@ impl Stream for FrameStream {
     type Item = Result<Frame, LogReadError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.logger_closed_fut.poll_unpin(cx).is_ready() {
+            return Poll::Ready(Some(Err(LogReadError::Error(anyhow::anyhow!(
+                "logger closed"
+            )))));
+        }
+
         match self.state {
             FrameStreamState::Init => {
                 self.transition_state_next_frame();
@@ -100,11 +111,7 @@ impl Stream for FrameStream {
                         return Poll::Ready(None);
                     }
 
-                    let Some(logger) = self.logger.upgrade() else {
-                        return Poll::Ready(Some(Err(LogReadError::Error(anyhow::anyhow!("logger closed")))));
-                    };
-
-                    let mut notifier = logger.new_frame_notifier.subscribe();
+                    let mut notifier = self.logger.new_frame_notifier.subscribe();
                     let max_available_frame_no = *notifier.borrow();
                     // check in case value has already changed, otherwise we'll be notified later
                     if max_available_frame_no > self.max_available_frame_no {

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -716,6 +716,7 @@ pub struct ReplicationLogger {
     /// a notifier channel other tasks can subscribe to, and get notified when new frames become
     /// available.
     pub new_frame_notifier: watch::Sender<FrameNo>,
+    pub closed_signal: watch::Sender<bool>,
     pub auto_checkpoint: u32,
 }
 
@@ -786,11 +787,15 @@ impl ReplicationLogger {
                 tracing::info!("SQLite autocheckpoint: {}", auto_checkpoint);
             }
         }
+
+        let (closed_signal, _) = watch::channel(false);
+
         Ok(Self {
             generation: Generation::new(generation_start_frame_no),
             compactor: LogCompactor::new(&db_path, log_file.header.db_id, callback)?,
             log_file: RwLock::new(log_file),
             db_path,
+            closed_signal,
             new_frame_notifier,
             auto_checkpoint,
         })

--- a/sqld/src/replication/replica/replicator.rs
+++ b/sqld/src/replication/replica/replicator.rs
@@ -12,6 +12,7 @@ use tonic::metadata::AsciiMetadataValue;
 use tonic::transport::Channel;
 use tonic::{Code, Request};
 
+use crate::ResetOp;
 use crate::replication::frame::Frame;
 use crate::replication::replica::error::ReplicationError;
 use crate::replication::replica::snapshot::TempSnapshot;
@@ -41,7 +42,7 @@ pub struct Replicator {
     pub current_frame_no_notifier: watch::Receiver<FrameNo>,
     frames_sender: mpsc::Sender<Frames>,
     /// hard reset channel: send the namespace there, to reset it
-    hard_reset: mpsc::Sender<Bytes>,
+    hard_reset: mpsc::Sender<ResetOp>,
 }
 
 impl Replicator {
@@ -51,7 +52,7 @@ impl Replicator {
         uri: tonic::transport::Uri,
         namespace: Bytes,
         join_set: &mut JoinSet<anyhow::Result<()>>,
-        hard_reset: mpsc::Sender<Bytes>,
+        hard_reset: mpsc::Sender<ResetOp>,
     ) -> anyhow::Result<Self> {
         let client = Client::with_origin(channel, uri);
         let (applied_frame_notifier, current_frame_no_notifier) = watch::channel(FrameNo::MAX);
@@ -154,7 +155,7 @@ impl Replicator {
             ReplicationError::Lagging => {
                 tracing::error!("Replica ahead of primary: hard-reseting replica");
                 self.hard_reset
-                    .send(self.namespace.clone())
+                    .send(ResetOp::Reset(self.namespace.clone()))
                     .await
                     .expect("reset loop exited");
 
@@ -165,7 +166,7 @@ impl Replicator {
                     "Primary is attempting to replicate a different database, overwriting replica."
                 );
                 self.hard_reset
-                    .send(self.namespace.clone())
+                    .send(ResetOp::Reset(self.namespace.clone()))
                     .await
                     .expect("reset loop exited");
 
@@ -207,7 +208,8 @@ impl Replicator {
                     if e.code() == Code::FailedPrecondition
                         && e.message() == NAMESPACE_DOESNT_EXIST =>
                 {
-                    dbg!();
+                    tracing::info!("namespace `{}` doesn't exist, cleaning...", std::str::from_utf8(&self.namespace).unwrap_or_default());
+                    let _ = self.hard_reset.send(ResetOp::Destroy(self.namespace.clone())).await;
                     return Err(crate::error::Error::NamespaceDoesntExist(
                         String::from_utf8(self.namespace.to_vec()).unwrap_or_default(),
                     ));

--- a/sqld/src/replication/replica/replicator.rs
+++ b/sqld/src/replication/replica/replicator.rs
@@ -207,6 +207,7 @@ impl Replicator {
                     if e.code() == Code::FailedPrecondition
                         && e.message() == NAMESPACE_DOESNT_EXIST =>
                 {
+                    dbg!();
                     return Err(crate::error::Error::NamespaceDoesntExist(
                         String::from_utf8(self.namespace.to_vec()).unwrap_or_default(),
                     ));

--- a/sqld/src/rpc/replication_log.rs
+++ b/sqld/src/rpc/replication_log.rs
@@ -172,7 +172,7 @@ impl ReplicationLog for ReplicationLogService {
             FrameStream::new(Arc::downgrade(&logger), req.next_offset, true).unwrap(),
             self.idle_shutdown_layer.clone(),
         )
-            .map(map_frame_stream_output);
+        .map(map_frame_stream_output);
 
         Ok(tonic::Response::new(Box::pin(stream)))
     }

--- a/sqld/src/rpc/replication_log.rs
+++ b/sqld/src/rpc/replication_log.rs
@@ -169,7 +169,8 @@ impl ReplicationLog for ReplicationLogService {
             })?;
 
         let stream = StreamGuard::new(
-            FrameStream::new(Arc::downgrade(&logger), req.next_offset, true).unwrap(),
+            FrameStream::new(Arc::downgrade(&logger), req.next_offset, true)
+                .map_err(|e| Status::internal(e.to_string()))?,
             self.idle_shutdown_layer.clone(),
         )
         .map(map_frame_stream_output);
@@ -208,7 +209,8 @@ impl ReplicationLog for ReplicationLogService {
             })?;
 
         let frames = StreamGuard::new(
-            FrameStream::new(Arc::downgrade(&logger), req.next_offset, false).unwrap(),
+            FrameStream::new(Arc::downgrade(&logger), req.next_offset, false)
+                .map_err(|e| Status::internal(e.to_string()))?,
             self.idle_shutdown_layer.clone(),
         )
         .map(map_frame_stream_output)

--- a/sqld/src/rpc/replication_log.rs
+++ b/sqld/src/rpc/replication_log.rs
@@ -169,7 +169,7 @@ impl ReplicationLog for ReplicationLogService {
             })?;
 
         let stream = StreamGuard::new(
-            FrameStream::new(Arc::downgrade(&logger), req.next_offset, true)
+            FrameStream::new(logger, req.next_offset, true)
                 .map_err(|e| Status::internal(e.to_string()))?,
             self.idle_shutdown_layer.clone(),
         )
@@ -209,7 +209,7 @@ impl ReplicationLog for ReplicationLogService {
             })?;
 
         let frames = StreamGuard::new(
-            FrameStream::new(Arc::downgrade(&logger), req.next_offset, false)
+            FrameStream::new(logger, req.next_offset, false)
                 .map_err(|e| Status::internal(e.to_string()))?,
             self.idle_shutdown_layer.clone(),
         )

--- a/sqld/src/rpc/replication_log.rs
+++ b/sqld/src/rpc/replication_log.rs
@@ -169,10 +169,10 @@ impl ReplicationLog for ReplicationLogService {
             })?;
 
         let stream = StreamGuard::new(
-            FrameStream::new(logger, req.next_offset, true),
+            FrameStream::new(Arc::downgrade(&logger), req.next_offset, true).unwrap(),
             self.idle_shutdown_layer.clone(),
         )
-        .map(map_frame_stream_output);
+            .map(map_frame_stream_output);
 
         Ok(tonic::Response::new(Box::pin(stream)))
     }
@@ -208,7 +208,7 @@ impl ReplicationLog for ReplicationLogService {
             })?;
 
         let frames = StreamGuard::new(
-            FrameStream::new(logger.clone(), req.next_offset, false),
+            FrameStream::new(Arc::downgrade(&logger), req.next_offset, false).unwrap(),
             self.idle_shutdown_layer.clone(),
         )
         .map(map_frame_stream_output)


### PR DESCRIPTION
enable namespace deletion with the `DELETE /v1/namespaces/:namespaces` on the primary admin API.

Deleting a namespace on the primary releases all resources associated with that namespace, and removes the namespace directory and the backup from bottomless.

Once the namespace is removed from the primary, any replica attempting to replicate will get a `namespace_doesnt_exist` error, and will in turn remove all resources associated with that namespace.