### PR TITLE
Revert "libsql-bindings: auto-finalize dangling statements (#523)"

### DIFF
--- a/sqld-libsql-bindings/src/lib.rs
+++ b/sqld-libsql-bindings/src/lib.rs
@@ -35,25 +35,6 @@ impl Deref for Connection<'_> {
     }
 }
 
-impl Drop for Connection<'_> {
-    fn drop(&mut self) {
-        unsafe {
-            let db = self.conn.handle();
-            if db.is_null() {
-                return;
-            }
-            let mut stmt = ffi::sqlite3_next_stmt(db, std::ptr::null_mut());
-            while !stmt.is_null() {
-                let rc = ffi::sqlite3_finalize(stmt);
-                if rc != ffi::SQLITE_OK {
-                    tracing::error!("Failed to finalize a dangling statement: {rc}")
-                }
-                stmt = ffi::sqlite3_next_stmt(db, stmt);
-            }
-        }
-    }
-}
-
 impl<'a> Connection<'a> {
     /// returns a dummy, in-memory connection. For testing purposes only
     pub fn test(_: &mut ()) -> Self {


### PR DESCRIPTION
This reverts commit 8b75dc886a2f1359bea12938afd9c8b8545cbf4f. It interacts badly with FTS5 extension, which also decided to finalize statements on its own.