### PR TITLE
Namespace forking

### DIFF
--- a/bottomless/src/lib.rs
+++ b/bottomless/src/lib.rs
@@ -415,7 +415,7 @@ pub extern "C" fn xGetPathname(buf: *mut c_char, orig: *const c_char, orig_len: 
 
 async fn try_restore(replicator: &mut replicator::Replicator) -> i32 {
     match replicator.restore(None, None).await {
-        Ok(replicator::RestoreAction::SnapshotMainDbFile) => {
+        Ok((replicator::RestoreAction::SnapshotMainDbFile, _)) => {
             replicator.new_generation();
             match replicator.snapshot_main_db_file(None).await {
                 Ok(Some(h)) => {
@@ -437,7 +437,7 @@ async fn try_restore(replicator: &mut replicator::Replicator) -> i32 {
                 return ffi::SQLITE_CANTOPEN;
             }
         }
-        Ok(replicator::RestoreAction::ReuseGeneration(gen)) => {
+        Ok((replicator::RestoreAction::ReuseGeneration(gen), _)) => {
             replicator.set_generation(gen);
         }
         Err(e) => {

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -962,7 +962,8 @@ impl Replicator {
         Some((first_frame_no, last_frame_no, timestamp, compression_kind))
     }
 
-    // Restores the database state from given remote generation
+    /// Restores the database state from given remote generation
+    /// On success, returns the RestoreAction, and whether the database was recovered from backup.
     async fn restore_from(
         &mut self,
         generation: Uuid,
@@ -1299,7 +1300,8 @@ impl Replicator {
         Ok(())
     }
 
-    // Restores the database state from newest remote generation
+    /// Restores the database state from newest remote generation
+    /// On success, returns the RestoreAction, and whether the database was recovered from backup.
     pub async fn restore(
         &mut self,
         generation: Option<Uuid>,

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -967,7 +967,7 @@ impl Replicator {
         &mut self,
         generation: Uuid,
         utc_time: Option<NaiveDateTime>,
-    ) -> Result<RestoreAction> {
+    ) -> Result<(RestoreAction, bool)> {
         if let Some(tombstone) = self.get_tombstone().await? {
             if let Some(timestamp) = Self::generation_to_timestamp(&generation) {
                 if tombstone.timestamp() as u64 >= timestamp.to_unix().0 {
@@ -989,7 +989,7 @@ impl Replicator {
         let last_frame = self.get_last_consistent_frame(&generation).await?;
         tracing::debug!("Last consistent remote frame in generation {generation}: {last_frame}.");
         if let Some(action) = self.compare_with_local(generation, last_frame).await? {
-            return Ok(action);
+            return Ok((action, false));
         }
 
         // at this point we know, we should do a full restore
@@ -1071,11 +1071,11 @@ impl Replicator {
 
         if applied_wal_frame {
             tracing::info!("WAL file has been applied onto database file in generation {}. Requesting snapshot.", generation);
-            Ok::<_, anyhow::Error>(RestoreAction::SnapshotMainDbFile)
+            Ok::<_, anyhow::Error>((RestoreAction::SnapshotMainDbFile, true))
         } else {
             tracing::info!("Reusing generation {}.", generation);
             // since WAL was not applied, we can reuse the latest generation
-            Ok::<_, anyhow::Error>(RestoreAction::ReuseGeneration(generation))
+            Ok::<_, anyhow::Error>((RestoreAction::ReuseGeneration(generation), true))
         }
     }
 
@@ -1304,14 +1304,14 @@ impl Replicator {
         &mut self,
         generation: Option<Uuid>,
         timestamp: Option<NaiveDateTime>,
-    ) -> Result<RestoreAction> {
+    ) -> Result<(RestoreAction, bool)> {
         let generation = match generation {
             Some(gen) => gen,
             None => match self.latest_generation_before(timestamp.as_ref()).await {
                 Some(gen) => gen,
                 None => {
                     tracing::debug!("No generation found, nothing to restore");
-                    return Ok(RestoreAction::SnapshotMainDbFile);
+                    return Ok((RestoreAction::SnapshotMainDbFile, false));
                 }
             },
         };

--- a/sqld/src/admin_api.rs
+++ b/sqld/src/admin_api.rs
@@ -31,6 +31,10 @@ pub async fn run_admin_api<M: MakeNamespace>(
         .route("/v1/config", get(handle_get_config))
         .route("/v1/block", post(handle_post_block))
         .route(
+            "/v1/namespaces/:namespace/fork/:to",
+            post(handle_fork_namespace),
+        )
+        .route(
             "/v1/namespaces/:namespace/create",
             post(handle_create_namespace),
         )
@@ -39,7 +43,6 @@ pub async fn run_admin_api<M: MakeNamespace>(
             post(handle_restore_namespace),
         )
         .route("/v1/namespaces/:namespace", delete(handle_delete_namespace))
-        .route("/v1/namespaces/:from/fork/:to", post(handle_fork_namespace))
         .with_state(Arc::new(AppState {
             db_config_store,
             namespaces,

--- a/sqld/src/admin_api.rs
+++ b/sqld/src/admin_api.rs
@@ -113,10 +113,11 @@ async fn handle_create_namespace<M: MakeNamespace>(
 }
 
 async fn handle_fork_namespace<M: MakeNamespace>(
-    State(_app_state): State<Arc<AppState<M>>>,
-    Path((_from, _to)): Path<(String, String)>,
+    State(app_state): State<Arc<AppState<M>>>,
+    Path((from, to)): Path<(String, String)>,
 ) -> crate::Result<()> {
-    todo!()
+    app_state.namespaces.fork(from.into(), to.into()).await?;
+    Ok(())
 }
 
 async fn dump_stream_from_url(url: &Url) -> Result<DumpStream, LoadDumpError> {

--- a/sqld/src/error.rs
+++ b/sqld/src/error.rs
@@ -3,8 +3,8 @@ use hyper::StatusCode;
 use tonic::metadata::errors::InvalidMetadataValueBytes;
 
 use crate::{
-    auth::AuthError, query_result_builder::QueryResultBuilderError,
-    replication::replica::error::ReplicationError, namespace::ForkError,
+    auth::AuthError, namespace::ForkError, query_result_builder::QueryResultBuilderError,
+    replication::replica::error::ReplicationError,
 };
 
 #[allow(clippy::enum_variant_names)]
@@ -184,7 +184,6 @@ impl IntoResponse for LoadDumpError {
         }
     }
 }
-
 
 impl ResponseError for ForkError {}
 

--- a/sqld/src/error.rs
+++ b/sqld/src/error.rs
@@ -189,6 +189,12 @@ impl ResponseError for ForkError {}
 
 impl IntoResponse for ForkError {
     fn into_response(self) -> axum::response::Response {
-        self.format_err(StatusCode::INTERNAL_SERVER_ERROR)
+        match self {
+            ForkError::Internal(_)
+            | ForkError::Io(_)
+            | ForkError::LogRead(_)
+            | ForkError::CreateNamespace(_) => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
+            ForkError::ForkReplica => self.format_err(StatusCode::BAD_REQUEST),
+        }
     }
 }

--- a/sqld/src/namespace.rs
+++ b/sqld/src/namespace.rs
@@ -213,6 +213,10 @@ impl<F: MakeNamespace> NamespaceStore<F> {
         }
     }
 
+    pub async fn fork(&self, _from: Bytes, _to: Bytes) -> crate::Result<()> {
+        todo!()
+    }
+
     pub async fn with<Fun, R>(&self, namespace: Bytes, f: Fun) -> crate::Result<R>
     where
         Fun: FnOnce(&Namespace<F::Database>) -> R,

--- a/sqld/src/namespace/fork.rs
+++ b/sqld/src/namespace/fork.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
-use tokio::io::{AsyncSeekExt, AsyncWriteExt};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio_stream::StreamExt;
 
 use crate::database::PrimaryDatabase;
@@ -124,8 +124,9 @@ impl ForkTask<'_> {
             .join(std::str::from_utf8(&self.dest_namespace).unwrap());
         tokio::fs::rename(temp_dir.path(), dest_path).await?;
 
+        tokio::io::stdin().read_i8().await.unwrap();
         self.make_namespace
-            .create(self.dest_namespace.clone(), RestoreOption::Latest, false)
+            .create(self.dest_namespace.clone(), RestoreOption::Latest, true)
             .await
             .map_err(|e| ForkError::CreateNamespace(Box::new(e)))
     }

--- a/sqld/src/namespace/fork.rs
+++ b/sqld/src/namespace/fork.rs
@@ -1,0 +1,126 @@
+use std::io::SeekFrom;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use tokio::io::{AsyncSeekExt, AsyncWriteExt};
+use tokio_stream::StreamExt;
+
+use crate::database::PrimaryDatabase;
+use crate::replication::frame::Frame;
+use crate::replication::primary::frame_stream::FrameStream;
+use crate::replication::{LogReadError, ReplicationLogger};
+
+use super::MakeNamespace;
+
+// FIXME: get this const from somewhere else (crate wide)
+const PAGE_SIZE: usize = 4096;
+
+type Result<T> = crate::Result<T, ForkError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ForkError {
+    #[error("internal error: {0}")]
+    Internal(anyhow::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("failed to read frame from replication log: {0}")]
+    LogRead(anyhow::Error),
+    #[error("an error occured creating the namespace: {0}")]
+    CreateNamespace(Box<crate::error::Error>),
+}
+
+impl From<tokio::task::JoinError> for ForkError {
+    fn from(e: tokio::task::JoinError) -> Self {
+        Self::Internal(e.into())
+    }
+}
+
+async fn write_frame(frame: Frame, temp_file: &mut tokio::fs::File) -> Result<()> {
+    let page_no = frame.header().page_no;
+    let page_pos = (page_no - 1) as usize * PAGE_SIZE;
+    temp_file.seek(SeekFrom::Start(page_pos as u64)).await?;
+    temp_file.write_all(frame.page()).await?;
+
+    Ok(())
+}
+
+pub struct ForkTask<'a> {
+    pub base_path: PathBuf,
+    pub logger: Arc<ReplicationLogger>,
+    pub dest_namespace: Bytes,
+    pub make_namespace: &'a dyn MakeNamespace<Database = PrimaryDatabase>,
+}
+
+impl ForkTask<'_> {
+    pub async fn fork(self) -> Result<super::Namespace<PrimaryDatabase>> {
+        match self.try_fork().await {
+            Err(e) => {
+                let _ = tokio::fs::remove_dir_all(
+                    self.base_path
+                        .join("dbs")
+                        .join(std::str::from_utf8(&self.dest_namespace).unwrap()),
+                )
+                .await;
+                Err(e)
+            }
+            Ok(ns) => Ok(ns),
+        }
+    }
+
+    async fn try_fork(&self) -> Result<super::Namespace<PrimaryDatabase>> {
+        // until what index to replicate
+        let base_path = self.base_path.clone();
+        let temp_dir =
+            tokio::task::spawn_blocking(move || tempfile::tempdir_in(base_path)).await??;
+        let mut data_file = tokio::fs::File::create(temp_dir.path().join("data")).await?;
+
+        let logger = self.logger.clone();
+        let end_frame_no = *logger.new_frame_notifier.borrow();
+        let mut next_frame_no = 0;
+        while next_frame_no < end_frame_no {
+            let mut streamer = FrameStream::new(logger.clone(), next_frame_no, false);
+            while let Some(res) = streamer.next().await {
+                match res {
+                    Ok(frame) => {
+                        next_frame_no = next_frame_no.max(frame.header().frame_no + 1);
+                        write_frame(frame, &mut data_file).await?;
+                    }
+                    Err(LogReadError::SnapshotRequired) => {
+                        let snapshot = loop {
+                            if let Some(snap) = logger.get_snapshot_file(next_frame_no).map_err(ForkError::Internal)? {
+                                break snap;
+                            }
+
+                            // the snapshot must exist, it is just not yet available.
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                        };
+
+                        let iter = snapshot.frames_iter_from(next_frame_no);
+                        for frame in iter {
+                            let frame = frame.map_err(ForkError::LogRead)?;
+                            next_frame_no = next_frame_no.max(frame.header().frame_no + 1);
+                            write_frame(frame, &mut data_file).await?;
+                        }
+                    }
+                    Err(LogReadError::Ahead) => {
+                        unreachable!("trying to fork ahead of the forked database!")
+                    }
+                    Err(LogReadError::Error(e)) => return Err(ForkError::LogRead(e)),
+                }
+            }
+        }
+
+        let dest_path = self
+            .base_path
+            .join("dbs")
+            .join(std::str::from_utf8(&self.dest_namespace).unwrap());
+        tokio::fs::rename(temp_dir.path(), dest_path).await?;
+
+        self.make_namespace
+            .create(self.dest_namespace.clone(), None, false)
+            .await
+            .map_err(|e| ForkError::CreateNamespace(Box::new(e)))
+    }
+}

--- a/sqld/src/namespace/fork.rs
+++ b/sqld/src/namespace/fork.rs
@@ -29,6 +29,8 @@ pub enum ForkError {
     LogRead(anyhow::Error),
     #[error("an error occured creating the namespace: {0}")]
     CreateNamespace(Box<crate::error::Error>),
+    #[error("cannot fork a replica, try again with the primary.")]
+    ForkReplica,
 }
 
 impl From<tokio::task::JoinError> for ForkError {

--- a/sqld/src/namespace/fork.rs
+++ b/sqld/src/namespace/fork.rs
@@ -90,7 +90,10 @@ impl ForkTask<'_> {
                     }
                     Err(LogReadError::SnapshotRequired) => {
                         let snapshot = loop {
-                            if let Some(snap) = logger.get_snapshot_file(next_frame_no).map_err(ForkError::Internal)? {
+                            if let Some(snap) = logger
+                                .get_snapshot_file(next_frame_no)
+                                .map_err(ForkError::Internal)?
+                            {
                                 break snap;
                             }
 

--- a/sqld/src/namespace/mod.rs
+++ b/sqld/src/namespace/mod.rs
@@ -494,8 +494,6 @@ impl Namespace<PrimaryDatabase> {
                 ));
             }
 
-            dbg!(is_dirty);
-            dbg!(did_recover);
             is_dirty |= did_recover;
             Some(Arc::new(std::sync::Mutex::new(replicator)))
         } else {

--- a/sqld/src/namespace/mod.rs
+++ b/sqld/src/namespace/mod.rs
@@ -177,7 +177,7 @@ impl MakeNamespace for ReplicaNamespaceMaker {
         _from: &Namespace<Self::Database>,
         _to: Bytes,
     ) -> crate::Result<Namespace<Self::Database>> {
-        return Err(ForkError::ForkReplica.into())
+        return Err(ForkError::ForkReplica.into());
     }
 }
 

--- a/sqld/src/namespace/mod.rs
+++ b/sqld/src/namespace/mod.rs
@@ -261,12 +261,12 @@ impl<F: MakeNamespace> NamespaceStore<F> {
             Entry::Occupied(e) => e.into_mut(),
             Entry::Vacant(e) => {
                 // we just want to load the namespace into memory, so we refuse creation.
-                let ns = self.factory.create(from.clone(), None, false).await?;
+                let ns = self.make_namespace.create(from.clone(), RestoreOption::Latest, false).await?;
                 e.insert(ns)
             }
         };
 
-        let forked = self.factory.fork(from_ns, to.clone()).await?;
+        let forked = self.make_namespace.fork(from_ns, to.clone()).await?;
         lock.insert(to.clone(), forked);
 
         Ok(())

--- a/sqld/src/namespace/mod.rs
+++ b/sqld/src/namespace/mod.rs
@@ -177,7 +177,7 @@ impl MakeNamespace for ReplicaNamespaceMaker {
         _from: &Namespace<Self::Database>,
         _to: Bytes,
     ) -> crate::Result<Namespace<Self::Database>> {
-        todo!("cannot fork from replica");
+        return Err(ForkError::ForkReplica.into())
     }
 }
 

--- a/sqld/src/replication/snapshot.rs
+++ b/sqld/src/replication/snapshot.rs
@@ -135,7 +135,7 @@ impl SnapshotFile {
             match self.file.read_exact_at(&mut buf, read_offset as _) {
                 Ok(_) => match Frame::try_from_bytes(buf.freeze()) {
                     Ok(frame) => Some(Ok(frame)),
-                    Err(e) => Some(Err(e.into())),
+                    Err(e) => Some(Err(e)),
                 },
                 Err(e) => Some(Err(e.into())),
             }

--- a/sqld/src/replication/snapshot.rs
+++ b/sqld/src/replication/snapshot.rs
@@ -122,7 +122,7 @@ impl SnapshotFile {
     }
 
     /// Iterator on the frames contained in the snapshot file, in reverse frame_no order.
-    pub fn frames_iter(&self) -> impl Iterator<Item = anyhow::Result<Bytes>> + '_ {
+    pub fn frames_iter(&self) -> impl Iterator<Item = anyhow::Result<Frame>> + '_ {
         let mut current_offset = 0;
         std::iter::from_fn(move || {
             if current_offset >= self.header.frame_count {
@@ -133,7 +133,10 @@ impl SnapshotFile {
             current_offset += 1;
             let mut buf = BytesMut::zeroed(LogFile::FRAME_SIZE);
             match self.file.read_exact_at(&mut buf, read_offset as _) {
-                Ok(_) => Some(Ok(buf.freeze())),
+                Ok(_) => match Frame::try_from_bytes(buf.freeze()) {
+                    Ok(frame) => Some(Ok(frame)),
+                    Err(e) => Some(Err(e.into())),
+                },
                 Err(e) => Some(Err(e.into())),
             }
         })
@@ -143,19 +146,16 @@ impl SnapshotFile {
     pub fn frames_iter_from(
         &self,
         frame_no: u64,
-    ) -> impl Iterator<Item = anyhow::Result<Bytes>> + '_ {
+    ) -> impl Iterator<Item = anyhow::Result<Frame>> + '_ {
         let mut iter = self.frames_iter();
         std::iter::from_fn(move || match iter.next() {
-            Some(Ok(bytes)) => match Frame::try_from_bytes(bytes.clone()) {
-                Ok(frame) => {
-                    if frame.header().frame_no < frame_no {
-                        None
-                    } else {
-                        Some(Ok(bytes))
-                    }
+            Some(Ok(frame)) => {
+                if frame.header().frame_no < frame_no {
+                    None
+                } else {
+                    Some(Ok(frame))
                 }
-                Err(e) => Some(Err(e)),
-            },
+            }
             other => other,
         })
     }
@@ -317,7 +317,7 @@ impl SnapshotMerger {
         let snapshot_dir_path = snapshot_dir_path(db_path);
         for (name, _) in snapshots.iter().rev() {
             let snapshot = SnapshotFile::open(&snapshot_dir_path.join(name))?;
-            let iter = snapshot.frames_iter().map(|b| Frame::try_from_bytes(b?));
+            let iter = snapshot.frames_iter();
             builder.append_frames(iter)?;
         }
 
@@ -468,7 +468,6 @@ mod test {
     use bytes::Bytes;
     use tempfile::tempdir;
 
-    use crate::replication::frame::FrameHeader;
     use crate::replication::primary::logger::WalPage;
     use crate::replication::snapshot::SnapshotFile;
 
@@ -539,8 +538,7 @@ mod test {
         let mut expected_frame_no = 49;
         for frame in frames {
             let frame = frame.unwrap();
-            let header: FrameHeader = pod_read_unaligned(&frame[..size_of::<FrameHeader>()]);
-            assert_eq!(header.frame_no, expected_frame_no);
+            assert_eq!(frame.header().frame_no, expected_frame_no);
             expected_frame_no -= 1;
         }
 

--- a/sqld/src/rpc/replication_log.rs
+++ b/sqld/src/rpc/replication_log.rs
@@ -265,8 +265,10 @@ impl ReplicationLog for ReplicationLogService {
                     let mut frames = snapshot.frames_iter_from(offset);
                     loop {
                         match frames.next() {
-                            Some(Ok(data)) => {
-                                let _ = sender.blocking_send(Ok(Frame { data }));
+                            Some(Ok(frame)) => {
+                                let _ = sender.blocking_send(Ok(Frame {
+                                    data: frame.bytes(),
+                                }));
                             }
                             Some(Err(e)) => {
                                 let _ = sender.blocking_send(Err(Status::new(


### PR DESCRIPTION
This PR introduces a basic forking functionality. The admin API route `POST /v1/namespaces/:from/fork/:to` forks the namespace `:from` into a new namespace `:to` from the current point in time.

Forking works by creating a copy of the source database. This copy is performed from the replication log, to ensure point-in-time consistency. The forking algorithm works as follows:
- Determine the point in time at which to fork. This is done by saving the current frame_no.
- Replay the replication log from the start until the chosen point, and write that to a new database file
- Create a new namespace by placing the database file in the correct directory
- Let the recovery process take care of regenerating a replication log and replicating to bottomless