### PR TITLE
Bottomless periodic checkpoint fix

### DIFF
--- a/sqld/src/connection/mod.rs
+++ b/sqld/src/connection/mod.rs
@@ -102,6 +102,9 @@ pub trait Connection: Send + Sync + 'static {
 
     /// Check whether the connection is in autocommit mode.
     async fn is_autocommit(&self) -> Result<bool>;
+
+    /// Calls for database checkpoint (if supported).
+    async fn checkpoint(&self) -> Result<()>;
 }
 
 fn make_batch_program(batch: Vec<Query>) -> Vec<Step> {
@@ -281,6 +284,11 @@ impl<DB: Connection> Connection for TrackedConnection<DB> {
     async fn is_autocommit(&self) -> crate::Result<bool> {
         self.inner.is_autocommit().await
     }
+
+    #[inline]
+    async fn checkpoint(&self) -> Result<()> {
+        self.inner.checkpoint().await
+    }
 }
 
 #[cfg(test)]
@@ -309,6 +317,10 @@ mod test {
         }
 
         async fn is_autocommit(&self) -> crate::Result<bool> {
+            unreachable!()
+        }
+
+        async fn checkpoint(&self) -> Result<()> {
             unreachable!()
         }
     }

--- a/sqld/src/connection/write_proxy.rs
+++ b/sqld/src/connection/write_proxy.rs
@@ -307,6 +307,11 @@ impl Connection for WriteProxyConnection {
             State::Init | State::Invalid => true,
         })
     }
+
+    async fn checkpoint(&self) -> Result<()> {
+        self.wait_replication_sync().await?;
+        self.read_conn.checkpoint().await
+    }
 }
 
 impl Drop for WriteProxyConnection {

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -42,6 +42,10 @@ use crate::net::Accept;
 use crate::net::AddrIncoming;
 use crate::stats::Stats;
 
+use sha256::try_digest;
+
+use crate::connection::{Connection, MakeConnection};
+use crate::namespace::RestoreOption;
 pub use sqld_libsql_bindings as libsql;
 
 pub mod config;
@@ -191,9 +195,16 @@ async fn run_storage_monitor(db_path: Arc<Path>, stats: Stats) -> anyhow::Result
     Ok(())
 }
 
-async fn run_checkpoint_cron(db_path: Arc<Path>, period: Duration) -> anyhow::Result<()> {
+async fn run_periodic_checkpoint<C>(
+    connection_maker: Arc<C>,
+    period: Duration,
+) -> anyhow::Result<()>
+where
+    C: MakeConnection,
+{
+    use tokio::time::{interval, sleep, Instant, MissedTickBehavior};
+
     const RETRY_INTERVAL: Duration = Duration::from_secs(60);
-    let data_path = db_path.join("data");
     tracing::info!("setting checkpoint interval to {:?}", period);
     let mut interval = interval(period);
     interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -208,37 +219,27 @@ async fn run_checkpoint_cron(db_path: Arc<Path>, period: Duration) -> anyhow::Re
         } else {
             interval.tick().await;
         }
-        let data_path = data_path.clone();
-        retry = tokio::task::spawn_blocking(move || match rusqlite::Connection::open(&data_path) {
-            Ok(conn) => unsafe {
+        retry = match connection_maker.create().await {
+            Ok(conn) => {
+                tracing::trace!("database checkpoint");
                 let start = Instant::now();
-                let mut num_checkpointed: std::ffi::c_int = 0;
-                let rc = rusqlite::ffi::sqlite3_wal_checkpoint_v2(
-                    conn.handle(),
-                    std::ptr::null(),
-                    libsql::ffi::SQLITE_CHECKPOINT_TRUNCATE,
-                    &mut num_checkpointed as *mut _,
-                    std::ptr::null_mut(),
-                );
-                if rc == 0 {
-                    if num_checkpointed == -1 {
-                        return Some(Duration::default());
-                    } else {
+                match conn.checkpoint().await {
+                    Ok(_) => {
                         let elapsed = Instant::now() - start;
-                        tracing::info!("database checkpoint (took: {:?})", elapsed);
+                        tracing::info!("database checkpoint finished (took: {:?})", elapsed);
+                        None
                     }
-                    None
-                } else {
-                    tracing::warn!("failed to execute checkpoint - error code: {}", rc);
-                    Some(RETRY_INTERVAL)
+                    Err(err) => {
+                        tracing::warn!("failed to execute checkpoint: {}", err);
+                        Some(RETRY_INTERVAL)
+                    }
                 }
-            },
+            }
             Err(err) => {
-                tracing::warn!("couldn't connect to '{:?}': {}", data_path, err);
+                tracing::warn!("couldn't connect: {}", err);
                 Some(RETRY_INTERVAL)
             }
-        })
-        .await?;
+        }
     }
 }
 
@@ -364,12 +365,6 @@ where
         self.init_sqlite_globals();
         let db_is_dirty = init_sentinel_file(&self.path)?;
         let idle_shutdown_kicker = self.setup_shutdown();
-
-        if let Some(interval) = self.db_config.checkpoint_interval {
-            if self.db_config.bottomless_replication.is_some() {
-                join_set.spawn(run_checkpoint_cron(self.path.clone(), interval));
-            }
-        }
 
         let db_config_store = Arc::new(
             DatabaseConfigStore::load(&self.path).context("Could not load database config")?,

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -30,22 +30,17 @@ use rpc::replication_log_proxy::ReplicationLogProxyService;
 use rpc::run_rpc_server;
 use tokio::sync::Notify;
 use tokio::task::JoinSet;
-use tokio::time::{interval, sleep, Instant, MissedTickBehavior};
 use utils::services::idle_shutdown::IdleShutdownKicker;
 
 use crate::auth::Auth;
 use crate::connection::config::DatabaseConfigStore;
 use crate::connection::libsql::open_db;
+use crate::connection::{Connection, MakeConnection};
 use crate::error::Error;
 use crate::migration::maybe_migrate;
 use crate::net::Accept;
 use crate::net::AddrIncoming;
 use crate::stats::Stats;
-
-use sha256::try_digest;
-
-use crate::connection::{Connection, MakeConnection};
-use crate::namespace::RestoreOption;
 pub use sqld_libsql_bindings as libsql;
 
 pub mod config;

--- a/sqld/src/namespace/mod.rs
+++ b/sqld/src/namespace/mod.rs
@@ -31,8 +31,7 @@ use crate::replication::replica::Replicator;
 use crate::replication::{NamespacedSnapshotCallback, ReplicationLogger};
 use crate::stats::Stats;
 use crate::{
-    check_fresh_db, init_bottomless_replicator, run_periodic_checkpoint, run_periodic_compactions,
-    ResetOp, DB_CREATE_TIMEOUT, DEFAULT_AUTO_CHECKPOINT, DEFAULT_NAMESPACE_NAME,
+    run_periodic_checkpoint, DB_CREATE_TIMEOUT, DEFAULT_AUTO_CHECKPOINT, DEFAULT_NAMESPACE_NAME,
     MAX_CONCURRENT_DBS,
 };
 

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -20,8 +20,7 @@ use crate::libsql::ffi::SQLITE_IOERR_WRITE;
 use crate::libsql::ffi::{
     sqlite3,
     types::{XWalCheckpointFn, XWalFrameFn, XWalSavePointUndoFn, XWalUndoFn},
-    PageHdrIter, PgHdr, Wal, SQLITE_CHECKPOINT_FULL, SQLITE_CHECKPOINT_PASSIVE,
-    SQLITE_CHECKPOINT_RESTART, SQLITE_CHECKPOINT_TRUNCATE, SQLITE_IOERR, SQLITE_OK,
+    PageHdrIter, PgHdr, Wal, SQLITE_CHECKPOINT_TRUNCATE, SQLITE_IOERR, SQLITE_OK,
 };
 use crate::libsql::wal_hook::WalHook;
 use crate::replication::frame::{Frame, FrameHeader};
@@ -195,16 +194,9 @@ unsafe impl WalHook for ReplicationLoggerHook {
              ** checkpoint attempts weaker than TRUNCATE are ignored.
              */
             if emode < SQLITE_CHECKPOINT_TRUNCATE {
-                let kind = match emode {
-                    SQLITE_CHECKPOINT_TRUNCATE => "TRUNCATE",
-                    SQLITE_CHECKPOINT_RESTART => "RESTART",
-                    SQLITE_CHECKPOINT_FULL => "FULL",
-                    SQLITE_CHECKPOINT_PASSIVE => "PASSIVE",
-                    _ => "(unknown)",
-                };
                 tracing::trace!(
                     "Ignoring a checkpoint request weaker than TRUNCATE: {}",
-                    kind
+                    emode
                 );
                 // Return an error to signal to sqlite that the WAL was not checkpointed, and it is
                 // therefore not safe to delete it.

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -80,8 +80,10 @@ unsafe impl WalHook for ReplicationLoggerHook {
         let last_valid_frame = wal.hdr.mxFrame;
         let ctx = Self::wal_extract_ctx(wal);
 
+        let mut frame_count = 0;
         for (page_no, data) in PageHdrIter::new(page_headers, page_size as _) {
-            ctx.write_frame(page_no, data)
+            ctx.write_frame(page_no, data);
+            frame_count += 1;
         }
         if let Err(e) = ctx.flush(ntruncate) {
             tracing::error!("error writing to replication log: {e}");
@@ -119,7 +121,6 @@ unsafe impl WalHook for ReplicationLoggerHook {
                     tracing::error!("fatal error during backup: {e}, exiting");
                     std::process::abort()
                 }
-                let frame_count = PageHdrIter::new(page_headers, page_size as usize).count();
                 replicator.submit_frames(frame_count as u32);
             }
 
@@ -236,12 +237,13 @@ unsafe impl WalHook for ReplicationLoggerHook {
             let runtime = tokio::runtime::Handle::current();
             if let Some(replicator) = ctx.bottomless_replicator.as_mut() {
                 let mut replicator = replicator.lock().unwrap();
-                if replicator.commits_in_current_generation() == 0 {
-                    tracing::debug!("No commits happened in this generation, not snapshotting");
-                    return SQLITE_OK;
-                }
                 let last_known_frame = replicator.last_known_frame();
                 replicator.request_flush();
+                if last_known_frame == 0 {
+                    tracing::debug!("No comitted changes in this generation, not snapshotting");
+                    replicator.skip_snapshot_for_current_generation();
+                    return SQLITE_OK;
+                }
                 if let Err(e) = runtime.block_on(replicator.wait_until_committed(last_known_frame))
                 {
                     tracing::error!(


### PR DESCRIPTION
This PR fixes issues when bottomless checkpoint interval was set on:

1. The fiber that was calling for checkpoint should be using `MakeNamespace` SQLite connection factory (which properly configures connections to be used by specifying auto_checkpoints, bottomless xCheckpoint hooks and journal=WAL).
2. In snapshotting was supposed to be skipped, that information was not propagated through - in result in the next generation we were waiting for the previous generation snapshot completion, which would never arrive causing deadlock.
3. In bottomless we used outdated field (`commits_in_current_generation`) to determine if current generation has any changes. In practice we should use `last_known_frame()`, which returns a frame counter that is reset with new generation and updated only when we received committed frames.