### PR TITLE
fix bad naming for namespace header key

### DIFF
--- a/sqld/src/replication/replica/replicator.rs
+++ b/sqld/src/replication/replica/replicator.rs
@@ -20,7 +20,7 @@ use crate::rpc::replication_log::rpc::{
     replication_log_client::ReplicationLogClient, HelloRequest, LogOffset,
 };
 use crate::rpc::replication_log::NEED_SNAPSHOT_ERROR_MSG;
-use crate::rpc::NAMESPACE_DOESNT_EXIST;
+use crate::rpc::{NAMESPACE_DOESNT_EXIST, NAMESPACE_METADATA_KEY};
 use crate::ResetOp;
 
 use super::hook::{Frames, InjectorHookCtx};
@@ -129,7 +129,7 @@ impl Replicator {
     fn make_request<T>(&self, msg: T) -> Request<T> {
         let mut req = Request::new(msg);
         req.metadata_mut().insert_bin(
-            "x-namespace",
+            NAMESPACE_METADATA_KEY,
             BinaryMetadataValue::from_bytes(&self.namespace[..]),
         );
 

--- a/sqld/src/rpc/mod.rs
+++ b/sqld/src/rpc/mod.rs
@@ -21,7 +21,7 @@ pub mod replication_log_proxy;
 
 /// A tonic error code to signify that a namespace doesn't exist.
 pub const NAMESPACE_DOESNT_EXIST: &str = "NAMESPACE_DOESNT_EXIST";
-pub(crate) const NAMESPACE_METADATA_KEY: &str = "x-namespace";
+pub(crate) const NAMESPACE_METADATA_KEY: &str = "x-namespace-bin";
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run_rpc_server(
@@ -78,11 +78,11 @@ fn extract_namespace<T>(
         return Ok(Bytes::from_static(DEFAULT_NAMESPACE_NAME.as_bytes()));
     }
 
-    if let Some(namespace) = req.metadata().get_bin("x-namespace") {
+    if let Some(namespace) = req.metadata().get_bin(NAMESPACE_METADATA_KEY) {
         namespace
             .to_bytes()
             .map_err(|_| Status::invalid_argument("Metadata can't be converted into Bytes"))
     } else {
-        Err(Status::invalid_argument("Missing x-namespace metadata"))
+        Err(Status::invalid_argument("Missing x-namespace-bin metadata"))
     }
 }


### PR DESCRIPTION
Tonic panics if the key for a binary header is not formatted correctly. Tonic doc could be clearer as to what is not a proper formatting, so I had to ding into tonic source to figure it out. And it turns out keys for binary metadata must be suffixed with `-bin`. Now we know :smile: