### PR TITLE
Return current namespace replication index in stats

### DIFF
--- a/sqld/src/http/admin/stats.rs
+++ b/sqld/src/http/admin/stats.rs
@@ -6,6 +6,7 @@ use axum::extract::{Path, State};
 use axum::Json;
 
 use crate::namespace::MakeNamespace;
+use crate::replication::FrameNo;
 use crate::stats::Stats;
 
 use super::AppState;
@@ -16,6 +17,7 @@ pub struct StatsResponse {
     pub rows_written_count: u64,
     pub storage_bytes_used: u64,
     pub write_requests_delegated: u64,
+    pub current_frame_no: FrameNo,
 }
 
 impl From<&Stats> for StatsResponse {
@@ -25,6 +27,7 @@ impl From<&Stats> for StatsResponse {
             rows_written_count: stats.rows_written(),
             storage_bytes_used: stats.storage_bytes_used(),
             write_requests_delegated: stats.write_requests_delegated(),
+            current_frame_no: stats.get_current_frame_no(),
         }
     }
 }

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -691,7 +691,7 @@ pub struct LogFileHeader {
 
 impl LogFileHeader {
     pub fn last_frame_no(&self) -> FrameNo {
-        self.start_frame_no + self.frame_count
+        self.start_frame_no + self.frame_count - 1
     }
 
     fn sqld_version(&self) -> Version {

--- a/sqld/src/stats.rs
+++ b/sqld/src/stats.rs
@@ -7,13 +7,21 @@ use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
 use tokio::task::JoinSet;
 
+use crate::replication::FrameNo;
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Stats {
+    #[serde(default)]
     rows_written: AtomicU64,
+    #[serde(default)]
     rows_read: AtomicU64,
+    #[serde(default)]
     storage_bytes_used: AtomicU64,
     // number of write requests delegated from a replica to primary
+    #[serde(default)]
     write_requests_delegated: AtomicU64,
+    #[serde(default)]
+    current_frame_no: AtomicU64,
 }
 
 impl Stats {
@@ -74,6 +82,14 @@ impl Stats {
 
     pub fn write_requests_delegated(&self) -> u64 {
         self.write_requests_delegated.load(Ordering::Relaxed)
+    }
+
+    pub fn set_current_frame_no(&self, fno: FrameNo) {
+        self.current_frame_no.store(fno, Ordering::Relaxed);
+    }
+
+    pub(crate) fn get_current_frame_no(&self) -> FrameNo {
+        self.current_frame_no.load(Ordering::Relaxed)
     }
 }
 


### PR DESCRIPTION
This PR adds the current replication index of a namespace in its stats payload:
```json
{
    "rows_read_count": 0,
    "rows_written_count": 0,
    "storage_bytes_used": 12288,
    "write_requests_delegated": 0,
    "current_frame_no": 4
}
```
