### PR TITLE
rework namespace creation API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4467,6 +4467,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -23,6 +23,7 @@ crossbeam = "0.8.2"
 enclose = "1.1"
 fallible-iterator = "0.3.0"
 futures = "0.3.25"
+futures-core = "0.3"
 hmac = "0.12"
 hyper = { version = "0.14.23", features = ["http2"] }
 hyper-tungstenite = "0.10"
@@ -39,6 +40,7 @@ rand = "0.8"
 regex = "1.7.0"
 reqwest = { version = "0.11.16", features = ["json", "rustls-tls"], default-features = false }
 rusqlite = { workspace = true }
+semver = "1.0.18"
 serde = { version = "1.0.149", features = ["derive", "rc"] }
 serde_json = { version = "1.0.91", features = ["preserve_order"] }
 sha2 = "0.10"
@@ -50,17 +52,16 @@ thiserror = "1.0.38"
 tokio = { version = "1.22.2", features = ["rt-multi-thread", "net", "io-std", "io-util", "time", "macros", "sync", "fs", "signal"] }
 tokio-stream = "0.1.11"
 tokio-tungstenite = "0.19"
+tokio-util = { version = "0.7.8", features = ["io"] }
 tonic = { version = "0.9.2", features = ["tls"] }
 tonic-web = "0.9"
 tower = { version = "0.4.13", features = ["make"] }
 tower-http = { version = "0.3.5", features = ["compression-full", "cors", "trace"] }
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 tracing-panic = "0.1"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+url = { version = "2.3", features = ["serde"] }
 uuid = { version = "1.3", features = ["v4", "serde"] }
-futures-core = "0.3"
-tokio-util = { version = "0.7.8", features = ["io"] }
-semver = "1.0.18"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/sqld/src/admin_api.rs
+++ b/sqld/src/admin_api.rs
@@ -1,13 +1,17 @@
 use anyhow::Context as _;
-use axum::extract::{BodyStream, Path, State};
+use axum::extract::{Path, State};
 use axum::Json;
+use futures::future::OptionFuture;
 use futures::TryStreamExt;
 use serde::Deserialize;
 use std::sync::Arc;
 use std::{io::ErrorKind, net::SocketAddr};
+use tokio_util::io::ReaderStream;
+use url::Url;
 
 use crate::connection::config::{DatabaseConfig, DatabaseConfigStore};
-use crate::namespace::{MakeNamespace, NamespaceStore};
+use crate::error::LoadDumpError;
+use crate::namespace::{DumpStream, MakeNamespace, NamespaceStore};
 
 struct AppState<F: MakeNamespace> {
     db_config_store: Arc<DatabaseConfigStore>,
@@ -24,10 +28,6 @@ pub async fn run_admin_api<F: MakeNamespace>(
         .route("/", get(handle_get_index))
         .route("/v1/config", get(handle_get_config))
         .route("/v1/block", post(handle_post_block))
-        .route(
-            "/v1/namespaces/:namespace/create-with-dump",
-            post(handle_create_namespace_with_dump),
-        )
         .route(
             "/v1/namespaces/:namespace/create",
             post(handle_create_namespace),
@@ -67,6 +67,11 @@ struct BlockReq {
     block_reason: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct CreateNamespaceReq {
+    dump_url: Option<Url>,
+}
+
 async fn handle_post_block<F: MakeNamespace>(
     State(app_state): State<Arc<AppState<F>>>,
     Json(req): Json<BlockReq>,
@@ -85,23 +90,63 @@ async fn handle_post_block<F: MakeNamespace>(
     }
 }
 
-async fn handle_create_namespace_with_dump<F: MakeNamespace>(
-    State(app_state): State<Arc<AppState<F>>>,
-    Path(namespace): Path<String>,
-    body: BodyStream,
-) -> Result<(), crate::error::Error> {
-    let dump = Box::new(body.map_err(|e| std::io::Error::new(ErrorKind::Other, e)));
-    app_state
-        .namespaces
-        .create(namespace.into(), Some(dump))
-        .await?;
-    Ok(())
-}
+// async fn handle_create_namespace_with_dump<F: MakeNamespace>(
+//     State(app_state): State<Arc<AppState<F>>>,
+//     Path(namespace): Path<String>,
+//     body: BodyStream,
+// ) -> Result<(), crate::error::Error> {
+//     let dump = Box::new(body.map_err(|e| std::io::Error::new(ErrorKind::Other, e)));
+//     app_state
+//         .namespaces
+//         .create(namespace.into(), Some(dump))
+//         .await?;
+//     Ok(())
+// }
 
 async fn handle_create_namespace<F: MakeNamespace>(
     State(app_state): State<Arc<AppState<F>>>,
     Path(namespace): Path<String>,
+    Json(req): Json<CreateNamespaceReq>,
 ) -> Result<(), crate::error::Error> {
-    app_state.namespaces.create(namespace.into(), None).await?;
+    let maybe_dump: Option<DumpStream> =
+        OptionFuture::from(req.dump_url.as_ref().map(dump_stream_from_url))
+            .await
+            .transpose()?;
+    app_state
+        .namespaces
+        .create(namespace.into(), maybe_dump)
+        .await?;
     Ok(())
+}
+
+async fn dump_stream_from_url(url: &Url) -> Result<DumpStream, LoadDumpError> {
+    match url.scheme() {
+        "http" => {
+            let client = hyper::client::Client::new();
+            let uri = url
+                .as_str()
+                .parse()
+                .map_err(|_| LoadDumpError::InvalidDumpUrl)?;
+            let resp = client.get(uri).await?;
+            let body = resp
+                .into_body()
+                .map_err(|e| std::io::Error::new(ErrorKind::Other, e));
+            Ok(Box::new(body))
+        }
+        "file" => {
+            let path = url.to_file_path().map_err(|_| LoadDumpError::InvalidDumpUrl)?;
+            if !path.is_absolute() {
+                return Err(LoadDumpError::DumpFilePathNotAbsolute);
+            }
+
+            if !path.try_exists()? {
+                return Err(LoadDumpError::DumpFileDoesntExist);
+            }
+
+            let f = tokio::fs::File::open(path).await?;
+
+            Ok(Box::new(ReaderStream::new(f)))
+        }
+        _ => todo!("unsupported url scheme"),
+    }
 }

--- a/sqld/src/admin_api.rs
+++ b/sqld/src/admin_api.rs
@@ -90,19 +90,6 @@ async fn handle_post_block<F: MakeNamespace>(
     }
 }
 
-// async fn handle_create_namespace_with_dump<F: MakeNamespace>(
-//     State(app_state): State<Arc<AppState<F>>>,
-//     Path(namespace): Path<String>,
-//     body: BodyStream,
-// ) -> Result<(), crate::error::Error> {
-//     let dump = Box::new(body.map_err(|e| std::io::Error::new(ErrorKind::Other, e)));
-//     app_state
-//         .namespaces
-//         .create(namespace.into(), Some(dump))
-//         .await?;
-//     Ok(())
-// }
-
 async fn handle_create_namespace<F: MakeNamespace>(
     State(app_state): State<Arc<AppState<F>>>,
     Path(namespace): Path<String>,

--- a/sqld/src/admin_api.rs
+++ b/sqld/src/admin_api.rs
@@ -134,7 +134,9 @@ async fn dump_stream_from_url(url: &Url) -> Result<DumpStream, LoadDumpError> {
             Ok(Box::new(body))
         }
         "file" => {
-            let path = url.to_file_path().map_err(|_| LoadDumpError::InvalidDumpUrl)?;
+            let path = url
+                .to_file_path()
+                .map_err(|_| LoadDumpError::InvalidDumpUrl)?;
             if !path.is_absolute() {
                 return Err(LoadDumpError::DumpFilePathNotAbsolute);
             }

--- a/sqld/src/error.rs
+++ b/sqld/src/error.rs
@@ -147,6 +147,8 @@ pub enum LoadDumpError {
     InvalidDumpUrl,
     #[error("error fetching dump: {0}")]
     Fetch(#[from] hyper::Error),
+    #[error("unsupported dump url scheme `{0}`, supported schemes are: `http`, `file`")]
+    UnsupportedUrlScheme(String),
 }
 
 impl ResponseError for LoadDumpError {}
@@ -161,6 +163,7 @@ impl IntoResponse for LoadDumpError {
             | LoadDumpExistingDb
             | InvalidDumpUrl
             | DumpFileDoesntExist
+            | UnsupportedUrlScheme(_)
             | DumpFilePathNotAbsolute => self.format_err(StatusCode::BAD_REQUEST),
         }
     }

--- a/sqld/src/error.rs
+++ b/sqld/src/error.rs
@@ -66,13 +66,11 @@ pub enum Error {
     ReplicationError(#[from] ReplicationError),
     #[error("Failed to connect to primary")]
     PrimaryConnectionTimeout,
-    #[error("Cannot load a dump on a replica")]
-    ReplicaLoadDump,
-    #[error("cannot load from a dump if a database already exists.")]
-    LoadDumpExistingDb,
+    #[error("Error while loading dump: {0}")]
+    LoadDumpError(#[from] LoadDumpError),
 }
 
-impl Error {
+trait ResponseError: std::error::Error {
     fn format_err(&self, status: StatusCode) -> axum::response::Response {
         let json = serde_json::json!({ "error": self.to_string() });
         tracing::error!("HTTP API: {}, {}", status, json);
@@ -80,11 +78,13 @@ impl Error {
     }
 }
 
+impl ResponseError for Error {}
+
 impl IntoResponse for Error {
     fn into_response(self) -> axum::response::Response {
         use Error::*;
 
-        match &self {
+        match self {
             FailedToParse(_) => self.format_err(StatusCode::BAD_REQUEST),
             AuthError(_) => self.format_err(StatusCode::UNAUTHORIZED),
             Anyhow(_) => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
@@ -112,8 +112,7 @@ impl IntoResponse for Error {
             PrimaryConnectionTimeout => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
             NamespaceAlreadyExist(_) => self.format_err(StatusCode::BAD_REQUEST),
             InvalidNamespace => self.format_err(StatusCode::BAD_REQUEST),
-            ReplicaLoadDump => self.format_err(StatusCode::BAD_REQUEST),
-            LoadDumpExistingDb => self.format_err(StatusCode::BAD_REQUEST),
+            LoadDumpError(e) => e.into_response(),
         }
     }
 }
@@ -129,5 +128,40 @@ impl From<tokio::sync::oneshot::error::RecvError> for Error {
 impl From<bincode::Error> for Error {
     fn from(other: bincode::Error) -> Self {
         Self::Internal(other.to_string())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LoadDumpError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Cannot load a dump on a replica")]
+    ReplicaLoadDump,
+    #[error("cannot load from a dump if a database already exists")]
+    LoadDumpExistingDb,
+    #[error("the passed dump file path is not absolute")]
+    DumpFilePathNotAbsolute,
+    #[error("the passed dump file path doesn't exist")]
+    DumpFileDoesntExist,
+    #[error("invalid dump url")]
+    InvalidDumpUrl,
+    #[error("error fetching dump: {0}")]
+    Fetch(#[from] hyper::Error),
+}
+
+impl ResponseError for LoadDumpError {}
+
+impl IntoResponse for LoadDumpError {
+    fn into_response(self) -> axum::response::Response {
+        use LoadDumpError::*;
+
+        match &self {
+            Io(_) | Fetch(_) => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
+            ReplicaLoadDump
+            | LoadDumpExistingDb
+            | InvalidDumpUrl
+            | DumpFileDoesntExist
+            | DumpFilePathNotAbsolute => self.format_err(StatusCode::BAD_REQUEST),
+        }
     }
 }


### PR DESCRIPTION
This PR makes changes to the namespace creation API. Namely, it:

- the `create-with-dump` route is dropped
- the `create` route takes a payload:
```json
{
    "dump_url": string | null,
}

```

the `dump_url` is either an HTTP url pointing to the dump to be loaded, or, a `file` url, with an absolute path to the dump file.
