### PR TITLE
Wait for replication index on replica connections

### DIFF
--- a/sqld/src/connection/libsql.rs
+++ b/sqld/src/connection/libsql.rs
@@ -541,6 +541,7 @@ impl super::Connection for LibSqlConnection {
         pgm: Program,
         auth: Authenticated,
         builder: B,
+        _replication_index: Option<FrameNo>,
     ) -> Result<(B, State)> {
         check_program_auth(auth, &pgm)?;
         let (resp, receiver) = oneshot::channel();
@@ -568,7 +569,12 @@ impl super::Connection for LibSqlConnection {
         Ok(receiver.await??)
     }
 
-    async fn describe(&self, sql: String, auth: Authenticated) -> Result<DescribeResult> {
+    async fn describe(
+        &self,
+        sql: String,
+        auth: Authenticated,
+        _replication_index: Option<FrameNo>,
+    ) -> Result<DescribeResult> {
         check_describe_auth(auth)?;
         let (resp, receiver) = oneshot::channel();
         let cb = Box::new(move |maybe_conn: Result<&mut Connection>| {
@@ -600,7 +606,7 @@ impl super::Connection for LibSqlConnection {
         receiver.await?
     }
 
-    async fn checkpoint(&self) -> Result<()> {
+    async fn checkpoint(&self, _replication_index: Option<FrameNo>) -> Result<()> {
         let (resp, receiver) = oneshot::channel();
         let cb = Box::new(move |maybe_conn: Result<&mut Connection>| {
             let res = maybe_conn.and_then(|c| c.checkpoint());

--- a/sqld/src/connection/libsql.rs
+++ b/sqld/src/connection/libsql.rs
@@ -606,7 +606,7 @@ impl super::Connection for LibSqlConnection {
         receiver.await?
     }
 
-    async fn checkpoint(&self, _replication_index: Option<FrameNo>) -> Result<()> {
+    async fn checkpoint(&self) -> Result<()> {
         let (resp, receiver) = oneshot::channel();
         let cb = Box::new(move |maybe_conn: Result<&mut Connection>| {
             let res = maybe_conn.and_then(|c| c.checkpoint());

--- a/sqld/src/connection/mod.rs
+++ b/sqld/src/connection/mod.rs
@@ -117,7 +117,7 @@ pub trait Connection: Send + Sync + 'static {
     async fn is_autocommit(&self) -> Result<bool>;
 
     /// Calls for database checkpoint (if supported).
-    async fn checkpoint(&self, replication_index: Option<FrameNo>) -> Result<()>;
+    async fn checkpoint(&self) -> Result<()>;
 }
 
 fn make_batch_program(batch: Vec<Query>) -> Vec<Step> {
@@ -307,8 +307,8 @@ impl<DB: Connection> Connection for TrackedConnection<DB> {
     }
 
     #[inline]
-    async fn checkpoint(&self, replication_index: Option<FrameNo>) -> Result<()> {
-        self.inner.checkpoint(replication_index).await
+    async fn checkpoint(&self) -> Result<()> {
+        self.inner.checkpoint().await
     }
 }
 
@@ -343,7 +343,7 @@ mod test {
             unreachable!()
         }
 
-        async fn checkpoint(&self, _replication_index: Option<FrameNo>) -> Result<()> {
+        async fn checkpoint(&self) -> Result<()> {
             unreachable!()
         }
     }

--- a/sqld/src/connection/mod.rs
+++ b/sqld/src/connection/mod.rs
@@ -10,6 +10,7 @@ use crate::error::Error;
 use crate::query::{Params, Query};
 use crate::query_analysis::{State, Statement};
 use crate::query_result_builder::{IgnoreResult, QueryResultBuilder};
+use crate::replication::FrameNo;
 use crate::Result;
 
 use self::program::{Cond, DescribeResult, Program, Step};
@@ -29,7 +30,8 @@ pub trait Connection: Send + Sync + 'static {
         &self,
         pgm: Program,
         auth: Authenticated,
-        reponse_builder: B,
+        response_builder: B,
+        replication_index: Option<FrameNo>,
     ) -> Result<(B, State)>;
 
     /// Execute all the queries in the batch sequentially.
@@ -40,6 +42,7 @@ pub trait Connection: Send + Sync + 'static {
         batch: Vec<Query>,
         auth: Authenticated,
         result_builder: B,
+        replication_index: Option<FrameNo>,
     ) -> Result<(B, State)> {
         let batch_len = batch.len();
         let mut steps = make_batch_program(batch);
@@ -64,7 +67,9 @@ pub trait Connection: Send + Sync + 'static {
 
         // ignore the rollback result
         let builder = result_builder.take(batch_len);
-        let (builder, state) = self.execute_program(pgm, auth, builder).await?;
+        let (builder, state) = self
+            .execute_program(pgm, auth, builder, replication_index)
+            .await?;
 
         Ok((builder.into_inner(), state))
     }
@@ -76,10 +81,12 @@ pub trait Connection: Send + Sync + 'static {
         batch: Vec<Query>,
         auth: Authenticated,
         result_builder: B,
+        replication_index: Option<FrameNo>,
     ) -> Result<(B, State)> {
         let steps = make_batch_program(batch);
         let pgm = Program::new(steps);
-        self.execute_program(pgm, auth, result_builder).await
+        self.execute_program(pgm, auth, result_builder, replication_index)
+            .await
     }
 
     async fn rollback(&self, auth: Authenticated) -> Result<()> {
@@ -91,6 +98,7 @@ pub trait Connection: Send + Sync + 'static {
             }],
             auth,
             IgnoreResult,
+            None,
         )
         .await?;
 
@@ -98,13 +106,18 @@ pub trait Connection: Send + Sync + 'static {
     }
 
     /// Parse the SQL statement and return information about it.
-    async fn describe(&self, sql: String, auth: Authenticated) -> Result<DescribeResult>;
+    async fn describe(
+        &self,
+        sql: String,
+        auth: Authenticated,
+        replication_index: Option<FrameNo>,
+    ) -> Result<DescribeResult>;
 
     /// Check whether the connection is in autocommit mode.
     async fn is_autocommit(&self) -> Result<bool>;
 
     /// Calls for database checkpoint (if supported).
-    async fn checkpoint(&self) -> Result<()>;
+    async fn checkpoint(&self, replication_index: Option<FrameNo>) -> Result<()>;
 }
 
 fn make_batch_program(batch: Vec<Query>) -> Vec<Step> {
@@ -271,13 +284,21 @@ impl<DB: Connection> Connection for TrackedConnection<DB> {
         pgm: Program,
         auth: Authenticated,
         builder: B,
+        replication_index: Option<FrameNo>,
     ) -> crate::Result<(B, State)> {
-        self.inner.execute_program(pgm, auth, builder).await
+        self.inner
+            .execute_program(pgm, auth, builder, replication_index)
+            .await
     }
 
     #[inline]
-    async fn describe(&self, sql: String, auth: Authenticated) -> crate::Result<DescribeResult> {
-        self.inner.describe(sql, auth).await
+    async fn describe(
+        &self,
+        sql: String,
+        auth: Authenticated,
+        replication_index: Option<FrameNo>,
+    ) -> crate::Result<DescribeResult> {
+        self.inner.describe(sql, auth, replication_index).await
     }
 
     #[inline]
@@ -286,8 +307,8 @@ impl<DB: Connection> Connection for TrackedConnection<DB> {
     }
 
     #[inline]
-    async fn checkpoint(&self) -> Result<()> {
-        self.inner.checkpoint().await
+    async fn checkpoint(&self, replication_index: Option<FrameNo>) -> Result<()> {
+        self.inner.checkpoint(replication_index).await
     }
 }
 
@@ -304,6 +325,7 @@ mod test {
             _pgm: Program,
             _auth: Authenticated,
             _builder: B,
+            _replication_index: Option<FrameNo>,
         ) -> crate::Result<(B, State)> {
             unreachable!()
         }
@@ -312,6 +334,7 @@ mod test {
             &self,
             _sql: String,
             _auth: Authenticated,
+            _replication_index: Option<FrameNo>,
         ) -> crate::Result<DescribeResult> {
             unreachable!()
         }
@@ -320,7 +343,7 @@ mod test {
             unreachable!()
         }
 
-        async fn checkpoint(&self) -> Result<()> {
+        async fn checkpoint(&self, _replication_index: Option<FrameNo>) -> Result<()> {
             unreachable!()
         }
     }

--- a/sqld/src/connection/write_proxy.rs
+++ b/sqld/src/connection/write_proxy.rs
@@ -245,9 +245,10 @@ impl WriteProxyConnection {
         }
     }
 
-    /// wait for the replicator to have caught up with our current write frame_no
-    async fn wait_replication_sync(&self) -> Result<()> {
-        let current_fno = *self.last_write_frame_no.lock();
+    /// wait for the replicator to have caught up with the replication_index if `Some` or our
+    /// current write frame_no
+    async fn wait_replication_sync(&self, replication_index: Option<FrameNo>) -> Result<()> {
+        let current_fno = replication_index.or_else(|| *self.last_write_frame_no.lock());
         match current_fno {
             Some(current_frame_no) => {
                 let mut receiver = self.applied_frame_no_receiver.clone();
@@ -273,16 +274,17 @@ impl Connection for WriteProxyConnection {
         pgm: Program,
         auth: Authenticated,
         builder: B,
+        replication_index: Option<FrameNo>,
     ) -> Result<(B, State)> {
         let mut state = self.state.lock().await;
         if *state == State::Init && pgm.is_read_only() {
-            self.wait_replication_sync().await?;
+            self.wait_replication_sync(replication_index).await?;
             // We know that this program won't perform any writes. We attempt to run it on the
             // replica. If it leaves an open transaction, then this program is an interactive
             // transaction, so we rollback the replica, and execute again on the primary.
             let (builder, new_state) = self
                 .read_conn
-                .execute_program(pgm.clone(), auth.clone(), builder)
+                .execute_program(pgm.clone(), auth.clone(), builder, replication_index)
                 .await?;
             if new_state != State::Init {
                 self.read_conn.rollback(auth.clone()).await?;
@@ -295,9 +297,14 @@ impl Connection for WriteProxyConnection {
         }
     }
 
-    async fn describe(&self, sql: String, auth: Authenticated) -> Result<DescribeResult> {
-        self.wait_replication_sync().await?;
-        self.read_conn.describe(sql, auth).await
+    async fn describe(
+        &self,
+        sql: String,
+        auth: Authenticated,
+        replication_index: Option<FrameNo>,
+    ) -> Result<DescribeResult> {
+        self.wait_replication_sync(replication_index).await?;
+        self.read_conn.describe(sql, auth, replication_index).await
     }
 
     async fn is_autocommit(&self) -> Result<bool> {
@@ -308,9 +315,9 @@ impl Connection for WriteProxyConnection {
         })
     }
 
-    async fn checkpoint(&self) -> Result<()> {
-        self.wait_replication_sync().await?;
-        self.read_conn.checkpoint().await
+    async fn checkpoint(&self, replication_index: Option<FrameNo>) -> Result<()> {
+        self.wait_replication_sync(replication_index).await?;
+        self.read_conn.checkpoint(replication_index).await
     }
 }
 

--- a/sqld/src/connection/write_proxy.rs
+++ b/sqld/src/connection/write_proxy.rs
@@ -315,9 +315,9 @@ impl Connection for WriteProxyConnection {
         })
     }
 
-    async fn checkpoint(&self, replication_index: Option<FrameNo>) -> Result<()> {
-        self.wait_replication_sync(replication_index).await?;
-        self.read_conn.checkpoint(replication_index).await
+    async fn checkpoint(&self) -> Result<()> {
+        self.wait_replication_sync(None).await?;
+        self.read_conn.checkpoint().await
     }
 }
 

--- a/sqld/src/hrana/batch.rs
+++ b/sqld/src/hrana/batch.rs
@@ -12,6 +12,7 @@ use crate::query_analysis::Statement;
 use crate::query_result_builder::{
     QueryResultBuilder, QueryResultBuilderError, StepResult, StepResultsBuilder,
 };
+use crate::replication::FrameNo;
 
 use super::result_builder::HranaBatchProtoBuilder;
 use super::stmt::{proto_stmt_to_query, stmt_error_from_sqld_error};
@@ -106,10 +107,11 @@ pub async fn execute_batch(
     db: &impl Connection,
     auth: Authenticated,
     pgm: Program,
+    replication_index: Option<u64>,
 ) -> Result<proto::BatchResult> {
     let batch_builder = HranaBatchProtoBuilder::default();
     let (builder, _state) = db
-        .execute_program(pgm, auth, batch_builder)
+        .execute_program(pgm, auth, batch_builder, replication_index)
         .await
         .map_err(catch_batch_error)?;
 
@@ -146,10 +148,11 @@ pub async fn execute_sequence(
     db: &impl Connection,
     auth: Authenticated,
     pgm: Program,
+    replication_index: Option<FrameNo>,
 ) -> Result<()> {
     let builder = StepResultsBuilder::default();
     let (builder, _state) = db
-        .execute_program(pgm, auth, builder)
+        .execute_program(pgm, auth, builder, replication_index)
         .await
         .map_err(catch_batch_error)?;
     builder

--- a/sqld/src/hrana/http/mod.rs
+++ b/sqld/src/hrana/http/mod.rs
@@ -140,7 +140,7 @@ async fn handle_cursor<C: Connection>(
     let db = stream_guard.get_db_owned()?;
     let sqls = stream_guard.sqls();
     let pgm = batch::proto_batch_to_program(&req_body.batch, sqls, version)?;
-    cursor_hnd.open(db, auth, pgm);
+    cursor_hnd.open(db, auth, pgm, req_body.batch.replication_index);
 
     let resp_body = proto::CursorRespBody {
         baton: stream_guard.release(),

--- a/sqld/src/hrana/http/proto.rs
+++ b/sqld/src/hrana/http/proto.rs
@@ -117,6 +117,9 @@ pub struct SequenceStreamReq {
     #[serde(default)]
     #[prost(int32, optional, tag = "2")]
     pub sql_id: Option<i32>,
+    #[serde(default)]
+    #[prost(uint64, optional, tag = "3")]
+    pub replication_index: Option<u64>,
 }
 
 #[derive(Serialize, prost::Message)]
@@ -130,6 +133,9 @@ pub struct DescribeStreamReq {
     #[serde(default)]
     #[prost(int32, optional, tag = "2")]
     pub sql_id: Option<i32>,
+    #[serde(default)]
+    #[prost(uint64, optional, tag = "3")]
+    pub replication_index: Option<u64>,
 }
 
 #[derive(Serialize, prost::Message)]

--- a/sqld/src/hrana/http/request.rs
+++ b/sqld/src/hrana/http/request.rs
@@ -64,7 +64,7 @@ async fn try_handle<D: Connection>(
             let sqls = stream_guard.sqls();
             let query =
                 stmt::proto_stmt_to_query(&req.stmt, sqls, version).map_err(catch_stmt_error)?;
-            let result = stmt::execute_stmt(db, auth, query)
+            let result = stmt::execute_stmt(db, auth, query, req.stmt.replication_index)
                 .await
                 .map_err(catch_stmt_error)?;
             proto::StreamResponse::Execute(proto::ExecuteStreamResp { result })
@@ -73,7 +73,7 @@ async fn try_handle<D: Connection>(
             let db = stream_guard.get_db()?;
             let sqls = stream_guard.sqls();
             let pgm = batch::proto_batch_to_program(&req.batch, sqls, version)?;
-            let result = batch::execute_batch(db, auth, pgm)
+            let result = batch::execute_batch(db, auth, pgm, req.batch.replication_index)
                 .await
                 .map_err(catch_batch_error)?;
             proto::StreamResponse::Batch(proto::BatchStreamResp { result })
@@ -83,7 +83,7 @@ async fn try_handle<D: Connection>(
             let sqls = stream_guard.sqls();
             let sql = stmt::proto_sql_to_sql(req.sql.as_deref(), req.sql_id, sqls, version)?;
             let pgm = batch::proto_sequence_to_program(sql).map_err(catch_stmt_error)?;
-            batch::execute_sequence(db, auth, pgm)
+            batch::execute_sequence(db, auth, pgm, req.replication_index)
                 .await
                 .map_err(catch_stmt_error)
                 .map_err(catch_batch_error)?;
@@ -93,7 +93,7 @@ async fn try_handle<D: Connection>(
             let db = stream_guard.get_db()?;
             let sqls = stream_guard.sqls();
             let sql = stmt::proto_sql_to_sql(req.sql.as_deref(), req.sql_id, sqls, version)?;
-            let result = stmt::describe_stmt(db, auth, sql.into())
+            let result = stmt::describe_stmt(db, auth, sql.into(), req.replication_index)
                 .await
                 .map_err(catch_stmt_error)?;
             proto::StreamResponse::Describe(proto::DescribeStreamResp { result })

--- a/sqld/src/hrana/proto.rs
+++ b/sqld/src/hrana/proto.rs
@@ -29,6 +29,9 @@ pub struct Stmt {
     #[serde(default)]
     #[prost(bool, optional, tag = "5")]
     pub want_rows: Option<bool>,
+    #[serde(default)]
+    #[prost(uint64, optional, tag = "6")]
+    pub replication_index: Option<u64>,
 }
 
 #[derive(Deserialize, prost::Message)]
@@ -73,6 +76,9 @@ pub struct Row {
 pub struct Batch {
     #[prost(message, repeated, tag = "1")]
     pub steps: Vec<BatchStep>,
+    #[prost(uint64, optional, tag = "2")]
+    #[serde(default)]
+    pub replication_index: Option<u64>,
 }
 
 #[derive(Deserialize, prost::Message)]

--- a/sqld/src/hrana/ws/proto.rs
+++ b/sqld/src/hrana/ws/proto.rs
@@ -143,6 +143,9 @@ pub struct ExecuteReq {
     pub stream_id: i32,
     #[prost(message, required, tag = "2")]
     pub stmt: Stmt,
+    #[serde(default)]
+    #[prost(uint64, optional, tag = "3")]
+    pub replication_index: Option<u64>,
 }
 
 #[derive(Serialize, prost::Message)]
@@ -213,6 +216,9 @@ pub struct SequenceReq {
     #[serde(default)]
     #[prost(int32, optional, tag = "3")]
     pub sql_id: Option<i32>,
+    #[serde(default)]
+    #[prost(uint64, optional, tag = "4")]
+    pub replication_index: Option<u64>,
 }
 
 #[derive(Serialize, prost::Message)]
@@ -228,6 +234,9 @@ pub struct DescribeReq {
     #[serde(default)]
     #[prost(int32, optional, tag = "3")]
     pub sql_id: Option<i32>,
+    #[serde(default)]
+    #[prost(uint64, optional, tag = "4")]
+    pub replication_index: Option<u64>,
 }
 
 #[derive(Serialize, prost::Message)]

--- a/sqld/src/http/user/hrana_over_http_1.rs
+++ b/sqld/src/http/user/hrana_over_http_1.rs
@@ -46,7 +46,7 @@ pub(crate) async fn handle_execute<D: Connection>(
             hrana::Version::Hrana1,
         )
         .map_err(catch_stmt_error)?;
-        hrana::stmt::execute_stmt(&db, auth, query)
+        hrana::stmt::execute_stmt(&db, auth, query, req_body.stmt.replication_index)
             .await
             .map(|result| RespBody { result })
             .map_err(catch_stmt_error)
@@ -79,7 +79,7 @@ pub(crate) async fn handle_batch<D: Connection>(
             hrana::Version::Hrana1,
         )
         .map_err(catch_stmt_error)?;
-        hrana::batch::execute_batch(&db, auth, pgm)
+        hrana::batch::execute_batch(&db, auth, pgm, req_body.batch.replication_index)
             .await
             .map(|result| RespBody { result })
             .context("Could not execute batch")

--- a/sqld/src/http/user/mod.rs
+++ b/sqld/src/http/user/mod.rs
@@ -121,7 +121,9 @@ async fn handle_query<C: Connection>(
     let db = connection_maker.create().await?;
 
     let builder = JsonHttpPayloadBuilder::new();
-    let (builder, _) = db.execute_batch_or_rollback(batch, auth, builder).await?;
+    let (builder, _) = db
+        .execute_batch_or_rollback(batch, auth, builder, query.replication_index)
+        .await?;
 
     let res = (
         [(header::CONTENT_TYPE, "application/json")],

--- a/sqld/src/http/user/snapshots/sqld__http__user__types__test__parse_http_query_with_replication_index.snap
+++ b/sqld/src/http/user/snapshots/sqld__http__user__types__test__parse_http_query_with_replication_index.snap
@@ -34,5 +34,5 @@ expression: found
       }
     }
   ],
-  "replication_index": null
+  "replication_index": 1
 }

--- a/sqld/src/http/user/types.rs
+++ b/sqld/src/http/user/types.rs
@@ -10,6 +10,7 @@ use crate::query;
 #[derive(Debug, Deserialize, Serialize)]
 pub struct HttpQuery {
     pub statements: Vec<QueryObject>,
+    pub replication_index: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]

--- a/sqld/src/http/user/types.rs
+++ b/sqld/src/http/user/types.rs
@@ -250,9 +250,31 @@ mod test {
 
     #[test]
     fn parse_http_query() {
-        let json = r#"{"statements":["select * from test",
-            {"q": "select ?", "params": [12, true]},
-            {"q": "select ?", "params": {":foo": "bar"}}]}"#;
+        let json = r#"
+            {
+                "statements": [
+                    "select * from test",
+                    {"q": "select ?", "params": [12, true]},
+                    {"q": "select ?", "params": {":foo": "bar"}}
+                ]
+            }"#;
+        let found: HttpQuery = serde_json::from_str(json).unwrap();
+        insta::with_settings!({sort_maps => true}, {
+            insta::assert_json_snapshot!(found);
+        })
+    }
+
+    #[test]
+    fn parse_http_query_with_replication_index() {
+        let json = r#"
+            {
+                "statements": [
+                    "select * from test",
+                    {"q": "select ?", "params": [12, true]},
+                    {"q": "select ?", "params": {":foo": "bar"}}
+                ],
+                "replication_index": 1
+            }"#;
         let found: HttpQuery = serde_json::from_str(json).unwrap();
         insta::with_settings!({sort_maps => true}, {
             insta::assert_json_snapshot!(found);

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -159,7 +159,7 @@ where
             Ok(conn) => {
                 tracing::trace!("database checkpoint");
                 let start = Instant::now();
-                match conn.checkpoint(None).await {
+                match conn.checkpoint().await {
                     Ok(_) => {
                         let elapsed = Instant::now() - start;
                         tracing::info!("database checkpoint finished (took: {:?})", elapsed);

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -159,7 +159,7 @@ where
             Ok(conn) => {
                 tracing::trace!("database checkpoint");
                 let start = Instant::now();
-                match conn.checkpoint().await {
+                match conn.checkpoint(None).await {
                     Ok(_) => {
                         let elapsed = Instant::now() - start;
                         tracing::info!("database checkpoint finished (took: {:?})", elapsed);

--- a/sqld/src/rpc/proxy.rs
+++ b/sqld/src/rpc/proxy.rs
@@ -495,7 +495,7 @@ impl Proxy for ProxyService {
 
         let builder = ExecuteResultBuilder::default();
         let (results, state) = db
-            .execute_program(pgm, auth, builder)
+            .execute_program(pgm, auth, builder, None)
             .await
             // TODO: this is no necessarily a permission denied error!
             .map_err(|e| tonic::Status::new(tonic::Code::PermissionDenied, e.to_string()))?;
@@ -572,7 +572,7 @@ impl Proxy for ProxyService {
         };
 
         let description = db
-            .describe(stmt, auth)
+            .describe(stmt, auth, None)
             .await
             // TODO: this is no necessarily a permission denied error!
             // FIXME: the double map_err looks off


### PR DESCRIPTION
This allows users to wait for writes based on the `replication_index` on replica connections.