### PR TITLE
sqld: Add replica `ReplicaProxy`

### DIFF
--- a/sqld/src/rpc/mod.rs
+++ b/sqld/src/rpc/mod.rs
@@ -12,6 +12,7 @@ use crate::rpc::replication_log::ReplicationLogService;
 use crate::utils::services::idle_shutdown::IdleShutdownLayer;
 
 pub mod proxy;
+pub mod replica_proxy;
 pub mod replication_log;
 pub mod replication_log_proxy;
 

--- a/sqld/src/rpc/replica_proxy.rs
+++ b/sqld/src/rpc/replica_proxy.rs
@@ -1,0 +1,37 @@
+use hyper::Uri;
+use tonic::transport::Channel;
+
+use super::proxy::rpc::{
+    self, proxy_client::ProxyClient, proxy_server::Proxy, Ack, DisconnectMessage, ExecuteResults,
+};
+
+pub struct ReplicaProxyService {
+    client: ProxyClient<Channel>,
+}
+
+impl ReplicaProxyService {
+    pub fn new(channel: Channel, uri: Uri) -> Self {
+        let client = ProxyClient::with_origin(channel, uri);
+        Self { client }
+    }
+}
+
+#[tonic::async_trait]
+impl Proxy for ReplicaProxyService {
+    async fn execute(
+        &self,
+        req: tonic::Request<rpc::ProgramReq>,
+    ) -> Result<tonic::Response<ExecuteResults>, tonic::Status> {
+        let mut client = self.client.clone();
+        client.execute(req).await
+    }
+
+    //TODO: also handle cleanup on peer disconnect
+    async fn disconnect(
+        &self,
+        msg: tonic::Request<DisconnectMessage>,
+    ) -> Result<tonic::Response<Ack>, tonic::Status> {
+        let mut client = self.client.clone();
+        client.disconnect(msg).await
+    }
+}


### PR DESCRIPTION
This adds a proxy for the write proxy api. This will pass through all `Proxy` based requests directly to the primary.