### PR TITLE
Namespace usage limits

### DIFF
--- a/sqld/src/connection/config.rs
+++ b/sqld/src/connection/config.rs
@@ -7,6 +7,7 @@ use std::{fs, io};
 use crate::error::Error;
 use crate::Result;
 
+#[derive(Debug)]
 pub struct DatabaseConfigStore {
     config_path: PathBuf,
     tmp_config_path: PathBuf,


### PR DESCRIPTION
This PR fixes usage limits for namespaces.
The admin API changes in the following way:
- `GET /v1/config` -> `GET /v1/namespaces/:namespace/config`
- `POST /v1/block` -> `POST /v1/namespaces/:namespace/config`
