### PR TITLE
sqld: add Describe RPC

### DIFF
--- a/sqld/proto/proxy.proto
+++ b/sqld/proto/proxy.proto
@@ -51,6 +51,24 @@ message ResultRows {
     optional int64    last_insert_rowid = 4;
 }
 
+message DescribeRequest {
+    string client_id = 1;
+    string stmt = 2;
+}
+
+message DescribeResult {
+    oneof describe_result {
+        Error       error = 1;
+        Description description = 2;
+    }
+}
+
+message Description {
+    repeated Column   column_descriptions = 1;
+    repeated string   param_names = 2;
+    uint64            param_count = 3;
+}
+
 message Value {
     /// bincode encoded Value
     bytes   data = 1;
@@ -134,5 +152,6 @@ message ProgramReq {
 
 service Proxy {
   rpc Execute(ProgramReq) returns (ExecuteResults) {}
+  rpc Describe(DescribeRequest) returns (DescribeResult) {}
   rpc Disconnect(DisconnectMessage) returns (Ack) {}
 }

--- a/sqld/src/rpc/replica_proxy.rs
+++ b/sqld/src/rpc/replica_proxy.rs
@@ -2,7 +2,8 @@ use hyper::Uri;
 use tonic::transport::Channel;
 
 use super::proxy::rpc::{
-    self, proxy_client::ProxyClient, proxy_server::Proxy, Ack, DisconnectMessage, ExecuteResults,
+    self, proxy_client::ProxyClient, proxy_server::Proxy, Ack, DescribeRequest, DescribeResult,
+    DisconnectMessage, ExecuteResults,
 };
 
 pub struct ReplicaProxyService {
@@ -33,5 +34,13 @@ impl Proxy for ReplicaProxyService {
     ) -> Result<tonic::Response<Ack>, tonic::Status> {
         let mut client = self.client.clone();
         client.disconnect(msg).await
+    }
+
+    async fn describe(
+        &self,
+        req: tonic::Request<DescribeRequest>,
+    ) -> Result<tonic::Response<DescribeResult>, tonic::Status> {
+        let mut client = self.client.clone();
+        client.describe(req).await
     }
 }


### PR DESCRIPTION
Users can call the new RPC to get metadata from prepared statements, e.g. its columns, number of bound parameters, and so on. Perhaps we should further extend it with is_explain and is_readonly, which is already returned by our local helper functions.

This PR will be accompanied by client code in libsql/crates/libsql