### PR TITLE
replication: limit the number of frames in batch_log_entries

### DIFF
--- a/sqld/src/replication/primary/frame_stream.rs
+++ b/sqld/src/replication/primary/frame_stream.rs
@@ -16,6 +16,10 @@ pub struct FrameStream {
     logger: Arc<ReplicationLogger>,
     state: FrameStreamState,
     wait_for_more: bool,
+    // number of frames produced in this stream
+    produced_frames: usize,
+    // max number of frames to produce before ending the stream
+    max_frames: Option<usize>,
     /// a future that resolves when the logger was closed.
     logger_closed_fut: BoxFuture<'static, ()>,
 }
@@ -25,6 +29,7 @@ impl FrameStream {
         logger: Arc<ReplicationLogger>,
         current_frameno: FrameNo,
         wait_for_more: bool,
+        max_frames: Option<usize>,
     ) -> crate::Result<Self> {
         let max_available_frame_no = *logger.new_frame_notifier.subscribe().borrow();
         let mut sub = logger.closed_signal.subscribe();
@@ -38,6 +43,8 @@ impl FrameStream {
             logger,
             state: FrameStreamState::Init,
             wait_for_more,
+            produced_frames: 0,
+            max_frames,
             logger_closed_fut,
         })
     }
@@ -45,6 +52,13 @@ impl FrameStream {
     fn transition_state_next_frame(&mut self) {
         if matches!(self.state, FrameStreamState::Closed) {
             return;
+        }
+        if let Some(max_frames) = self.max_frames {
+            if self.produced_frames == max_frames {
+                tracing::trace!("Max number of frames reached ({max_frames}), closing stream");
+                self.state = FrameStreamState::Closed;
+                return;
+            }
         }
 
         let next_frameno = self.current_frame_no;
@@ -99,6 +113,7 @@ impl Stream for FrameStream {
             FrameStreamState::WaitingFrame(ref mut fut) => match ready!(fut.as_mut().poll(cx)) {
                 Ok(frame) => {
                     self.current_frame_no += 1;
+                    self.produced_frames += 1;
                     self.transition_state_next_frame();
                     Poll::Ready(Some(Ok(frame)))
                 }

--- a/sqld/src/replication/primary/frame_stream.rs
+++ b/sqld/src/replication/primary/frame_stream.rs
@@ -55,7 +55,7 @@ impl FrameStream {
         }
         if let Some(max_frames) = self.max_frames {
             if self.produced_frames == max_frames {
-                tracing::trace!("Max number of frames reached ({max_frames}), closing stream");
+                tracing::debug!("Max number of frames reached ({max_frames}), closing stream");
                 self.state = FrameStreamState::Closed;
                 return;
             }

--- a/sqld/src/rpc/replication_log.rs
+++ b/sqld/src/rpc/replication_log.rs
@@ -37,6 +37,8 @@ pub struct ReplicationLogService {
 pub const NO_HELLO_ERROR_MSG: &str = "NO_HELLO";
 pub const NEED_SNAPSHOT_ERROR_MSG: &str = "NEED_SNAPSHOT";
 
+pub const MAX_FRAMES_PER_BATCH: usize = 1024;
+
 impl ReplicationLogService {
     pub fn new(
         namespaces: Arc<NamespaceStore<PrimaryNamespaceMaker>>,
@@ -154,7 +156,7 @@ impl ReplicationLog for ReplicationLogService {
             })?;
 
         let stream = StreamGuard::new(
-            FrameStream::new(logger, req.next_offset, true)
+            FrameStream::new(logger, req.next_offset, true, None)
                 .map_err(|e| Status::internal(e.to_string()))?,
             self.idle_shutdown_layer.clone(),
         )
@@ -194,7 +196,7 @@ impl ReplicationLog for ReplicationLogService {
             })?;
 
         let frames = StreamGuard::new(
-            FrameStream::new(logger, req.next_offset, false)
+            FrameStream::new(logger, req.next_offset, false, Some(MAX_FRAMES_PER_BATCH))
                 .map_err(|e| Status::internal(e.to_string()))?,
             self.idle_shutdown_layer.clone(),
         )


### PR DESCRIPTION
... to 1024. Users replicate frames in a loop anyway, and with a limit of 1024 frames, we'll effectively send data with ~4MiB pagination. That makes going out-of-memory way less likely. Tested locally by observing that the embedded replica demo from libsql/crates/core crate (cargo run --example replica) consumed log entries in batches of up to 1024 pages in size, when a large number of pages was injected to the database with `INSERT INTO t VALUES (zeroblob(4096000))`.