### PR TITLE
bottomless: append namespace to db_id

### DIFF
--- a/sqld/src/namespace.rs
+++ b/sqld/src/namespace.rs
@@ -381,7 +381,11 @@ pub type DumpStream =
 
 fn make_bottomless_options(options: &Options, name: &Bytes) -> Options {
     let mut options = options.clone();
-    let db_id = format!("ns-{}", std::str::from_utf8(name).unwrap());
+    let db_id = format!(
+        "ns-{}:{}",
+        std::str::from_utf8(name).unwrap(),
+        options.db_id.unwrap_or_default()
+    );
     options.db_id = Some(db_id);
     options
 }

--- a/sqld/src/namespace.rs
+++ b/sqld/src/namespace.rs
@@ -381,11 +381,9 @@ pub type DumpStream =
 
 fn make_bottomless_options(options: &Options, name: &Bytes) -> Options {
     let mut options = options.clone();
-    let db_id = format!(
-        "ns-{}:{}",
-        std::str::from_utf8(name).unwrap(),
-        options.db_id.unwrap_or_default()
-    );
+    let namespace = std::str::from_utf8(name).unwrap();
+    let db_id = options.db_id.unwrap_or_default();
+    let db_id = format!("ns-{db_id}:{namespace}");
     options.db_id = Some(db_id);
     options
 }


### PR DESCRIPTION
Instead of replacing `LIBSQL_BOTTOMLESS_DATABASE_ID` assigned by the platform with namespace, we just prepend it with namespace data.