### PR TITLE
Abstract sqld networking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3785,6 +3785,7 @@ dependencies = [
  "nix",
  "once_cell",
  "parking_lot",
+ "pin-project-lite",
  "priority-queue",
  "proptest",
  "prost",

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -34,6 +34,7 @@ mimalloc = { version = "0.1.36", default-features = false }
 nix = { version = "0.26.2", features = ["fs"] }
 once_cell = "1.17.0"
 parking_lot = "0.12.1"
+pin-project-lite = "0.2.13"
 priority-queue = "1.3"
 prost = "0.11.3"
 rand = "0.8"

--- a/sqld/src/config.rs
+++ b/sqld/src/config.rs
@@ -19,7 +19,7 @@ pub struct RpcClientConfig<C = HttpConnector> {
 
 impl<C: Connector> RpcClientConfig<C> {
     pub(crate) async fn configure(self) -> anyhow::Result<(Channel, tonic::transport::Uri)> {
-        let uri = tonic::transport::Uri::from_maybe_shared(self.remote_url.clone())?;
+        let uri = tonic::transport::Uri::from_maybe_shared(self.remote_url)?;
         let mut builder = Channel::builder(uri.clone());
         if let Some(ref tls_config) = self.tls_config {
             let cert_pem = std::fs::read_to_string(&tls_config.cert)?;
@@ -157,4 +157,10 @@ impl DbConfig {
 
         Ok(valid_extensions.into())
     }
+}
+
+pub struct HeartbeatConfig {
+    pub heartbeat_url: String,
+    pub heartbeat_period: Duration,
+    pub heartbeat_auth: Option<String>,
 }

--- a/sqld/src/config.rs
+++ b/sqld/src/config.rs
@@ -1,0 +1,160 @@
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use hyper::client::HttpConnector;
+use sha256::try_digest;
+use tonic::transport::Channel;
+
+use crate::auth::{self, Auth};
+use crate::net::{AddrIncoming, Connector};
+
+pub struct RpcClientConfig<C = HttpConnector> {
+    pub remote_url: String,
+    pub connector: C,
+    pub tls_config: Option<TlsConfig>,
+}
+
+impl<C: Connector> RpcClientConfig<C> {
+    pub(crate) async fn configure(self) -> anyhow::Result<(Channel, tonic::transport::Uri)> {
+        let uri = tonic::transport::Uri::from_maybe_shared(self.remote_url.clone())?;
+        let mut builder = Channel::builder(uri.clone());
+        if let Some(ref tls_config) = self.tls_config {
+            let cert_pem = std::fs::read_to_string(&tls_config.cert)?;
+            let key_pem = std::fs::read_to_string(&tls_config.key)?;
+            let identity = tonic::transport::Identity::from_pem(cert_pem, key_pem);
+
+            let ca_cert_pem = std::fs::read_to_string(&tls_config.ca_cert)?;
+            let ca_cert = tonic::transport::Certificate::from_pem(ca_cert_pem);
+
+            let tls_config = tonic::transport::ClientTlsConfig::new()
+                .identity(identity)
+                .ca_certificate(ca_cert)
+                .domain_name("sqld");
+            builder = builder.tls_config(tls_config)?;
+        }
+
+        let channel = builder.connect_with_connector_lazy(self.connector);
+
+        Ok((channel, uri))
+    }
+}
+
+#[derive(Clone)]
+pub struct TlsConfig {
+    pub cert: PathBuf,
+    pub key: PathBuf,
+    pub ca_cert: PathBuf,
+}
+
+pub struct RpcServerConfig<A = AddrIncoming> {
+    pub acceptor: A,
+    pub addr: SocketAddr,
+    pub tls_config: Option<TlsConfig>,
+}
+
+pub struct UserApiConfig<A = AddrIncoming> {
+    pub hrana_ws_acceptor: Option<A>,
+    pub http_acceptor: Option<A>,
+    pub enable_http_console: bool,
+    pub self_url: Option<String>,
+    pub http_auth: Option<String>,
+    pub auth_jwt_key: Option<String>,
+}
+
+impl<A> UserApiConfig<A> {
+    pub fn get_auth(&self) -> anyhow::Result<Auth> {
+        let mut auth = Auth::default();
+
+        if let Some(arg) = self.http_auth.as_deref() {
+            if let Some(param) = auth::parse_http_basic_auth_arg(arg)? {
+                auth.http_basic = Some(param);
+                tracing::info!("Using legacy HTTP basic authentication");
+            }
+        }
+
+        if let Some(jwt_key) = self.auth_jwt_key.as_deref() {
+            let jwt_key =
+                auth::parse_jwt_key(jwt_key).context("Could not parse JWT decoding key")?;
+            auth.jwt_key = Some(jwt_key);
+            tracing::info!("Using JWT-based authentication");
+        }
+
+        auth.disabled = auth.http_basic.is_none() && auth.jwt_key.is_none();
+        if auth.disabled {
+            tracing::warn!(
+                "No authentication specified, the server will not require authentication"
+            )
+        }
+
+        Ok(auth)
+    }
+}
+
+pub struct AdminApiConfig<A = AddrIncoming> {
+    pub acceptor: A,
+}
+
+#[derive(Clone)]
+pub struct DbConfig {
+    pub extensions_path: Option<Arc<Path>>,
+    pub bottomless_replication: Option<bottomless::replicator::Options>,
+    pub max_log_size: u64,
+    pub max_log_duration: Option<f32>,
+    pub soft_heap_limit_mb: Option<usize>,
+    pub hard_heap_limit_mb: Option<usize>,
+    pub max_response_size: u64,
+    pub max_total_response_size: u64,
+    pub snapshot_exec: Option<String>,
+    pub checkpoint_interval: Option<Duration>,
+}
+
+impl DbConfig {
+    pub fn validate_extensions(&self) -> anyhow::Result<Arc<[PathBuf]>> {
+        let mut valid_extensions = vec![];
+        if let Some(ext_dir) = &self.extensions_path {
+            let extensions_list = ext_dir.join("trusted.lst");
+
+            let file_contents = std::fs::read_to_string(&extensions_list)
+                .with_context(|| format!("can't read {}", &extensions_list.display()))?;
+
+            let extensions = file_contents.lines().filter(|c| !c.is_empty());
+
+            for line in extensions {
+                let mut ext_info = line.trim().split_ascii_whitespace();
+
+                let ext_sha = ext_info.next().ok_or_else(|| {
+                    anyhow::anyhow!("invalid line on {}: {}", &extensions_list.display(), line)
+                })?;
+                let ext_fname = ext_info.next().ok_or_else(|| {
+                    anyhow::anyhow!("invalid line on {}: {}", &extensions_list.display(), line)
+                })?;
+
+                anyhow::ensure!(
+                    ext_info.next().is_none(),
+                    "extension list seem to contain a filename with whitespaces. Rejected"
+                );
+
+                let extension_full_path = ext_dir.join(ext_fname);
+                let digest = try_digest(extension_full_path.as_path()).with_context(|| {
+                    format!(
+                        "Failed to get sha256 digest, while trying to read {}",
+                        extension_full_path.display()
+                    )
+                })?;
+
+                anyhow::ensure!(
+                    digest == ext_sha,
+                    "sha256 differs for {}. Got {}",
+                    ext_fname,
+                    digest
+                );
+                valid_extensions.push(extension_full_path);
+            }
+        }
+
+        Ok(valid_extensions.into())
+    }
+}

--- a/sqld/src/connection/write_proxy.rs
+++ b/sqld/src/connection/write_proxy.rs
@@ -36,7 +36,7 @@ use super::{MakeConnection, Program};
 pub struct MakeWriteProxyConnection {
     client: ProxyClient<Channel>,
     db_path: PathBuf,
-    extensions: Vec<PathBuf>,
+    extensions: Arc<[PathBuf]>,
     stats: Stats,
     config_store: Arc<DatabaseConfigStore>,
     applied_frame_no_receiver: watch::Receiver<FrameNo>,
@@ -49,7 +49,7 @@ impl MakeWriteProxyConnection {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         db_path: PathBuf,
-        extensions: Vec<PathBuf>,
+        extensions: Arc<[PathBuf]>,
         channel: Channel,
         uri: tonic::transport::Uri,
         stats: Stats,
@@ -165,7 +165,7 @@ impl WriteProxyConnection {
     async fn new(
         write_proxy: ProxyClient<Channel>,
         db_path: PathBuf,
-        extensions: Vec<PathBuf>,
+        extensions: Arc<[PathBuf]>,
         stats: Stats,
         config_store: Arc<DatabaseConfigStore>,
         applied_frame_no_receiver: watch::Receiver<FrameNo>,

--- a/sqld/src/hrana/ws/conn.rs
+++ b/sqld/src/hrana/ws/conn.rs
@@ -50,7 +50,7 @@ struct ResponseFuture {
 
 pub(super) async fn handle_tcp<F: MakeNamespace>(
     server: Arc<Server<F>>,
-    socket: tokio::net::TcpStream,
+    socket: Box<dyn crate::net::Conn>,
     conn_id: u64,
 ) -> Result<()> {
     let handshake::Output {

--- a/sqld/src/hrana/ws/mod.rs
+++ b/sqld/src/hrana/ws/mod.rs
@@ -1,12 +1,18 @@
-use crate::auth::Auth;
-use crate::namespace::{MakeNamespace, NamespaceStore};
-use crate::utils::services::idle_shutdown::IdleKicker;
-use anyhow::{Context as _, Result};
-use enclose::enclose;
+use std::future::poll_fn;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+
+use anyhow::Result;
+use enclose::enclose;
+use futures::pin_mut;
 use tokio::sync::{mpsc, oneshot};
+use tonic::transport::server::Connected;
+
+use crate::auth::Auth;
+use crate::namespace::{MakeNamespace, NamespaceStore};
+use crate::net::Conn;
+use crate::utils::services::idle_shutdown::IdleKicker;
 
 pub mod proto;
 
@@ -16,7 +22,7 @@ mod protobuf;
 mod session;
 
 struct Server<F: MakeNamespace> {
-    namespaces: Arc<NamespaceStore<F>>,
+    namespaces: NamespaceStore<F>,
     auth: Arc<Auth>,
     idle_kicker: Option<IdleKicker>,
     max_response_size: u64,
@@ -25,9 +31,8 @@ struct Server<F: MakeNamespace> {
     disable_namespaces: bool,
 }
 
-#[derive(Debug)]
 pub struct Accept {
-    pub socket: tokio::net::TcpStream,
+    pub socket: Box<dyn Conn>,
     pub peer_addr: SocketAddr,
 }
 
@@ -44,7 +49,7 @@ pub async fn serve<F: MakeNamespace>(
     max_response_size: u64,
     mut accept_rx: mpsc::Receiver<Accept>,
     mut upgrade_rx: mpsc::Receiver<Upgrade>,
-    namespaces: Arc<NamespaceStore<F>>,
+    namespaces: NamespaceStore<F>,
     disable_default_namespace: bool,
     disable_namespaces: bool,
 ) -> Result<()> {
@@ -98,18 +103,25 @@ pub async fn serve<F: MakeNamespace>(
     }
 }
 
-pub async fn listen(bind_addr: SocketAddr, accept_tx: mpsc::Sender<Accept>) -> Result<()> {
-    let listener = tokio::net::TcpListener::bind(bind_addr)
-        .await
-        .context("Could not bind TCP listener")?;
-    let local_addr = listener.local_addr()?;
-    tracing::info!("Listening for Hrana connections on {}", local_addr);
+pub async fn listen<A>(acceptor: A, accept_tx: mpsc::Sender<Accept>)
+where
+    A: crate::net::Accept,
+{
+    pin_mut!(acceptor);
 
-    loop {
-        let (socket, peer_addr) = listener
-            .accept()
-            .await
-            .context("Could not accept a TCP connection")?;
-        let _: Result<_, _> = accept_tx.send(Accept { socket, peer_addr }).await;
+    while let Some(maybe_conn) = poll_fn(|cx| acceptor.as_mut().poll_accept(cx)).await {
+        match maybe_conn {
+            Ok(conn) => {
+                let Some(peer_addr) = conn.connect_info().remote_addr() else {
+                    tracing::error!("connection missing remote addr");
+                    continue;
+                };
+                let socket: Box<dyn Conn> = Box::new(conn);
+                let _: Result<_, _> = accept_tx.send(Accept { socket, peer_addr }).await;
+            }
+            Err(e) => {
+                tracing::error!("error handling incoming hrana ws connection: {e}");
+            }
+        }
     }
 }

--- a/sqld/src/hrana/ws/mod.rs
+++ b/sqld/src/hrana/ws/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use enclose::enclose;
-use futures::pin_mut;
+use tokio::pin;
 use tokio::sync::{mpsc, oneshot};
 use tonic::transport::server::Connected;
 
@@ -107,7 +107,7 @@ pub async fn listen<A>(acceptor: A, accept_tx: mpsc::Sender<Accept>)
 where
     A: crate::net::Accept,
 {
-    pin_mut!(acceptor);
+    pin!(acceptor);
 
     while let Some(maybe_conn) = poll_fn(|cx| acceptor.as_mut().poll_accept(cx)).await {
         match maybe_conn {

--- a/sqld/src/http/mod.rs
+++ b/sqld/src/http/mod.rs
@@ -1,11 +1,9 @@
 pub mod db_factory;
-mod h2c;
 mod hrana_over_http_1;
 mod result_builder;
 pub mod stats;
 mod types;
 
-use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -18,12 +16,12 @@ use axum::Router;
 use axum_extra::middleware::option_layer;
 use base64::prelude::BASE64_STANDARD_NO_PAD;
 use base64::Engine;
-use hyper::server::conn::AddrIncoming;
 use hyper::{header, Body, Request, Response, StatusCode};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Number;
 use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinSet;
 use tonic::transport::Server;
 use tower_http::trace::DefaultOnResponse;
 use tower_http::{compression::CompressionLayer, cors};
@@ -43,7 +41,7 @@ use crate::rpc::proxy::rpc::proxy_server::{Proxy, ProxyServer};
 use crate::rpc::replication_log::rpc::replication_log_server::ReplicationLog;
 use crate::rpc::ReplicationLogServer;
 use crate::stats::Stats;
-use crate::utils::services::idle_shutdown::IdleShutdownLayer;
+use crate::utils::services::idle_shutdown::IdleShutdownKicker;
 use crate::version;
 
 use self::db_factory::MakeConnectionExtractor;
@@ -185,7 +183,7 @@ async fn handle_fallback() -> impl IntoResponse {
 /// axum's `State` extractor.
 pub(crate) struct AppState<F: MakeNamespace> {
     auth: Arc<Auth>,
-    namespaces: Arc<NamespaceStore<F>>,
+    namespaces: NamespaceStore<F>,
     upgrade_tx: mpsc::Sender<hrana::ws::Upgrade>,
     hrana_http_srv: Arc<hrana::http::Server<<F::Database as Database>::Connection>>,
     enable_console: bool,
@@ -209,160 +207,216 @@ impl<F: MakeNamespace> Clone for AppState<F> {
     }
 }
 
-// TODO: refactor
-#[allow(clippy::too_many_arguments)]
-pub async fn run_http<M, S, P>(
-    addr: SocketAddr,
-    auth: Arc<Auth>,
-    namespaces: Arc<NamespaceStore<M>>,
-    upgrade_tx: mpsc::Sender<hrana::ws::Upgrade>,
-    hrana_http_srv: Arc<hrana::http::Server<<M::Database as Database>::Connection>>,
-    enable_console: bool,
-    idle_shutdown_layer: Option<IdleShutdownLayer>,
-    stats: Stats,
-    proxy_service: P,
-    replication_service: S,
-    disable_default_namespace: bool,
-    disable_namespaces: bool,
-) -> anyhow::Result<()>
+pub struct UserApi<'a, M: MakeNamespace, A, P, S> {
+    pub auth: Arc<Auth>,
+    pub http_acceptor: Option<A>,
+    pub hrana_ws_acceptor: Option<A>,
+    pub namespaces: NamespaceStore<M>,
+    pub idle_shutdown_kicker: Option<IdleShutdownKicker>,
+    pub stats: Stats,
+    pub proxy_service: P,
+    pub replication_service: S,
+    pub disable_default_namespace: bool,
+    pub disable_namespaces: bool,
+    pub max_response_size: u64,
+    pub enable_console: bool,
+    pub self_url: Option<String>,
+    pub join_set: &'a mut JoinSet<anyhow::Result<()>>,
+}
+
+impl<M, A, P, S> UserApi<'_, M, A, P, S>
 where
     M: MakeNamespace,
-    S: ReplicationLog,
+    A: crate::net::Accept,
     P: Proxy,
+    S: ReplicationLog,
 {
-    let state = AppState {
-        auth,
-        upgrade_tx,
-        hrana_http_srv,
-        enable_console,
-        stats,
-        namespaces,
-        disable_default_namespace,
-        disable_namespaces,
-    };
+    pub fn configure(self) {
+        let (hrana_accept_tx, hrana_accept_rx) = mpsc::channel(8);
+        let (hrana_upgrade_tx, hrana_upgrade_rx) = mpsc::channel(8);
+        let hrana_http_srv = Arc::new(hrana::http::Server::new(self.self_url.clone()));
 
-    tracing::info!("listening for HTTP requests on {addr}");
-
-    fn trace_request<B>(req: &Request<B>, _span: &Span) {
-        tracing::debug!("got request: {} {}", req.method(), req.uri());
-    }
-
-    macro_rules! handle_hrana {
-        ($endpoint:expr, $version:expr, $encoding:expr,) => {{
-            async fn handle_hrana<F: MakeNamespace>(
-                AxumState(state): AxumState<AppState<F>>,
-                MakeConnectionExtractor(connection_maker): MakeConnectionExtractor<
-                    <F::Database as Database>::Connection,
-                >,
-                auth: Authenticated,
-                req: Request<Body>,
-            ) -> Result<Response<Body>, Error> {
-                Ok(state
-                    .hrana_http_srv
-                    .handle_request(connection_maker, auth, req, $endpoint, $version, $encoding)
-                    .await?)
+        self.join_set.spawn({
+            let namespaces = self.namespaces.clone();
+            let auth = self.auth.clone();
+            let idle_kicker = self
+                .idle_shutdown_kicker
+                .clone()
+                .map(|isl| isl.into_kicker());
+            let disable_default_namespace = self.disable_default_namespace;
+            let disable_namespaces = self.disable_namespaces;
+            let max_response_size = self.max_response_size;
+            async move {
+                hrana::ws::serve(
+                    auth,
+                    idle_kicker,
+                    max_response_size,
+                    hrana_accept_rx,
+                    hrana_upgrade_rx,
+                    namespaces,
+                    disable_default_namespace,
+                    disable_namespaces,
+                )
+                .await
+                .context("Hrana server failed")
             }
-            handle_hrana
-        }};
+        });
+
+        self.join_set.spawn({
+            let server = hrana_http_srv.clone();
+            async move {
+                server.run_expire().await;
+                Ok(())
+            }
+        });
+
+        if let Some(acceptor) = self.hrana_ws_acceptor {
+            self.join_set.spawn(async move {
+                hrana::ws::listen(acceptor, hrana_accept_tx).await;
+                Ok(())
+            });
+        }
+
+        if let Some(acceptor) = self.http_acceptor {
+            let state = AppState {
+                auth: self.auth,
+                upgrade_tx: hrana_upgrade_tx,
+                hrana_http_srv,
+                enable_console: self.enable_console,
+                stats: self.stats.clone(),
+                namespaces: self.namespaces,
+                disable_default_namespace: self.disable_default_namespace,
+                disable_namespaces: self.disable_namespaces,
+            };
+
+            fn trace_request<B>(req: &Request<B>, _span: &Span) {
+                tracing::debug!("got request: {} {}", req.method(), req.uri());
+            }
+
+            macro_rules! handle_hrana {
+                ($endpoint:expr, $version:expr, $encoding:expr,) => {{
+                    async fn handle_hrana<F: MakeNamespace>(
+                        AxumState(state): AxumState<AppState<F>>,
+                        MakeConnectionExtractor(connection_maker): MakeConnectionExtractor<
+                            <F::Database as Database>::Connection,
+                        >,
+                        auth: Authenticated,
+                        req: Request<Body>,
+                    ) -> Result<Response<Body>, Error> {
+                        Ok(state
+                            .hrana_http_srv
+                            .handle_request(
+                                connection_maker,
+                                auth,
+                                req,
+                                $endpoint,
+                                $version,
+                                $encoding,
+                            )
+                            .await?)
+                    }
+                    handle_hrana
+                }};
+            }
+
+            let app = Router::new()
+                .route("/", post(handle_query))
+                .route("/", get(handle_upgrade))
+                .route("/version", get(handle_version))
+                .route("/console", get(show_console))
+                .route("/health", get(handle_health))
+                .route("/v1/stats", get(stats::handle_stats))
+                .route("/v1", get(hrana_over_http_1::handle_index))
+                .route("/v1/execute", post(hrana_over_http_1::handle_execute))
+                .route("/v1/batch", post(hrana_over_http_1::handle_batch))
+                .route("/v2", get(crate::hrana::http::handle_index))
+                .route(
+                    "/v2/pipeline",
+                    post(handle_hrana!(
+                        hrana::http::Endpoint::Pipeline,
+                        hrana::Version::Hrana2,
+                        hrana::Encoding::Json,
+                    )),
+                )
+                .route("/v3", get(crate::hrana::http::handle_index))
+                .route(
+                    "/v3/pipeline",
+                    post(handle_hrana!(
+                        hrana::http::Endpoint::Pipeline,
+                        hrana::Version::Hrana3,
+                        hrana::Encoding::Json,
+                    )),
+                )
+                .route(
+                    "/v3/cursor",
+                    post(handle_hrana!(
+                        hrana::http::Endpoint::Cursor,
+                        hrana::Version::Hrana3,
+                        hrana::Encoding::Json,
+                    )),
+                )
+                .route("/v3-protobuf", get(crate::hrana::http::handle_index))
+                .route(
+                    "/v3-protobuf/pipeline",
+                    post(handle_hrana!(
+                        hrana::http::Endpoint::Pipeline,
+                        hrana::Version::Hrana3,
+                        hrana::Encoding::Protobuf,
+                    )),
+                )
+                .route(
+                    "/v3-protobuf/cursor",
+                    post(handle_hrana!(
+                        hrana::http::Endpoint::Cursor,
+                        hrana::Version::Hrana3,
+                        hrana::Encoding::Protobuf,
+                    )),
+                )
+                .with_state(state);
+
+            let layered_app = app
+                .layer(option_layer(self.idle_shutdown_kicker.clone()))
+                .layer(
+                    tower_http::trace::TraceLayer::new_for_http()
+                        .on_request(trace_request)
+                        .on_response(
+                            DefaultOnResponse::new()
+                                .level(Level::DEBUG)
+                                .latency_unit(tower_http::LatencyUnit::Micros),
+                        ),
+                )
+                .layer(CompressionLayer::new())
+                .layer(
+                    cors::CorsLayer::new()
+                        .allow_methods(cors::AllowMethods::any())
+                        .allow_headers(cors::Any)
+                        .allow_origin(cors::Any),
+                );
+
+            // Merge the grpc based axum router into our regular http router
+            let replication = ReplicationLogServer::new(self.replication_service);
+            let write_proxy = ProxyServer::new(self.proxy_service);
+
+            let grpc_router = Server::builder()
+                .accept_http1(true)
+                .add_service(tonic_web::enable(replication))
+                .add_service(tonic_web::enable(write_proxy))
+                .into_router();
+
+            let router = layered_app.merge(grpc_router);
+
+            let router = router.fallback(handle_fallback);
+            let h2c = crate::h2c::H2cMaker::new(router);
+
+            self.join_set.spawn(async move {
+                hyper::server::Server::builder(acceptor)
+                    .serve(h2c)
+                    .await
+                    .context("http server")?;
+                Ok(())
+            });
+        }
     }
-
-    let app = Router::new()
-        .route("/", post(handle_query))
-        .route("/", get(handle_upgrade))
-        .route("/version", get(handle_version))
-        .route("/console", get(show_console))
-        .route("/health", get(handle_health))
-        .route("/v1/stats", get(stats::handle_stats))
-        .route("/v1", get(hrana_over_http_1::handle_index))
-        .route("/v1/execute", post(hrana_over_http_1::handle_execute))
-        .route("/v1/batch", post(hrana_over_http_1::handle_batch))
-        .route("/v2", get(crate::hrana::http::handle_index))
-        .route(
-            "/v2/pipeline",
-            post(handle_hrana!(
-                hrana::http::Endpoint::Pipeline,
-                hrana::Version::Hrana2,
-                hrana::Encoding::Json,
-            )),
-        )
-        .route("/v3", get(crate::hrana::http::handle_index))
-        .route(
-            "/v3/pipeline",
-            post(handle_hrana!(
-                hrana::http::Endpoint::Pipeline,
-                hrana::Version::Hrana3,
-                hrana::Encoding::Json,
-            )),
-        )
-        .route(
-            "/v3/cursor",
-            post(handle_hrana!(
-                hrana::http::Endpoint::Cursor,
-                hrana::Version::Hrana3,
-                hrana::Encoding::Json,
-            )),
-        )
-        .route("/v3-protobuf", get(crate::hrana::http::handle_index))
-        .route(
-            "/v3-protobuf/pipeline",
-            post(handle_hrana!(
-                hrana::http::Endpoint::Pipeline,
-                hrana::Version::Hrana3,
-                hrana::Encoding::Protobuf,
-            )),
-        )
-        .route(
-            "/v3-protobuf/cursor",
-            post(handle_hrana!(
-                hrana::http::Endpoint::Cursor,
-                hrana::Version::Hrana3,
-                hrana::Encoding::Protobuf,
-            )),
-        )
-        .with_state(state);
-
-    let layered_app = app
-        .layer(option_layer(idle_shutdown_layer.clone()))
-        .layer(
-            tower_http::trace::TraceLayer::new_for_http()
-                .on_request(trace_request)
-                .on_response(
-                    DefaultOnResponse::new()
-                        .level(Level::DEBUG)
-                        .latency_unit(tower_http::LatencyUnit::Micros),
-                ),
-        )
-        .layer(CompressionLayer::new())
-        .layer(
-            cors::CorsLayer::new()
-                .allow_methods(cors::AllowMethods::any())
-                .allow_headers(cors::Any)
-                .allow_origin(cors::Any),
-        );
-
-    // Merge the grpc based axum router into our regular http router
-    let replication = ReplicationLogServer::new(replication_service);
-    let write_proxy = ProxyServer::new(proxy_service);
-
-    let grpc_router = Server::builder()
-        .accept_http1(true)
-        .add_service(tonic_web::enable(replication))
-        .add_service(tonic_web::enable(write_proxy))
-        .into_router();
-
-    let router = layered_app.merge(grpc_router);
-
-    let router = router.fallback(handle_fallback);
-    let h2c = h2c::H2cMaker::new(router);
-
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
-    hyper::server::Server::builder(AddrIncoming::from_listener(listener)?)
-        .tcp_nodelay(true)
-        .serve(h2c)
-        .await
-        .context("http server")?;
-
-    Ok(())
 }
 
 /// Axum authenticated extractor

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::type_complexity, clippy::too_many_arguments)]
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::mpsc::RecvTimeoutError;
@@ -9,14 +8,17 @@ use std::time::Duration;
 
 use anyhow::Context as AnyhowContext;
 use bytes::Bytes;
-use enclose::enclose;
+use config::{AdminApiConfig, DbConfig, RpcClientConfig, RpcServerConfig, UserApiConfig};
 use futures::never::Never;
+use http::UserApi;
+use hyper::client::HttpConnector;
 use libsql::wal_hook::TRANSPARENT_METHODS;
 use namespace::{
     MakeNamespace, NamespaceStore, PrimaryNamespaceConfig, PrimaryNamespaceMaker,
     ReplicaNamespaceConfig, ReplicaNamespaceMaker,
 };
-use replication::{NamespacedSnapshotCallback, ReplicationLogger};
+use net::Connector;
+use replication::NamespacedSnapshotCallback;
 use rpc::proxy::rpc::proxy_server::Proxy;
 use rpc::proxy::ProxyService;
 use rpc::replica_proxy::ReplicaProxyService;
@@ -24,29 +26,33 @@ use rpc::replication_log::rpc::replication_log_server::ReplicationLog;
 use rpc::replication_log::ReplicationLogService;
 use rpc::replication_log_proxy::ReplicationLogProxyService;
 use rpc::run_rpc_server;
-use tokio::sync::mpsc;
+use tokio::sync::Notify;
 use tokio::task::JoinSet;
-use tonic::transport::Channel;
-use utils::services::idle_shutdown::IdleShutdownLayer;
+use tokio::time::{interval, sleep, Instant, MissedTickBehavior};
+use utils::services::idle_shutdown::IdleShutdownKicker;
 
-use self::connection::config::DatabaseConfigStore;
-use self::connection::libsql::open_db;
 use crate::auth::Auth;
+use crate::connection::config::DatabaseConfigStore;
+use crate::connection::libsql::open_db;
 use crate::error::Error;
 use crate::migration::maybe_migrate;
+use crate::net::Accept;
+use crate::net::AddrIncoming;
 use crate::stats::Stats;
 
-use sha256::try_digest;
-use tokio::time::{interval, sleep, Instant, MissedTickBehavior};
-
-use crate::namespace::RestoreOption;
 pub use sqld_libsql_bindings as libsql;
+
+pub mod config;
+pub mod connection;
+pub mod net;
+pub mod rpc;
+pub mod version;
 
 mod admin_api;
 mod auth;
-pub mod connection;
 mod database;
 mod error;
+mod h2c;
 mod heartbeat;
 mod hrana;
 mod http;
@@ -56,514 +62,96 @@ mod query;
 mod query_analysis;
 mod query_result_builder;
 mod replication;
-pub mod rpc;
 mod stats;
 #[cfg(test)]
 mod test;
 mod utils;
-pub mod version;
 
 const MAX_CONCURRENT_DBS: usize = 128;
 const DB_CREATE_TIMEOUT: Duration = Duration::from_secs(1);
 const DEFAULT_NAMESPACE_NAME: &str = "default";
 const DEFAULT_AUTO_CHECKPOINT: u32 = 1000;
 
-#[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
-pub enum Backend {
-    Libsql,
-}
-
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Debug, Clone)]
-pub struct Config {
-    pub db_path: PathBuf,
-    pub extensions_path: Option<PathBuf>,
-    pub http_addr: Option<SocketAddr>,
-    pub enable_http_console: bool,
-    pub http_auth: Option<String>,
-    pub http_self_url: Option<String>,
-    pub hrana_addr: Option<SocketAddr>,
-    pub admin_addr: Option<SocketAddr>,
-    pub auth_jwt_key: Option<String>,
-    pub backend: Backend,
-    pub writer_rpc_addr: Option<String>,
-    pub writer_rpc_tls: bool,
-    pub writer_rpc_cert: Option<PathBuf>,
-    pub writer_rpc_key: Option<PathBuf>,
-    pub writer_rpc_ca_cert: Option<PathBuf>,
-    pub rpc_server_addr: Option<SocketAddr>,
-    pub rpc_server_tls: bool,
-    pub rpc_server_cert: Option<PathBuf>,
-    pub rpc_server_key: Option<PathBuf>,
-    pub rpc_server_ca_cert: Option<PathBuf>,
-    pub bottomless_replication: Option<bottomless::replicator::Options>,
+pub struct Server<C = HttpConnector, A = AddrIncoming> {
+    pub path: Arc<Path>,
+    pub db_config: DbConfig,
+    pub user_api_config: UserApiConfig<A>,
+    pub admin_api_config: Option<AdminApiConfig<A>>,
+    pub rpc_server_config: Option<RpcServerConfig<A>>,
+    pub rpc_client_config: Option<RpcClientConfig<C>>,
     pub idle_shutdown_timeout: Option<Duration>,
     pub initial_idle_shutdown_timeout: Option<Duration>,
-    pub max_log_size: u64,
-    pub max_log_duration: Option<f32>,
-    pub heartbeat_url: Option<String>,
-    pub heartbeat_auth: Option<String>,
-    pub heartbeat_period: Duration,
-    pub soft_heap_limit_mb: Option<usize>,
-    pub hard_heap_limit_mb: Option<usize>,
-    pub max_response_size: u64,
-    pub max_total_response_size: u64,
-    pub snapshot_exec: Option<String>,
     pub disable_default_namespace: bool,
+    pub heartbeat_config: Option<HeartbeatConfig>,
     pub disable_namespaces: bool,
-    pub checkpoint_interval: Option<Duration>,
+    pub shutdown: Arc<Notify>,
 }
 
-impl Default for Config {
-    fn default() -> Self {
-        Config {
-            db_path: "data.sqld".into(),
-            extensions_path: None,
-            http_addr: Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080)),
-            enable_http_console: false,
-            http_auth: None,
-            http_self_url: None,
-            hrana_addr: None,
-            admin_addr: None,
-            auth_jwt_key: None,
-            backend: Backend::Libsql,
-            writer_rpc_addr: None,
-            writer_rpc_tls: false,
-            writer_rpc_cert: None,
-            writer_rpc_key: None,
-            writer_rpc_ca_cert: None,
-            rpc_server_addr: None,
-            rpc_server_tls: false,
-            rpc_server_cert: None,
-            rpc_server_key: None,
-            rpc_server_ca_cert: None,
-            bottomless_replication: None,
-            idle_shutdown_timeout: None,
-            initial_idle_shutdown_timeout: None,
-            max_log_size: 200,
-            max_log_duration: None,
-            heartbeat_url: None,
-            heartbeat_auth: None,
-            heartbeat_period: Duration::from_secs(30),
-            soft_heap_limit_mb: None,
-            hard_heap_limit_mb: None,
-            max_response_size: 10 * 1024 * 1024,       // 10MiB
-            max_total_response_size: 32 * 1024 * 1024, // 32MiB
-            snapshot_exec: None,
-            disable_default_namespace: false,
-            disable_namespaces: true,
-            checkpoint_interval: None,
-        }
-    }
+pub struct HeartbeatConfig {
+    pub heartbeat_url: String,
+    pub heartbeat_period: Duration,
+    pub heartbeat_auth: Option<String>,
 }
 
-async fn run_service<F, S, P>(
-    namespaces: Arc<NamespaceStore<F>>,
-    config: &Config,
-    join_set: &mut JoinSet<anyhow::Result<()>>,
-    idle_shutdown_layer: Option<IdleShutdownLayer>,
+struct Services<'a, M: MakeNamespace, A, P, S> {
+    namespaces: NamespaceStore<M>,
+    idle_shutdown_kicker: Option<IdleShutdownKicker>,
     stats: Stats,
     db_config_store: Arc<DatabaseConfigStore>,
     proxy_service: P,
     replication_service: S,
-) -> anyhow::Result<()>
+    user_api_config: UserApiConfig<A>,
+    admin_api_config: Option<AdminApiConfig<A>>,
+    disable_namespaces: bool,
+    disable_default_namespace: bool,
+    db_config: DbConfig,
+    auth: Arc<Auth>,
+    join_set: &'a mut JoinSet<anyhow::Result<()>>,
+}
+
+impl<M, A, P, S> Services<'_, M, A, P, S>
 where
-    F: MakeNamespace,
-    S: ReplicationLog,
+    M: MakeNamespace,
+    A: crate::net::Accept,
     P: Proxy,
+    S: ReplicationLog,
 {
-    let auth = get_auth(config)?;
+    fn configure(self) {
+        let user_http = UserApi {
+            http_acceptor: self.user_api_config.http_acceptor,
+            hrana_ws_acceptor: self.user_api_config.hrana_ws_acceptor,
+            auth: self.auth,
+            namespaces: self.namespaces.clone(),
+            idle_shutdown_kicker: self.idle_shutdown_kicker.clone(),
+            stats: self.stats.clone(),
+            proxy_service: self.proxy_service,
+            replication_service: self.replication_service,
+            disable_default_namespace: self.disable_default_namespace,
+            disable_namespaces: self.disable_namespaces,
+            max_response_size: self.db_config.max_response_size,
+            enable_console: self.user_api_config.enable_http_console,
+            self_url: self.user_api_config.self_url,
+            join_set: self.join_set,
+        };
 
-    let (hrana_accept_tx, hrana_accept_rx) = mpsc::channel(8);
-    let (hrana_upgrade_tx, hrana_upgrade_rx) = mpsc::channel(8);
+        user_http.configure();
 
-    if config.http_addr.is_some() || config.hrana_addr.is_some() {
-        let namespaces = namespaces.clone();
-        let auth = auth.clone();
-        let idle_kicker = idle_shutdown_layer.clone().map(|isl| isl.into_kicker());
-        let disable_default_namespace = config.disable_default_namespace;
-        let disable_namespaces = config.disable_namespaces;
-        let max_response_size = config.max_response_size;
-
-        join_set.spawn(async move {
-            hrana::ws::serve(
-                auth,
-                idle_kicker,
-                max_response_size,
-                hrana_accept_rx,
-                hrana_upgrade_rx,
-                namespaces,
-                disable_default_namespace,
-                disable_namespaces,
-            )
-            .await
-            .context("Hrana server failed")
-        });
-    }
-
-    if let Some(addr) = config.http_addr {
-        let hrana_http_srv = Arc::new(hrana::http::Server::new(config.http_self_url.clone()));
-        join_set.spawn(http::run_http(
-            addr,
-            auth,
-            namespaces.clone(),
-            hrana_upgrade_tx,
-            hrana_http_srv.clone(),
-            config.enable_http_console,
-            idle_shutdown_layer,
-            stats.clone(),
-            proxy_service,
-            replication_service,
-            config.disable_default_namespace,
-            config.disable_namespaces,
-        ));
-        join_set.spawn(async move {
-            hrana_http_srv.run_expire().await;
-            Ok(())
-        });
-    }
-
-    if let Some(addr) = config.hrana_addr {
-        join_set.spawn(async move {
-            hrana::ws::listen(addr, hrana_accept_tx)
-                .await
-                .context("Hrana listener failed")
-        });
-    }
-
-    if let Some(addr) = config.admin_addr {
-        join_set.spawn(admin_api::run_admin_api(addr, db_config_store, namespaces));
-    }
-
-    match &config.heartbeat_url {
-        Some(heartbeat_url) => {
-            let heartbeat_period = config.heartbeat_period;
-            tracing::info!(
-                "Server sending heartbeat to URL {} every {:?}",
-                heartbeat_url,
-                heartbeat_period,
-            );
-            let heartbeat_url = heartbeat_url.clone();
-            let heartbeat_auth = config.heartbeat_auth.clone();
-            join_set.spawn(async move {
-                heartbeat::server_heartbeat(
-                    heartbeat_url,
-                    heartbeat_auth,
-                    heartbeat_period,
-                    stats.clone(),
-                )
-                .await;
-                Ok(())
-            });
+        if let Some(AdminApiConfig { acceptor }) = self.admin_api_config {
+            self.join_set.spawn(admin_api::run_admin_api(
+                acceptor,
+                self.db_config_store,
+                self.namespaces,
+            ));
         }
-        None => {
-            tracing::warn!("No server heartbeat configured")
-        }
-    }
-
-    Ok(())
-}
-
-fn get_auth(config: &Config) -> anyhow::Result<Arc<Auth>> {
-    let mut auth = Auth::default();
-
-    if let Some(arg) = config.http_auth.as_deref() {
-        if let Some(param) = auth::parse_http_basic_auth_arg(arg)? {
-            auth.http_basic = Some(param);
-            tracing::info!("Using legacy HTTP basic authentication");
-        }
-    }
-
-    if let Some(jwt_key) = config.auth_jwt_key.as_deref() {
-        let jwt_key = auth::parse_jwt_key(jwt_key).context("Could not parse JWT decoding key")?;
-        auth.jwt_key = Some(jwt_key);
-        tracing::info!("Using JWT-based authentication");
-    }
-
-    auth.disabled = auth.http_basic.is_none() && auth.jwt_key.is_none();
-    if auth.disabled {
-        tracing::warn!("No authentication specified, the server will not require authentication")
-    }
-
-    Ok(Arc::new(auth))
-}
-
-fn configure_rpc(config: &Config) -> anyhow::Result<(Channel, tonic::transport::Uri)> {
-    let mut endpoint = Channel::from_shared(config.writer_rpc_addr.clone().unwrap())?;
-    if config.writer_rpc_tls {
-        let cert_pem = std::fs::read_to_string(config.writer_rpc_cert.clone().unwrap())?;
-        let key_pem = std::fs::read_to_string(config.writer_rpc_key.clone().unwrap())?;
-        let identity = tonic::transport::Identity::from_pem(cert_pem, key_pem);
-
-        let ca_cert_pem = std::fs::read_to_string(config.writer_rpc_ca_cert.clone().unwrap())?;
-        let ca_cert = tonic::transport::Certificate::from_pem(ca_cert_pem);
-
-        let tls_config = tonic::transport::ClientTlsConfig::new()
-            .identity(identity)
-            .ca_certificate(ca_cert)
-            .domain_name("sqld");
-        endpoint = endpoint.tls_config(tls_config)?;
-    }
-
-    let channel = endpoint.connect_lazy();
-    let uri = tonic::transport::Uri::from_maybe_shared(config.writer_rpc_addr.clone().unwrap())?;
-
-    Ok((channel, uri))
-}
-
-pub enum ResetOp {
-    Reset(Bytes),
-    Destroy(Bytes),
-}
-
-async fn start_replica(
-    config: &Config,
-    join_set: &mut JoinSet<anyhow::Result<()>>,
-    idle_shutdown_layer: Option<IdleShutdownLayer>,
-    stats: Stats,
-    db_config_store: Arc<DatabaseConfigStore>,
-) -> anyhow::Result<()> {
-    let (channel, uri) = configure_rpc(config)?;
-    let extensions = validate_extensions(config.extensions_path.clone())?;
-    let (hard_reset_snd, mut hard_reset_rcv) = mpsc::channel(1);
-    let conf = ReplicaNamespaceConfig {
-        base_path: config.db_path.to_owned(),
-        channel: channel.clone(),
-        uri: uri.clone(),
-        extensions,
-        stats: stats.clone(),
-        config_store: db_config_store.clone(),
-        max_response_size: config.max_response_size,
-        max_total_response_size: config.max_total_response_size,
-        hard_reset: hard_reset_snd,
-    };
-    let factory = ReplicaNamespaceMaker::new(conf);
-    let namespaces = Arc::new(NamespaceStore::new(factory, true));
-
-    // start the hard reset monitor
-    join_set.spawn({
-        let namespaces = namespaces.clone();
-        async move {
-            while let Some(op) = hard_reset_rcv.recv().await {
-                match op {
-                    ResetOp::Reset(ns) => {
-                        tracing::warn!(
-                            "received reset signal for: {:?}",
-                            std::str::from_utf8(&ns).ok()
-                        );
-                        namespaces.reset(ns, RestoreOption::Latest).await?;
-                    }
-                    ResetOp::Destroy(ns) => {
-                        namespaces.destroy(ns).await?;
-                    }
-                }
-            }
-
-            Ok(())
-        }
-    });
-
-    let replication_service = ReplicationLogProxyService::new(channel.clone(), uri.clone());
-    let proxy_service = ReplicaProxyService::new(channel, uri);
-
-    run_service(
-        namespaces,
-        config,
-        join_set,
-        idle_shutdown_layer,
-        stats,
-        db_config_store,
-        proxy_service,
-        replication_service,
-    )
-    .await?;
-
-    Ok(())
-}
-
-fn check_fresh_db(path: &Path) -> bool {
-    !path.join("wallog").exists()
-}
-
-fn validate_extensions(extensions_path: Option<PathBuf>) -> anyhow::Result<Vec<PathBuf>> {
-    let mut valid_extensions = vec![];
-    if let Some(ext_dir) = extensions_path {
-        let extensions_list = ext_dir.join("trusted.lst");
-
-        let file_contents = std::fs::read_to_string(&extensions_list)
-            .with_context(|| format!("can't read {}", &extensions_list.display()))?;
-
-        let extensions = file_contents.lines().filter(|c| !c.is_empty());
-
-        for line in extensions {
-            let mut ext_info = line.trim().split_ascii_whitespace();
-
-            let ext_sha = ext_info.next().ok_or_else(|| {
-                anyhow::anyhow!("invalid line on {}: {}", &extensions_list.display(), line)
-            })?;
-            let ext_fname = ext_info.next().ok_or_else(|| {
-                anyhow::anyhow!("invalid line on {}: {}", &extensions_list.display(), line)
-            })?;
-
-            anyhow::ensure!(
-                ext_info.next().is_none(),
-                "extension list seem to contain a filename with whitespaces. Rejected"
-            );
-
-            let extension_full_path = ext_dir.join(ext_fname);
-            let digest = try_digest(extension_full_path.as_path()).with_context(|| {
-                format!(
-                    "Failed to get sha256 digest, while trying to read {}",
-                    extension_full_path.display()
-                )
-            })?;
-
-            anyhow::ensure!(
-                digest == ext_sha,
-                "sha256 differs for {}. Got {}",
-                ext_fname,
-                digest
-            );
-            valid_extensions.push(extension_full_path);
-        }
-    }
-    Ok(valid_extensions)
-}
-
-pub async fn init_bottomless_replicator(
-    path: impl AsRef<std::path::Path>,
-    options: bottomless::replicator::Options,
-    restore_option: &RestoreOption,
-) -> anyhow::Result<(bottomless::replicator::Replicator, bool)> {
-    tracing::debug!("Initializing bottomless replication");
-    let path = path
-        .as_ref()
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("Invalid db path"))?
-        .to_owned();
-    let mut replicator = bottomless::replicator::Replicator::with_options(path, options).await?;
-
-    let (generation, timestamp) = match restore_option {
-        RestoreOption::Latest | RestoreOption::Dump(_) => (None, None),
-        RestoreOption::Generation(generation) => (Some(*generation), None),
-        RestoreOption::PointInTime(timestamp) => (None, Some(*timestamp)),
-    };
-
-    let (action, did_recover) = replicator.restore(generation, timestamp).await?;
-    match action {
-        bottomless::replicator::RestoreAction::SnapshotMainDbFile => {
-            replicator.new_generation();
-            replicator.snapshot_main_db_file(None).await?;
-            // Restoration process only leaves the local WAL file if it was
-            // detected to be newer than its remote counterpart.
-            replicator.maybe_replicate_wal().await?
-        }
-        bottomless::replicator::RestoreAction::ReuseGeneration(gen) => {
-            replicator.set_generation(gen);
-        }
-    }
-
-    Ok((replicator, did_recover))
-}
-
-async fn start_primary(
-    config: &Config,
-    join_set: &mut JoinSet<anyhow::Result<()>>,
-    idle_shutdown_layer: Option<IdleShutdownLayer>,
-    stats: Stats,
-    config_store: Arc<DatabaseConfigStore>,
-    db_is_dirty: bool,
-    snapshot_callback: NamespacedSnapshotCallback,
-) -> anyhow::Result<()> {
-    let extensions = validate_extensions(config.extensions_path.clone())?;
-    let conf = PrimaryNamespaceConfig {
-        base_path: config.db_path.to_owned(),
-        max_log_size: config.max_log_size,
-        db_is_dirty,
-        max_log_duration: config.max_log_duration.map(Duration::from_secs_f32),
-        snapshot_callback,
-        bottomless_replication: config.bottomless_replication.clone(),
-        extensions,
-        stats: stats.clone(),
-        config_store: config_store.clone(),
-        max_response_size: config.max_response_size,
-        max_total_response_size: config.max_total_response_size,
-        checkpoint_interval: config.checkpoint_interval,
-        disable_namespace: config.disable_namespaces,
-    };
-    let factory = PrimaryNamespaceMaker::new(conf);
-    let namespaces = Arc::new(NamespaceStore::new(factory, false));
-
-    if config.disable_namespaces {
-        // eagerly load the default namespace
-        namespaces
-            .create(DEFAULT_NAMESPACE_NAME.into(), RestoreOption::Latest)
-            .await?;
-    }
-
-    if let Some(ref addr) = config.rpc_server_addr {
-        join_set.spawn(run_rpc_server(
-            *addr,
-            config.rpc_server_tls,
-            config.rpc_server_cert.clone(),
-            config.rpc_server_key.clone(),
-            config.rpc_server_ca_cert.clone(),
-            idle_shutdown_layer.clone(),
-            namespaces.clone(),
-            config.disable_namespaces,
-        ));
-    }
-
-    let auth = get_auth(config)?;
-
-    let logger_service = ReplicationLogService::new(
-        namespaces.clone(),
-        idle_shutdown_layer.clone(),
-        Some(auth.clone()),
-        config.disable_namespaces,
-    );
-
-    let proxy_service =
-        ProxyService::new(namespaces.clone(), Some(auth), config.disable_namespaces);
-
-    run_service(
-        namespaces.clone(),
-        config,
-        join_set,
-        idle_shutdown_layer,
-        stats,
-        config_store,
-        proxy_service,
-        logger_service,
-    )
-    .await?;
-
-    Ok(())
-}
-
-async fn run_periodic_compactions(logger: Arc<ReplicationLogger>) -> anyhow::Result<()> {
-    // calling `ReplicationLogger::maybe_compact()` is cheap if the compaction does not actually
-    // take place, so we can affort to poll it very often for simplicity
-    let mut interval = tokio::time::interval(Duration::from_millis(1000));
-    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-
-    loop {
-        interval.tick().await;
-        let handle = tokio::task::spawn_blocking(enclose! {(logger) move || {
-            logger.maybe_compact()
-        }});
-        handle
-            .await
-            .expect("Compaction task crashed")
-            .context("Compaction failed")?;
     }
 }
 
 // Periodically check the storage used by the database and save it in the Stats structure.
 // TODO: Once we have a separate fiber that does WAL checkpoints, running this routine
 // right after checkpointing is exactly where it should be done.
-async fn run_storage_monitor(db_path: PathBuf, stats: Stats) -> anyhow::Result<()> {
+async fn run_storage_monitor(db_path: Arc<Path>, stats: Stats) -> anyhow::Result<()> {
     let (_drop_guard, exit_notify) = std::sync::mpsc::channel::<Never>();
     let _ = tokio::task::spawn_blocking(move || {
         let duration = tokio::time::Duration::from_secs(60);
@@ -599,7 +187,6 @@ async fn run_storage_monitor(db_path: PathBuf, stats: Stats) -> anyhow::Result<(
                     Err(RecvTimeoutError::Timeout) => (),
 
                 }
-
                 if maybe_conn.is_none() {
                     break
                 }
@@ -610,7 +197,7 @@ async fn run_storage_monitor(db_path: PathBuf, stats: Stats) -> anyhow::Result<(
     Ok(())
 }
 
-async fn run_checkpoint_cron(db_path: PathBuf, period: Duration) -> anyhow::Result<()> {
+async fn run_checkpoint_cron(db_path: Arc<Path>, period: Duration) -> anyhow::Result<()> {
     const RETRY_INTERVAL: Duration = Duration::from_secs(60);
     let data_path = db_path.join("data");
     tracing::info!("setting checkpoint interval to {:?}", period);
@@ -664,6 +251,7 @@ async fn run_checkpoint_cron(db_path: PathBuf, period: Duration) -> anyhow::Resu
 fn sentinel_file_path(path: &Path) -> PathBuf {
     path.join(".sentinel")
 }
+
 /// initialize the sentinel file. This file is created at the beginning of the process, and is
 /// deleted at the end, on a clean exit. If the file is present when we start the process, this
 /// means that the database was not shutdown properly, and might need repair. This function return
@@ -695,59 +283,38 @@ fn init_version_file(db_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn run_server(config: Config) -> anyhow::Result<()> {
-    tracing::trace!("Backend: {:?}", config.backend);
-
-    init_version_file(&config.db_path)?;
-    maybe_migrate(&config.db_path)?;
-
-    if config.bottomless_replication.is_some() {
-        bottomless::static_init::register_bottomless_methods();
-    }
-
-    if let Some(soft_limit_mb) = config.soft_heap_limit_mb {
-        tracing::warn!("Setting soft heap limit to {soft_limit_mb}MiB");
-        unsafe {
-            sqld_libsql_bindings::ffi::sqlite3_soft_heap_limit64(soft_limit_mb as i64 * 1024 * 1024)
-        };
-    }
-    if let Some(hard_limit_mb) = config.hard_heap_limit_mb {
-        tracing::warn!("Setting hard heap limit to {hard_limit_mb}MiB");
-        unsafe {
-            sqld_libsql_bindings::ffi::sqlite3_hard_heap_limit64(hard_limit_mb as i64 * 1024 * 1024)
-        };
-    }
-
-    loop {
-        if !config.db_path.exists() {
-            std::fs::create_dir_all(&config.db_path)?;
+impl<C, A> Server<C, A>
+where
+    C: Connector,
+    A: Accept,
+{
+    /// Setup sqlite global environment
+    fn init_sqlite_globals(&self) {
+        if self.db_config.bottomless_replication.is_some() {
+            bottomless::static_init::register_bottomless_methods();
         }
-        let mut join_set = JoinSet::new();
 
-        let (shutdown_sender, mut shutdown_receiver) = tokio::sync::mpsc::channel::<()>(1);
+        if let Some(soft_limit_mb) = self.db_config.soft_heap_limit_mb {
+            tracing::warn!("Setting soft heap limit to {soft_limit_mb}MiB");
+            unsafe {
+                sqld_libsql_bindings::ffi::sqlite3_soft_heap_limit64(
+                    soft_limit_mb as i64 * 1024 * 1024,
+                )
+            };
+        }
+        if let Some(hard_limit_mb) = self.db_config.hard_heap_limit_mb {
+            tracing::warn!("Setting hard heap limit to {hard_limit_mb}MiB");
+            unsafe {
+                sqld_libsql_bindings::ffi::sqlite3_hard_heap_limit64(
+                    hard_limit_mb as i64 * 1024 * 1024,
+                )
+            };
+        }
+    }
 
-        join_set.spawn({
-            let shutdown_sender = shutdown_sender.clone();
-            async move {
-                loop {
-                    tokio::signal::ctrl_c()
-                        .await
-                        .expect("failed to listen to CTRL-C");
-                    tracing::info!(
-                        "received CTRL-C, shutting down gracefully... This may take some time"
-                    );
-                    shutdown_sender
-                        .send(())
-                        .await
-                        .expect("failed to shutdown gracefully");
-                }
-            }
-        });
-
-        let db_is_dirty = init_sentinel_file(&config.db_path)?;
-
-        let snapshot_exec = config.snapshot_exec.clone();
-        let snapshot_callback = Arc::new(move |snapshot_file: &Path, namespace: &Bytes| {
+    pub fn make_snapshot_callback(&self) -> NamespacedSnapshotCallback {
+        let snapshot_exec = self.db_config.snapshot_exec.clone();
+        Arc::new(move |snapshot_file: &Path, namespace: &Bytes| {
             if let Some(exec) = snapshot_exec.as_ref() {
                 let ns = std::str::from_utf8(namespace)?;
                 let status = Command::new(exec).arg(snapshot_file).arg(ns).status()?;
@@ -757,70 +324,267 @@ pub async fn run_server(config: Config) -> anyhow::Result<()> {
                 );
             }
             Ok(())
-        });
+        })
+    }
 
-        let idle_shutdown_layer = config.idle_shutdown_timeout.map(|d| {
-            IdleShutdownLayer::new(
-                d,
-                config.initial_idle_shutdown_timeout,
-                shutdown_sender.clone(),
-            )
-        });
+    fn spawn_monitoring_tasks(&self, join_set: &mut JoinSet<anyhow::Result<()>>, stats: Stats) {
+        match self.heartbeat_config {
+            Some(ref config) => {
+                tracing::info!(
+                    "Server sending heartbeat to URL {} every {:?}",
+                    config.heartbeat_url,
+                    config.heartbeat_period,
+                );
+                join_set.spawn({
+                    let heartbeat_url = config.heartbeat_url.clone();
+                    let heartbeat_auth = config.heartbeat_auth.clone();
+                    let heartbeat_period = config.heartbeat_period;
+                    let stats = stats.clone();
+                    async move {
+                        heartbeat::server_heartbeat(
+                            heartbeat_url,
+                            heartbeat_auth,
+                            heartbeat_period,
+                            stats,
+                        )
+                        .await;
+                        Ok(())
+                    }
+                });
 
-        let stats = Stats::new(&config.db_path)?;
-
-        let db_config_store = Arc::new(
-            DatabaseConfigStore::load(&config.db_path).context("Could not load database config")?,
-        );
-
-        match config.writer_rpc_addr {
-            Some(_) => {
-                start_replica(
-                    &config,
-                    &mut join_set,
-                    idle_shutdown_layer,
-                    stats.clone(),
-                    db_config_store,
-                )
-                .await?
+                join_set.spawn(run_storage_monitor(self.path.clone(), stats));
             }
             None => {
-                start_primary(
-                    &config,
-                    &mut join_set,
-                    idle_shutdown_layer,
-                    stats.clone(),
+                tracing::warn!("No server heartbeat configured")
+            }
+        }
+    }
+
+    pub async fn start(self) -> anyhow::Result<()> {
+        let mut join_set = JoinSet::new();
+
+        init_version_file(&self.path)?;
+        maybe_migrate(&self.path)?;
+        let stats = Stats::new(&self.path)?;
+        self.spawn_monitoring_tasks(&mut join_set, stats.clone());
+        self.init_sqlite_globals();
+        let db_is_dirty = init_sentinel_file(&self.path)?;
+        let idle_shutdown_kicker = self.setup_shutdown();
+
+        if let Some(interval) = self.db_config.checkpoint_interval {
+            if self.db_config.bottomless_replication.is_some() {
+                join_set.spawn(run_checkpoint_cron(self.path.clone(), interval));
+            }
+        }
+
+        let db_config_store = Arc::new(
+            DatabaseConfigStore::load(&self.path).context("Could not load database config")?,
+        );
+        let snapshot_callback = self.make_snapshot_callback();
+        let auth = self.user_api_config.get_auth()?.into();
+        let extensions = self.db_config.validate_extensions()?;
+
+        match self.rpc_client_config {
+            Some(rpc_config) => {
+                let replica = Replica {
+                    rpc_config,
+                    stats: stats.clone(),
+                    db_config_store: db_config_store.clone(),
+                    extensions,
+                    db_config: self.db_config.clone(),
+                    base_path: self.path.clone(),
+                };
+                let (namespaces, proxy_service, replication_service) = replica.configure().await?;
+                let services = Services {
+                    namespaces,
+                    idle_shutdown_kicker,
+                    stats,
                     db_config_store,
+                    proxy_service,
+                    replication_service,
+                    user_api_config: self.user_api_config,
+                    admin_api_config: self.admin_api_config,
+                    disable_namespaces: self.disable_namespaces,
+                    disable_default_namespace: self.disable_default_namespace,
+                    db_config: self.db_config,
+                    auth,
+                    join_set: &mut join_set,
+                };
+
+                services.configure();
+            }
+            None => {
+                let primary = Primary {
+                    rpc_config: self.rpc_server_config,
+                    db_config: self.db_config.clone(),
+                    idle_shutdown_kicker: idle_shutdown_kicker.clone(),
+                    stats: stats.clone(),
+                    db_config_store: db_config_store.clone(),
                     db_is_dirty,
                     snapshot_callback,
+                    extensions,
+                    base_path: self.path.clone(),
+                    disable_namespaces: self.disable_namespaces,
+                    join_set: &mut join_set,
+                    auth: auth.clone(),
+                };
+                let (namespaces, proxy_service, replication_service) = primary.configure().await?;
+
+                let services = Services {
+                    namespaces,
+                    idle_shutdown_kicker,
+                    stats,
+                    db_config_store,
+                    proxy_service,
+                    replication_service,
+                    user_api_config: self.user_api_config,
+                    admin_api_config: self.admin_api_config,
+                    disable_namespaces: self.disable_namespaces,
+                    disable_default_namespace: self.disable_default_namespace,
+                    db_config: self.db_config,
+                    auth,
+                    join_set: &mut join_set,
+                };
+
+                services.configure();
+            }
+        }
+
+        tokio::select! {
+            _ = self.shutdown.notified() => {
+                join_set.shutdown().await;
+                // clean shutdown, remove sentinel file
+                std::fs::remove_file(sentinel_file_path(&self.path))?;
+            }
+            Some(res) = join_set.join_next() => {
+                res??;
+            },
+            else => (),
+        }
+
+        Ok(())
+    }
+
+    fn setup_shutdown(&self) -> Option<IdleShutdownKicker> {
+        let shutdown_notify = self.shutdown.clone();
+        self.idle_shutdown_timeout.map(|d| {
+            IdleShutdownKicker::new(d, self.initial_idle_shutdown_timeout, shutdown_notify)
+        })
+    }
+}
+
+struct Primary<'a, A> {
+    rpc_config: Option<RpcServerConfig<A>>,
+    db_config: DbConfig,
+    idle_shutdown_kicker: Option<IdleShutdownKicker>,
+    stats: Stats,
+    db_config_store: Arc<DatabaseConfigStore>,
+    db_is_dirty: bool,
+    snapshot_callback: NamespacedSnapshotCallback,
+    extensions: Arc<[PathBuf]>,
+    base_path: Arc<Path>,
+    disable_namespaces: bool,
+    auth: Arc<Auth>,
+    join_set: &'a mut JoinSet<anyhow::Result<()>>,
+}
+
+impl<A> Primary<'_, A>
+where
+    A: Accept,
+{
+    async fn configure(
+        mut self,
+    ) -> anyhow::Result<(
+        NamespaceStore<PrimaryNamespaceMaker>,
+        ProxyService,
+        ReplicationLogService,
+    )> {
+        let conf = PrimaryNamespaceConfig {
+            base_path: self.base_path,
+            max_log_size: self.db_config.max_log_size,
+            db_is_dirty: self.db_is_dirty,
+            max_log_duration: self.db_config.max_log_duration.map(Duration::from_secs_f32),
+            snapshot_callback: self.snapshot_callback,
+            bottomless_replication: self.db_config.bottomless_replication,
+            extensions: self.extensions,
+            stats: self.stats,
+            config_store: self.db_config_store,
+            max_response_size: self.db_config.max_response_size,
+            max_total_response_size: self.db_config.max_total_response_size,
+            checkpoint_interval: self.db_config.checkpoint_interval,
+            disable_namespace: self.disable_namespaces,
+        };
+        let factory = PrimaryNamespaceMaker::new(conf);
+        let namespaces = NamespaceStore::new(factory, false);
+
+        // eagerly load the default namespace when namespaces are disabled
+        if self.disable_namespaces {
+            namespaces
+                .create(
+                    DEFAULT_NAMESPACE_NAME.into(),
+                    namespace::RestoreOption::Latest,
                 )
-                .await?
-            }
+                .await?;
         }
 
-        if config.heartbeat_url.is_some() {
-            join_set.spawn(run_storage_monitor(config.db_path.clone(), stats));
+        if let Some(config) = self.rpc_config.take() {
+            self.join_set.spawn(run_rpc_server(
+                config.acceptor,
+                config.tls_config,
+                self.idle_shutdown_kicker.clone(),
+                namespaces.clone(),
+                self.disable_namespaces,
+            ));
         }
 
-        if let Some(interval) = config.checkpoint_interval {
-            if config.bottomless_replication.is_some() {
-                join_set.spawn(run_checkpoint_cron(config.db_path.clone(), interval));
-            }
-        }
+        let logger_service = ReplicationLogService::new(
+            namespaces.clone(),
+            self.idle_shutdown_kicker,
+            Some(self.auth.clone()),
+            self.disable_namespaces,
+        );
 
-        loop {
-            tokio::select! {
-                _ = shutdown_receiver.recv() => {
-                    join_set.shutdown().await;
-                    // clean shutdown, remove sentinel file
-                    std::fs::remove_file(sentinel_file_path(&config.db_path))?;
-                    return Ok(())
-                }
-                Some(res) = join_set.join_next() => {
-                    res??;
-                },
-                else => return Ok(()),
-            }
-        }
+        let proxy_service =
+            ProxyService::new(namespaces.clone(), Some(self.auth), self.disable_namespaces);
+
+        Ok((namespaces, proxy_service, logger_service))
+    }
+}
+
+struct Replica<C> {
+    rpc_config: RpcClientConfig<C>,
+    stats: Stats,
+    db_config_store: Arc<DatabaseConfigStore>,
+    extensions: Arc<[PathBuf]>,
+    db_config: DbConfig,
+    base_path: Arc<Path>,
+}
+
+impl<C: Connector> Replica<C> {
+    async fn configure(
+        self,
+    ) -> anyhow::Result<(
+        NamespaceStore<impl MakeNamespace>,
+        impl Proxy,
+        impl ReplicationLog,
+    )> {
+        let (channel, uri) = self.rpc_config.configure().await?;
+
+        let conf = ReplicaNamespaceConfig {
+            channel: channel.clone(),
+            uri: uri.clone(),
+            extensions: self.extensions.clone(),
+            stats: self.stats.clone(),
+            config_store: self.db_config_store.clone(),
+            base_path: self.base_path,
+            max_response_size: self.db_config.max_response_size,
+            max_total_response_size: self.db_config.max_total_response_size,
+        };
+        let factory = ReplicaNamespaceMaker::new(conf);
+        let namespaces = NamespaceStore::new(factory, true);
+        let replication_service = ReplicationLogProxyService::new(channel.clone(), uri.clone());
+        let proxy_service = ReplicaProxyService::new(channel, uri);
+
+        Ok((namespaces, proxy_service, replication_service))
     }
 }

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -1,18 +1,27 @@
 use std::env;
-use std::fs::{self, OpenOptions};
+use std::fs::OpenOptions;
 use std::io::{stdout, Write};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{bail, Context as _, Result};
 use bytesize::ByteSize;
 use clap::Parser;
+use hyper::client::HttpConnector;
 use mimalloc::MiMalloc;
-use sqld::{connection::dump::exporter::export_dump, version::Version, Config};
+use tokio::sync::Notify;
 use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::Layer;
+
+use sqld::config::{
+    AdminApiConfig, DbConfig, RpcClientConfig, RpcServerConfig, TlsConfig, UserApiConfig,
+};
+use sqld::net::AddrIncoming;
+use sqld::{connection::dump::exporter::export_dump, version::Version};
+use sqld::{HeartbeatConfig, Server};
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -27,8 +36,7 @@ struct Cli {
 
     /// The directory path where trusted extensions can be loaded from.
     /// If not present, extension loading is disabled.
-    /// If present, the directory is expected to have a trusted.lst file containing
-    /// the sha256 and name of each extension, one per line. Example:
+    /// If present, the directory is expected to have a trusted.lst file containing the sha256 and name of each extension, one per line. Example:
     ///
     /// 99890762817735984843bf5cf02a4b2ea648018fd05f04df6f9ce7f976841510  math.dylib
     #[clap(long, short)]
@@ -100,15 +108,6 @@ struct Cli {
     primary_grpc_key_file: Option<PathBuf>,
     #[clap(long)]
     primary_grpc_ca_cert_file: Option<PathBuf>,
-
-    #[clap(
-        long,
-        short,
-        value_enum,
-        default_value = "libsql",
-        env = "SQLD_BACKEND"
-    )]
-    backend: sqld::Backend,
 
     /// Don't display welcome message
     #[clap(long)]
@@ -247,66 +246,6 @@ impl Cli {
     }
 }
 
-fn config_from_args(args: Cli) -> Result<Config> {
-    let auth_jwt_key = if let Some(file_path) = args.auth_jwt_key_file {
-        let data = fs::read_to_string(file_path).context("Could not read file with JWT key")?;
-        Some(data)
-    } else {
-        match env::var("SQLD_AUTH_JWT_KEY") {
-            Ok(key) => Some(key),
-            Err(env::VarError::NotPresent) => None,
-            Err(env::VarError::NotUnicode(_)) => {
-                bail!("Env variable SQLD_AUTH_JWT_KEY does not contain a valid Unicode value")
-            }
-        }
-    };
-
-    Ok(Config {
-        db_path: args.db_path,
-        extensions_path: args.extensions_path,
-        http_addr: Some(args.http_listen_addr),
-        enable_http_console: args.enable_http_console,
-        hrana_addr: args.hrana_listen_addr,
-        admin_addr: args.admin_listen_addr,
-        auth_jwt_key,
-        http_auth: args.http_auth,
-        http_self_url: args.http_self_url,
-        backend: args.backend,
-        writer_rpc_addr: args.primary_grpc_url,
-        writer_rpc_tls: args.primary_grpc_tls,
-        writer_rpc_cert: args.primary_grpc_cert_file,
-        writer_rpc_key: args.primary_grpc_key_file,
-        writer_rpc_ca_cert: args.primary_grpc_ca_cert_file,
-        rpc_server_addr: args.grpc_listen_addr,
-        rpc_server_tls: args.grpc_tls,
-        rpc_server_cert: args.grpc_cert_file,
-        rpc_server_key: args.grpc_key_file,
-        rpc_server_ca_cert: args.grpc_ca_cert_file,
-        bottomless_replication: if args.enable_bottomless_replication {
-            Some(bottomless::replicator::Options::from_env()?)
-        } else {
-            None
-        },
-        idle_shutdown_timeout: args.idle_shutdown_timeout_s.map(Duration::from_secs),
-        initial_idle_shutdown_timeout: args
-            .initial_idle_shutdown_timeout_s
-            .map(Duration::from_secs),
-        max_log_size: args.max_log_size,
-        max_log_duration: args.max_log_duration,
-        heartbeat_url: args.heartbeat_url,
-        heartbeat_auth: args.heartbeat_auth,
-        heartbeat_period: Duration::from_secs(args.heartbeat_period_s),
-        soft_heap_limit_mb: args.soft_heap_limit_mb,
-        hard_heap_limit_mb: args.hard_heap_limit_mb,
-        max_response_size: args.max_response_size.0,
-        max_total_response_size: args.max_total_response_size.0,
-        snapshot_exec: args.snapshot_exec,
-        disable_default_namespace: args.disable_default_namespace,
-        disable_namespaces: !args.enable_namespaces,
-        checkpoint_interval: args.checkpoint_interval_s.map(Duration::from_secs),
-    })
-}
-
 fn perform_dump(dump_path: Option<&Path>, db_path: &Path) -> anyhow::Result<()> {
     let out: Box<dyn Write> = match dump_path {
         Some(path) => {
@@ -339,6 +278,204 @@ fn enable_libsql_logging() {
     ONCE.call_once(|| unsafe {
         rusqlite::trace::config_log(Some(libsql_log)).unwrap();
     });
+}
+
+fn make_db_config(config: &Cli) -> anyhow::Result<DbConfig> {
+    Ok(DbConfig {
+        extensions_path: config.extensions_path.clone().map(Into::into),
+        bottomless_replication: config
+            .enable_bottomless_replication
+            .then(bottomless::replicator::Options::from_env)
+            .transpose()?,
+        max_log_size: config.max_log_size,
+        max_log_duration: config.max_log_duration,
+        soft_heap_limit_mb: config.soft_heap_limit_mb,
+        hard_heap_limit_mb: config.hard_heap_limit_mb,
+        max_response_size: config.max_response_size.as_u64(),
+        max_total_response_size: config.max_total_response_size.as_u64(),
+        snapshot_exec: config.snapshot_exec.clone(),
+        checkpoint_interval: config.checkpoint_interval_s.map(Duration::from_secs),
+    })
+}
+
+async fn make_user_api_config(config: &Cli) -> anyhow::Result<UserApiConfig> {
+    let auth_jwt_key = if let Some(ref file_path) = config.auth_jwt_key_file {
+        let data = tokio::fs::read_to_string(file_path)
+            .await
+            .context("Could not read file with JWT key")?;
+        Some(data)
+    } else {
+        match env::var("SQLD_AUTH_JWT_KEY") {
+            Ok(key) => Some(key),
+            Err(env::VarError::NotPresent) => None,
+            Err(env::VarError::NotUnicode(_)) => {
+                bail!("Env variable SQLD_AUTH_JWT_KEY does not contain a valid Unicode value")
+            }
+        }
+    };
+    let http_acceptor =
+        AddrIncoming::new(tokio::net::TcpListener::bind(config.http_listen_addr).await?);
+    tracing::info!(
+        "listening for incomming user HTTP connection on {}",
+        config.http_listen_addr
+    );
+
+    let hrana_ws_acceptor = match config.hrana_listen_addr {
+        Some(addr) => {
+            let incoming = AddrIncoming::new(tokio::net::TcpListener::bind(addr).await?);
+
+            tracing::info!(
+                "listening for incomming user hrana websocket connection on {}",
+                addr
+            );
+
+            Some(incoming)
+        }
+        None => None,
+    };
+
+    Ok(UserApiConfig {
+        http_acceptor: Some(http_acceptor),
+        hrana_ws_acceptor,
+        enable_http_console: config.enable_http_console,
+        self_url: config.http_self_url.clone(),
+        http_auth: config.http_auth.clone(),
+        auth_jwt_key,
+    })
+}
+
+async fn make_admin_api_config(config: &Cli) -> anyhow::Result<Option<AdminApiConfig>> {
+    match config.admin_listen_addr {
+        Some(addr) => {
+            let acceptor = AddrIncoming::new(tokio::net::TcpListener::bind(addr).await?);
+
+            tracing::info!("listening for incomming adming HTTP connection on {}", addr);
+
+            Ok(Some(AdminApiConfig { acceptor }))
+        }
+        None => Ok(None),
+    }
+}
+
+async fn make_rpc_server_config(config: &Cli) -> anyhow::Result<Option<RpcServerConfig>> {
+    match config.grpc_listen_addr {
+        Some(addr) => {
+            let acceptor = AddrIncoming::new(tokio::net::TcpListener::bind(addr).await?);
+
+            tracing::info!("listening for incomming gRPC connection on {}", addr);
+
+            let tls_config = if config.grpc_tls {
+                Some(TlsConfig {
+                    cert: config
+                        .grpc_cert_file
+                        .clone()
+                        .context("server tls is enabled but cert file is missing")?,
+                    key: config
+                        .grpc_key_file
+                        .clone()
+                        .context("server tls is enabled but key file is missing")?,
+                    ca_cert: config
+                        .grpc_ca_cert_file
+                        .clone()
+                        .context("server tls is enabled but ca_cert file is missing")?,
+                })
+            } else {
+                None
+            };
+
+            Ok(Some(RpcServerConfig {
+                acceptor,
+                addr,
+                tls_config,
+            }))
+        }
+        None => Ok(None),
+    }
+}
+
+async fn make_rpc_client_config(config: &Cli) -> anyhow::Result<Option<RpcClientConfig>> {
+    match config.primary_grpc_url {
+        Some(ref url) => {
+            let mut connector = HttpConnector::new();
+            connector.enforce_http(true);
+            connector.set_nodelay(true);
+            let tls_config = if config.primary_grpc_tls {
+                Some(TlsConfig {
+                    cert: config
+                        .primary_grpc_cert_file
+                        .clone()
+                        .context("client tls is enabled but cert file is missing")?,
+                    key: config
+                        .primary_grpc_key_file
+                        .clone()
+                        .context("client tls is enabled but key file is missing")?,
+                    ca_cert: config
+                        .primary_grpc_ca_cert_file
+                        .clone()
+                        .context("client tls is enabled but ca_cert file is missing")?,
+                })
+            } else {
+                None
+            };
+
+            Ok(Some(RpcClientConfig {
+                remote_url: url.clone(),
+                connector,
+                tls_config,
+            }))
+        }
+        None => Ok(None),
+    }
+}
+
+fn make_hearbeat_config(config: &Cli) -> Option<HeartbeatConfig> {
+    Some(HeartbeatConfig {
+        heartbeat_url: config.heartbeat_url.clone()?,
+        heartbeat_period: Duration::from_secs(config.heartbeat_period_s),
+        heartbeat_auth: config.heartbeat_auth.clone(),
+    })
+}
+
+async fn build_server(config: &Cli) -> anyhow::Result<Server> {
+    let db_config = make_db_config(config)?;
+    let user_api_config = make_user_api_config(config).await?;
+    let admin_api_config = make_admin_api_config(config).await?;
+    let rpc_server_config = make_rpc_server_config(config).await?;
+    let rpc_client_config = make_rpc_client_config(config).await?;
+    let heartbeat_config = make_hearbeat_config(config);
+
+    let shutdown = Arc::new(Notify::new());
+    tokio::spawn({
+        let shutdown = shutdown.clone();
+        async move {
+            loop {
+                tokio::signal::ctrl_c()
+                    .await
+                    .expect("failed to listen to CTRL-C");
+                tracing::info!(
+                    "received CTRL-C, shutting down gracefully... This may take some time"
+                );
+                shutdown.notify_waiters();
+            }
+        }
+    });
+
+    Ok(Server {
+        path: config.db_path.clone().into(),
+        db_config,
+        user_api_config,
+        admin_api_config,
+        rpc_server_config,
+        rpc_client_config,
+        heartbeat_config,
+        idle_shutdown_timeout: config.idle_shutdown_timeout_s.map(Duration::from_secs),
+        initial_idle_shutdown_timeout: config
+            .initial_idle_shutdown_timeout_s
+            .map(Duration::from_secs),
+        disable_default_namespace: config.disable_default_namespace,
+        disable_namespaces: !config.enable_namespaces,
+        shutdown,
+    })
 }
 
 #[tokio::main]
@@ -385,8 +522,8 @@ async fn main() -> Result<()> {
         }
         None => {
             args.print_welcome_message();
-            let config = config_from_args(args)?;
-            sqld::run_server(config).await?;
+            let server = build_server(&args).await?;
+            server.start().await?;
 
             Ok(())
         }

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -17,11 +17,12 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::Layer;
 
 use sqld::config::{
-    AdminApiConfig, DbConfig, RpcClientConfig, RpcServerConfig, TlsConfig, UserApiConfig,
+    AdminApiConfig, DbConfig, HeartbeatConfig, RpcClientConfig, RpcServerConfig, TlsConfig,
+    UserApiConfig,
 };
 use sqld::net::AddrIncoming;
+use sqld::Server;
 use sqld::{connection::dump::exporter::export_dump, version::Version};
-use sqld::{HeartbeatConfig, Server};
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;

--- a/sqld/src/net.rs
+++ b/sqld/src/net.rs
@@ -1,0 +1,138 @@
+use std::error::Error as StdError;
+use std::io::Error as IoError;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
+
+use hyper::server::accept::Accept as HyperAccept;
+use hyper::Uri;
+use pin_project_lite::pin_project;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tonic::transport::server::{Connected, TcpConnectInfo};
+use tower::make::MakeConnection;
+
+pub trait Connector:
+    MakeConnection<Uri, Connection = Self::Conn, Future = Self::Fut, Error = Self::Err> + Send + 'static
+{
+    type Conn: Unpin + Send + 'static;
+    type Fut: Send + 'static;
+    type Err: StdError + Send + Sync;
+}
+
+impl<T> Connector for T
+where
+    T: MakeConnection<Uri> + Send + 'static,
+    T::Connection: Unpin + Send + 'static,
+    T::Future: Send + 'static,
+    T::Error: StdError + Send + Sync,
+{
+    type Conn = Self::Connection;
+    type Fut = Self::Future;
+    type Err = Self::Error;
+}
+
+pub trait Conn:
+    AsyncRead + AsyncWrite + Unpin + Send + 'static + Connected<ConnectInfo = TcpConnectInfo>
+{
+}
+
+pub trait Accept: HyperAccept<Conn = Self::Connection, Error = IoError> + Send + 'static {
+    type Connection: Conn;
+}
+
+pub struct AddrIncoming {
+    listener: tokio::net::TcpListener,
+}
+
+impl Drop for AddrIncoming {
+    fn drop(&mut self) {
+        dbg!();
+    }
+}
+
+impl AddrIncoming {
+    pub fn new(listener: tokio::net::TcpListener) -> Self {
+        Self { listener }
+    }
+}
+
+impl HyperAccept for AddrIncoming {
+    type Conn = AddrStream;
+    type Error = IoError;
+
+    fn poll_accept(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+        match ready!(self.listener.poll_accept(cx)) {
+            Ok((stream, remote_addr)) => {
+                // disable naggle algorithm
+                stream.set_nodelay(true)?;
+                let local_addr = stream.local_addr()?;
+                Poll::Ready(Some(Ok(AddrStream {
+                    stream,
+                    local_addr,
+                    remote_addr,
+                })))
+            }
+            Err(e) => Poll::Ready(Some(Err(e))),
+        }
+    }
+}
+
+pin_project! {
+    pub struct AddrStream {
+        #[pin]
+        stream: tokio::net::TcpStream,
+        remote_addr: SocketAddr,
+        local_addr: SocketAddr,
+    }
+}
+
+impl Accept for AddrIncoming {
+    type Connection = AddrStream;
+}
+
+impl Conn for AddrStream {}
+
+impl AsyncRead for AddrStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        self.project().stream.poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for AddrStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        self.project().stream.poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        self.project().stream.poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        self.project().stream.poll_shutdown(cx)
+    }
+}
+
+impl Connected for AddrStream {
+    type ConnectInfo = TcpConnectInfo;
+
+    fn connect_info(&self) -> Self::ConnectInfo {
+        self.stream.connect_info()
+    }
+}

--- a/sqld/src/net.rs
+++ b/sqld/src/net.rs
@@ -44,12 +44,6 @@ pub struct AddrIncoming {
     listener: tokio::net::TcpListener,
 }
 
-impl Drop for AddrIncoming {
-    fn drop(&mut self) {
-        dbg!();
-    }
-}
-
 impl AddrIncoming {
     pub fn new(listener: tokio::net::TcpListener) -> Self {
         Self { listener }

--- a/sqld/src/rpc/mod.rs
+++ b/sqld/src/rpc/mod.rs
@@ -1,17 +1,15 @@
 use anyhow::Context;
 use bytes::Bytes;
-use std::net::SocketAddr;
-use std::path::PathBuf;
-use std::sync::Arc;
 use tonic::Status;
 use tower::util::option_layer;
 
+use crate::config::TlsConfig;
 use crate::namespace::{NamespaceStore, PrimaryNamespaceMaker};
 use crate::rpc::proxy::rpc::proxy_server::ProxyServer;
 use crate::rpc::proxy::ProxyService;
 pub use crate::rpc::replication_log::rpc::replication_log_server::ReplicationLogServer;
 use crate::rpc::replication_log::ReplicationLogService;
-use crate::utils::services::idle_shutdown::IdleShutdownLayer;
+use crate::utils::services::idle_shutdown::IdleShutdownKicker;
 use crate::DEFAULT_NAMESPACE_NAME;
 
 pub mod proxy;
@@ -24,14 +22,11 @@ pub const NAMESPACE_DOESNT_EXIST: &str = "NAMESPACE_DOESNT_EXIST";
 pub(crate) const NAMESPACE_METADATA_KEY: &str = "x-namespace-bin";
 
 #[allow(clippy::too_many_arguments)]
-pub async fn run_rpc_server(
-    addr: SocketAddr,
-    tls: bool,
-    cert_path: Option<PathBuf>,
-    key_path: Option<PathBuf>,
-    ca_cert_path: Option<PathBuf>,
-    idle_shutdown_layer: Option<IdleShutdownLayer>,
-    namespaces: Arc<NamespaceStore<PrimaryNamespaceMaker>>,
+pub async fn run_rpc_server<A: crate::net::Accept>(
+    acceptor: A,
+    maybe_tls: Option<TlsConfig>,
+    idle_shutdown_layer: Option<IdleShutdownKicker>,
+    namespaces: NamespaceStore<PrimaryNamespaceMaker>,
     disable_namespaces: bool,
 ) -> anyhow::Result<()> {
     let proxy_service = ProxyService::new(namespaces.clone(), None, disable_namespaces);
@@ -42,15 +37,15 @@ pub async fn run_rpc_server(
         disable_namespaces,
     );
 
-    tracing::info!("serving write proxy server at {addr}");
+    // tracing::info!("serving write proxy server at {addr}");
 
     let mut builder = tonic::transport::Server::builder();
-    if tls {
-        let cert_pem = std::fs::read_to_string(cert_path.unwrap())?;
-        let key_pem = std::fs::read_to_string(key_path.unwrap())?;
+    if let Some(tls_config) = maybe_tls {
+        let cert_pem = std::fs::read_to_string(&tls_config.cert)?;
+        let key_pem = std::fs::read_to_string(&tls_config.key)?;
         let identity = tonic::transport::Identity::from_pem(cert_pem, key_pem);
 
-        let ca_cert_pem = std::fs::read_to_string(ca_cert_path.unwrap())?;
+        let ca_cert_pem = std::fs::read_to_string(&tls_config.ca_cert)?;
         let ca_cert = tonic::transport::Certificate::from_pem(ca_cert_pem);
 
         let tls_config = tonic::transport::ServerTlsConfig::new()
@@ -60,13 +55,17 @@ pub async fn run_rpc_server(
             .tls_config(tls_config)
             .context("Failed to read the TSL config of RPC server")?;
     }
-    builder
+    let router = builder
         .layer(&option_layer(idle_shutdown_layer))
         .add_service(ProxyServer::new(proxy_service))
         .add_service(ReplicationLogServer::new(logger_service))
-        .serve(addr)
-        .await?;
+        .into_router();
 
+    let h2c = crate::h2c::H2cMaker::new(router);
+    hyper::server::Server::builder(acceptor)
+        .serve(h2c)
+        .await
+        .context("http server")?;
     Ok(())
 }
 

--- a/sqld/src/rpc/proxy.rs
+++ b/sqld/src/rpc/proxy.rs
@@ -262,14 +262,14 @@ pub mod rpc {
 
 pub struct ProxyService {
     clients: RwLock<HashMap<Uuid, Arc<TrackedConnection<LibSqlConnection>>>>,
-    namespaces: Arc<NamespaceStore<PrimaryNamespaceMaker>>,
+    namespaces: NamespaceStore<PrimaryNamespaceMaker>,
     auth: Option<Arc<Auth>>,
     disable_namespaces: bool,
 }
 
 impl ProxyService {
     pub fn new(
-        namespaces: Arc<NamespaceStore<PrimaryNamespaceMaker>>,
+        namespaces: NamespaceStore<PrimaryNamespaceMaker>,
         auth: Option<Arc<Auth>>,
         disable_namespaces: bool,
     ) -> Self {

--- a/sqld/src/test/bottomless.rs
+++ b/sqld/src/test/bottomless.rs
@@ -1,26 +1,75 @@
-use crate::{run_server, Config};
 use anyhow::Result;
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::types::{Delete, ObjectIdentifier};
 use aws_sdk_s3::Client;
+use futures_core::Future;
 use itertools::Itertools;
 use libsql_client::{Connection, QueryResult, Statement, Value};
-use std::net::ToSocketAddrs;
+use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::PathBuf;
 use std::time::Duration;
-use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use url::Url;
 
+use crate::config::{DbConfig, UserApiConfig};
+use crate::net::AddrIncoming;
+use crate::Server;
+
 const S3_URL: &str = "http://localhost:9000/";
 
-fn start_db(step: u32, config: &Config) -> JoinHandle<()> {
-    let db_config = config.clone();
-    tokio::spawn(async move {
-        if let Err(e) = run_server(db_config).await {
+/// returns a future that once polled will shutdown the server and wait for cleanup
+fn start_db(step: u32, server: Server) -> impl Future<Output = ()> {
+    let notify = server.shutdown.clone();
+    let handle = tokio::spawn(async move {
+        if let Err(e) = server.start().await {
             panic!("Failed step {}: {}", step, e);
         }
-    })
+    });
+
+    async move {
+        notify.notify_waiters();
+        handle.await.unwrap();
+    }
+}
+
+async fn configure_server(
+    options: &bottomless::replicator::Options,
+    addr: SocketAddr,
+    path: impl Into<PathBuf>,
+) -> Server {
+    let http_acceptor = AddrIncoming::new(tokio::net::TcpListener::bind(addr).await.unwrap());
+    Server {
+        db_config: DbConfig {
+            extensions_path: None,
+            bottomless_replication: Some(options.clone()),
+            max_log_size: 200 * 4046,
+            max_log_duration: None,
+            soft_heap_limit_mb: None,
+            hard_heap_limit_mb: None,
+            max_response_size: 10000000 * 4096,
+            max_total_response_size: 10000000 * 4096,
+            snapshot_exec: None,
+            checkpoint_interval: None,
+        },
+        admin_api_config: None,
+        disable_namespaces: true,
+        user_api_config: UserApiConfig {
+            hrana_ws_acceptor: None,
+            http_acceptor: Some(http_acceptor),
+            enable_http_console: false,
+            self_url: None,
+            http_auth: None,
+            auth_jwt_key: None,
+        },
+        path: path.into().into(),
+        disable_default_namespace: false,
+        heartbeat_config: None,
+        idle_shutdown_timeout: None,
+        initial_idle_shutdown_timeout: None,
+        rpc_server_config: None,
+        rpc_client_config: None,
+        shutdown: Default::default(),
+    }
 }
 
 #[tokio::test]
@@ -35,33 +84,32 @@ async fn backup_restore() {
     let _ = S3BucketCleaner::new(BUCKET).await;
     assert_bucket_occupancy(BUCKET, true).await;
 
+    let options = bottomless::replicator::Options {
+        create_bucket_if_not_exists: true,
+        verify_crc: true,
+        use_compression: bottomless::replicator::CompressionKind::Gzip,
+        bucket_name: BUCKET.to_string(),
+        max_batch_interval: Duration::from_millis(250),
+        restore_transaction_page_swap_after: 1, // in this test swap should happen at least once
+        ..bottomless::replicator::Options::from_env().unwrap()
+    };
+    let connection_addr = Url::parse(&format!("http://localhost:{}", PORT)).unwrap();
     let listener_addr = format!("0.0.0.0:{}", PORT)
         .to_socket_addrs()
         .unwrap()
         .next()
         .unwrap();
-    let connection_addr = Url::parse(&format!("http://localhost:{}", PORT)).unwrap();
-    let db_config = Config {
-        bottomless_replication: Some(bottomless::replicator::Options {
-            create_bucket_if_not_exists: true,
-            verify_crc: true,
-            use_compression: bottomless::replicator::CompressionKind::Gzip,
-            bucket_name: BUCKET.to_string(),
-            max_batch_interval: Duration::from_millis(250),
-            restore_transaction_page_swap_after: 1, // in this test swap should happen at least once
-            ..bottomless::replicator::Options::from_env().unwrap()
-        }),
-        db_path: PATH.into(),
-        http_addr: Some(listener_addr),
-        ..Config::default()
-    };
+
+    let make_server = || async { configure_server(&options, listener_addr, PATH).await };
 
     {
         tracing::info!(
             "---STEP 1: create a local database, fill it with data, wait for WAL backup---"
         );
         let cleaner = DbFileCleaner::new(PATH);
-        let db_job = start_db(1, &db_config);
+        dbg!();
+        let db_job = start_db(1, make_server().await);
+        dbg!();
 
         sleep(Duration::from_secs(2)).await;
 
@@ -76,7 +124,7 @@ async fn backup_restore() {
 
         sleep(Duration::from_secs(2)).await;
 
-        db_job.abort();
+        db_job.await;
         drop(cleaner);
     }
 
@@ -89,13 +137,15 @@ async fn backup_restore() {
             "---STEP 2: recreate the database from WAL - create a snapshot at the end---"
         );
         let cleaner = DbFileCleaner::new(PATH);
-        let db_job = start_db(2, &db_config);
+        dbg!();
+        let db_job = start_db(2, make_server().await);
+        dbg!();
 
         sleep(Duration::from_secs(2)).await;
 
         assert_updates(&connection_addr, ROWS, OPS, "A").await;
 
-        db_job.abort();
+        db_job.await;
         drop(cleaner);
     }
 
@@ -104,7 +154,9 @@ async fn backup_restore() {
     {
         tracing::info!("---STEP 3: recreate database from snapshot alone---");
         let cleaner = DbFileCleaner::new(PATH);
-        let db_job = start_db(3, &db_config);
+        dbg!();
+        let db_job = start_db(3, make_server().await);
+        dbg!();
 
         sleep(Duration::from_secs(2)).await;
 
@@ -113,7 +165,7 @@ async fn backup_restore() {
 
         // wait for WAL to backup
         sleep(Duration::from_secs(2)).await;
-        db_job.abort();
+        db_job.await;
         drop(cleaner);
     }
 
@@ -122,13 +174,15 @@ async fn backup_restore() {
     {
         tracing::info!("---STEP 4: recreate the database from snapshot + WAL---");
         let cleaner = DbFileCleaner::new(PATH);
-        let db_job = start_db(4, &db_config);
+        dbg!();
+        let db_job = start_db(4, make_server().await);
+        dbg!();
 
         sleep(Duration::from_secs(2)).await;
 
         assert_updates(&connection_addr, ROWS, OPS, "B").await;
 
-        db_job.abort();
+        db_job.await;
         drop(cleaner);
     }
 
@@ -141,13 +195,15 @@ async fn backup_restore() {
         remove_snapshots(BUCKET).await;
 
         let cleaner = DbFileCleaner::new(PATH);
-        let db_job = start_db(4, &db_config);
+        dbg!();
+        let db_job = start_db(4, make_server().await);
+        dbg!();
 
         sleep(Duration::from_secs(2)).await;
 
         assert_updates(&connection_addr, ROWS, OPS, "B").await;
 
-        db_job.abort();
+        db_job.await;
         drop(cleaner);
     }
 }
@@ -182,25 +238,21 @@ async fn rollback_restore() {
         .next()
         .unwrap();
     let conn = Url::parse(&format!("http://localhost:{}", PORT)).unwrap();
-    let db_config = Config {
-        bottomless_replication: Some(bottomless::replicator::Options {
-            create_bucket_if_not_exists: true,
-            verify_crc: true,
-            use_compression: bottomless::replicator::CompressionKind::Gzip,
-            bucket_name: BUCKET.to_string(),
-            max_batch_interval: Duration::from_millis(250),
-            restore_transaction_page_swap_after: 1, // in this test swap should happen at least once
-            ..bottomless::replicator::Options::from_env().unwrap()
-        }),
-        db_path: PATH.into(),
-        http_addr: Some(listener_addr),
-        ..Config::default()
+    let options = bottomless::replicator::Options {
+        create_bucket_if_not_exists: true,
+        verify_crc: true,
+        use_compression: bottomless::replicator::CompressionKind::Gzip,
+        bucket_name: BUCKET.to_string(),
+        max_batch_interval: Duration::from_millis(250),
+        restore_transaction_page_swap_after: 1, // in this test swap should happen at least once
+        ..bottomless::replicator::Options::from_env().unwrap()
     };
+    let make_server = || async { configure_server(&options, listener_addr, PATH).await };
 
     {
         tracing::info!("---STEP 1: create db, write row, rollback---");
         let cleaner = DbFileCleaner::new(PATH);
-        let db_job = start_db(1, &db_config);
+        let db_job = start_db(1, make_server().await);
 
         sleep(Duration::from_secs(2)).await;
 
@@ -240,14 +292,14 @@ async fn rollback_restore() {
             "rollback value should not be updated"
         );
 
-        db_job.abort();
+        db_job.await;
         drop(cleaner);
     }
 
     {
         tracing::info!("---STEP 2: recreate database, read modify, read again ---");
         let cleaner = DbFileCleaner::new(PATH);
-        let db_job = start_db(2, &db_config);
+        let db_job = start_db(2, make_server().await);
         sleep(Duration::from_secs(2)).await;
 
         let rs = get_data(&conn).await.unwrap();
@@ -269,7 +321,7 @@ async fn rollback_restore() {
             ]
         );
 
-        db_job.abort();
+        db_job.await;
         drop(cleaner);
     }
 }

--- a/sqld/src/test/bottomless.rs
+++ b/sqld/src/test/bottomless.rs
@@ -107,9 +107,7 @@ async fn backup_restore() {
             "---STEP 1: create a local database, fill it with data, wait for WAL backup---"
         );
         let cleaner = DbFileCleaner::new(PATH);
-        dbg!();
         let db_job = start_db(1, make_server().await);
-        dbg!();
 
         sleep(Duration::from_secs(2)).await;
 
@@ -137,9 +135,7 @@ async fn backup_restore() {
             "---STEP 2: recreate the database from WAL - create a snapshot at the end---"
         );
         let cleaner = DbFileCleaner::new(PATH);
-        dbg!();
         let db_job = start_db(2, make_server().await);
-        dbg!();
 
         sleep(Duration::from_secs(2)).await;
 
@@ -154,9 +150,7 @@ async fn backup_restore() {
     {
         tracing::info!("---STEP 3: recreate database from snapshot alone---");
         let cleaner = DbFileCleaner::new(PATH);
-        dbg!();
         let db_job = start_db(3, make_server().await);
-        dbg!();
 
         sleep(Duration::from_secs(2)).await;
 
@@ -174,9 +168,7 @@ async fn backup_restore() {
     {
         tracing::info!("---STEP 4: recreate the database from snapshot + WAL---");
         let cleaner = DbFileCleaner::new(PATH);
-        dbg!();
         let db_job = start_db(4, make_server().await);
-        dbg!();
 
         sleep(Duration::from_secs(2)).await;
 
@@ -195,9 +187,7 @@ async fn backup_restore() {
         remove_snapshots(BUCKET).await;
 
         let cleaner = DbFileCleaner::new(PATH);
-        dbg!();
         let db_job = start_db(4, make_server().await);
-        dbg!();
 
         sleep(Duration::from_secs(2)).await;
 


### PR DESCRIPTION
This PR aims to abstract networking for sqld so that we can simulate it and start writing tests using turmoil for network simulation.

I took the opportunity to clean up the configuration process and remove useless stuff that accumulated with time.

The `--backend` flag was removed because it is unused.

The `net` module contains network abstractions used throughout the crate.