### PR TITLE
Stop spawning long-lasting threads for libsql connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2415,7 +2415,7 @@ dependencies = [
 [[package]]
 name = "libsqlite3-sys"
 version = "0.26.0"
-source = "git+https://github.com/psarna/rusqlite?rev=2e28bca6#2e28bca6e8ebe8e9496b6bccb7e983ccf3dfad1f"
+source = "git+https://github.com/tursodatabase/rusqlite.git?rev=a72d529#a72d529a96d5dc3f4c3181358d8bd5d3a9ead8ac"
 dependencies = [
  "bindgen 0.65.1",
  "cc",
@@ -3246,7 +3246,7 @@ dependencies = [
 [[package]]
 name = "rusqlite"
 version = "0.29.0"
-source = "git+https://github.com/psarna/rusqlite?rev=2e28bca6#2e28bca6e8ebe8e9496b6bccb7e983ccf3dfad1f"
+source = "git+https://github.com/tursodatabase/rusqlite.git?rev=a72d529#a72d529a96d5dc3f4c3181358d8bd5d3a9ead8ac"
 dependencies = [
  "bitflags 2.4.0",
  "fallible-iterator 0.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,12 @@ members = [
 ]
 
 [workspace.dependencies]
-rusqlite = { version = "0.29.0", git = "https://github.com/psarna/rusqlite", rev = "2e28bca6", default-features = false, features = [
+rusqlite = { version = "0.29.0", git = "https://github.com/tursodatabase/rusqlite.git", rev = "a72d529", default-features = false, features = [
     "buildtime_bindgen",
     "bundled-libsql-wasm-experimental",
     "column_decltype",
-    "load_extension"
+    "load_extension",
+    "modern_sqlite"
 ] }
 
 # Config for 'cargo dist'

--- a/sqld-libsql-bindings/src/lib.rs
+++ b/sqld-libsql-bindings/src/lib.rs
@@ -3,10 +3,11 @@
 pub mod ffi;
 pub mod wal_hook;
 
-use std::{ffi::CString, marker::PhantomData, ops::Deref, time::Duration};
+use std::{ffi::CString, ops::Deref, time::Duration};
 
 pub use crate::wal_hook::WalMethodsHook;
 pub use once_cell::sync::Lazy;
+use wal_hook::TransparentMethods;
 
 use self::{
     ffi::{libsql_wal_methods, libsql_wal_methods_find},
@@ -22,12 +23,14 @@ pub fn get_orig_wal_methods() -> anyhow::Result<*mut libsql_wal_methods> {
     Ok(orig)
 }
 
-pub struct Connection<'a> {
+pub struct Connection<W: WalHook> {
     conn: rusqlite::Connection,
-    _pth: PhantomData<&'a mut ()>,
+    // Safety: _ctx MUST be dropped after the connection, because the connection has a pointer
+    // This pointer MUST NOT move out of the connection
+    _ctx: Box<W::Context>,
 }
 
-impl Deref for Connection<'_> {
+impl<W: WalHook> Deref for Connection<W> {
     type Target = rusqlite::Connection;
 
     fn deref(&self) -> &Self::Target {
@@ -35,27 +38,31 @@ impl Deref for Connection<'_> {
     }
 }
 
-impl<'a> Connection<'a> {
+impl Connection<TransparentMethods> {
     /// returns a dummy, in-memory connection. For testing purposes only
-    pub fn test(_: &mut ()) -> Self {
+    pub fn test() -> Self {
         let conn = rusqlite::Connection::open_in_memory().unwrap();
         Self {
             conn,
-            _pth: PhantomData,
+            _ctx: Box::new(()),
         }
     }
+}
+
+impl<W: WalHook> Connection<W> {
 
     /// Opens a database with the regular wal methods in the directory pointed to by path
-    pub fn open<W: WalHook>(
+    pub fn open(
         path: impl AsRef<std::path::Path>,
         flags: rusqlite::OpenFlags,
         // we technically _only_ need to know about W, but requiring a static ref to the wal_hook ensures that
         // it has been instanciated and lives for long enough
         _wal_hook: &'static WalMethodsHook<W>,
-        hook_ctx: &'a mut W::Context,
+        hook_ctx: W::Context,
         auto_checkpoint: u32,
     ) -> Result<Self, rusqlite::Error> {
         let path = path.as_ref().join("data");
+        let mut _ctx = Box::new(hook_ctx);
         tracing::trace!(
             "Opening a connection with regular WAL at {}",
             path.display()
@@ -75,7 +82,7 @@ impl<'a> Connection<'a> {
                 flags.bits(),
                 std::ptr::null_mut(),
                 W::name().as_ptr(),
-                hook_ctx as *mut _ as *mut _,
+                _ctx.as_mut() as *mut _ as *mut _,
             );
 
             if rc == 0 {
@@ -98,7 +105,7 @@ impl<'a> Connection<'a> {
 
         Ok(Connection {
             conn,
-            _pth: PhantomData,
+            _ctx,
         })
     }
 }

--- a/sqld/src/connection/write_proxy.rs
+++ b/sqld/src/connection/write_proxy.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex as PMutex;
 use rusqlite::types::ValueRef;
-use sqld_libsql_bindings::wal_hook::{TRANSPARENT_METHODS, TransparentMethods};
+use sqld_libsql_bindings::wal_hook::{TransparentMethods, TRANSPARENT_METHODS};
 use tokio::sync::{watch, Mutex};
 use tonic::metadata::BinaryMetadataValue;
 use tonic::transport::Channel;
@@ -27,27 +27,24 @@ use crate::stats::Stats;
 use crate::{Result, DEFAULT_AUTO_CHECKPOINT};
 
 use super::config::DatabaseConfigStore;
-use super::libsql::LibSqlConnection;
+use super::libsql::{LibSqlConnection, MakeLibSqlConn};
 use super::program::DescribeResult;
 use super::Connection;
 use super::{MakeConnection, Program};
 
-#[derive(Clone)]
-pub struct MakeWriteProxyConnection {
+pub struct MakeWriteProxyConn {
     client: ProxyClient<Channel>,
-    db_path: PathBuf,
-    extensions: Arc<[PathBuf]>,
     stats: Arc<Stats>,
-    config_store: Arc<DatabaseConfigStore>,
     applied_frame_no_receiver: watch::Receiver<Option<FrameNo>>,
     max_response_size: u64,
     max_total_response_size: u64,
     namespace: NamespaceName,
+    make_read_only_conn: MakeLibSqlConn<TransparentMethods>,
 }
 
-impl MakeWriteProxyConnection {
+impl MakeWriteProxyConn {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub async fn new(
         db_path: PathBuf,
         extensions: Arc<[PathBuf]>,
         channel: Channel,
@@ -58,32 +55,41 @@ impl MakeWriteProxyConnection {
         max_response_size: u64,
         max_total_response_size: u64,
         namespace: NamespaceName,
-    ) -> Self {
+    ) -> crate::Result<Self> {
         let client = ProxyClient::with_origin(channel, uri);
-        Self {
+        let make_read_only_conn = MakeLibSqlConn::new(
+            db_path.clone(),
+            &TRANSPARENT_METHODS,
+            || (),
+            stats.clone(),
+            config_store.clone(),
+            extensions.clone(),
+            max_response_size,
+            max_total_response_size,
+            DEFAULT_AUTO_CHECKPOINT,
+            applied_frame_no_receiver.clone(),
+        )
+        .await?;
+
+        Ok(Self {
             client,
-            db_path,
-            extensions,
             stats,
-            config_store,
             applied_frame_no_receiver,
             max_response_size,
             max_total_response_size,
             namespace,
-        }
+            make_read_only_conn,
+        })
     }
 }
 
 #[async_trait::async_trait]
-impl MakeConnection for MakeWriteProxyConnection {
+impl MakeConnection for MakeWriteProxyConn {
     type Connection = WriteProxyConnection;
     async fn create(&self) -> Result<Self::Connection> {
         let db = WriteProxyConnection::new(
             self.client.clone(),
-            self.db_path.clone(),
-            self.extensions.clone(),
             self.stats.clone(),
-            self.config_store.clone(),
             self.applied_frame_no_receiver.clone(),
             QueryBuilderConfig {
                 max_size: Some(self.max_response_size),
@@ -91,6 +97,7 @@ impl MakeConnection for MakeWriteProxyConnection {
                 auto_checkpoint: DEFAULT_AUTO_CHECKPOINT,
             },
             self.namespace.clone(),
+            self.make_read_only_conn.create().await?,
         )
         .await?;
         Ok(db)
@@ -163,26 +170,12 @@ impl WriteProxyConnection {
     #[allow(clippy::too_many_arguments)]
     async fn new(
         write_proxy: ProxyClient<Channel>,
-        db_path: PathBuf,
-        extensions: Arc<[PathBuf]>,
         stats: Arc<Stats>,
-        config_store: Arc<DatabaseConfigStore>,
         applied_frame_no_receiver: watch::Receiver<Option<FrameNo>>,
         builder_config: QueryBuilderConfig,
         namespace: NamespaceName,
+        read_conn: LibSqlConnection<TransparentMethods>,
     ) -> Result<Self> {
-        let read_conn = LibSqlConnection::new(
-            db_path,
-            extensions,
-            &TRANSPARENT_METHODS,
-            (),
-            stats.clone(),
-            config_store,
-            builder_config,
-            applied_frame_no_receiver.clone(),
-        )
-        .await?;
-
         Ok(Self {
             read_conn,
             write_proxy,

--- a/sqld/src/connection/write_proxy.rs
+++ b/sqld/src/connection/write_proxy.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex as PMutex;
 use rusqlite::types::ValueRef;
-use sqld_libsql_bindings::wal_hook::TRANSPARENT_METHODS;
+use sqld_libsql_bindings::wal_hook::{TRANSPARENT_METHODS, TransparentMethods};
 use tokio::sync::{watch, Mutex};
 use tonic::metadata::BinaryMetadataValue;
 use tonic::transport::Channel;
@@ -99,7 +99,7 @@ impl MakeConnection for MakeWriteProxyConnection {
 
 pub struct WriteProxyConnection {
     /// Lazily initialized read connection
-    read_conn: LibSqlConnection,
+    read_conn: LibSqlConnection<TransparentMethods>,
     write_proxy: ProxyClient<Channel>,
     state: Mutex<State>,
     client_id: Uuid,

--- a/sqld/src/namespace/mod.rs
+++ b/sqld/src/namespace/mod.rs
@@ -24,8 +24,8 @@ use uuid::Uuid;
 
 use crate::auth::Authenticated;
 use crate::connection::config::DatabaseConfigStore;
-use crate::connection::libsql::{open_db, LibSqlDbFactory};
-use crate::connection::write_proxy::MakeWriteProxyConnection;
+use crate::connection::libsql::{open_conn, MakeLibSqlConn};
+use crate::connection::write_proxy::MakeWriteProxyConn;
 use crate::connection::MakeConnection;
 use crate::database::{Database, PrimaryDatabase, ReplicaDatabase};
 use crate::error::{Error, LoadDumpError};
@@ -577,7 +577,7 @@ impl Namespace<ReplicaDatabase> {
 
         join_set.spawn(replicator.run());
 
-        let connection_maker = MakeWriteProxyConnection::new(
+        let connection_maker = MakeWriteProxyConn::new(
             db_path.clone(),
             config.extensions.clone(),
             config.channel.clone(),
@@ -589,6 +589,7 @@ impl Namespace<ReplicaDatabase> {
             config.max_total_response_size,
             name.clone(),
         )
+        .await?
         .throttled(
             MAX_CONCURRENT_DBS,
             Some(DB_CREATE_TIMEOUT),
@@ -718,7 +719,7 @@ impl Namespace<PrimaryDatabase> {
             DatabaseConfigStore::load(&db_path).context("Could not load database config")?,
         );
 
-        let connection_maker: Arc<_> = LibSqlDbFactory::new(
+        let connection_maker: Arc<_> = MakeLibSqlConn::new(
             db_path.clone(),
             &REPLICATION_METHODS,
             ctx_builder.clone(),
@@ -836,8 +837,15 @@ where
     let mut retries = 0;
     // there is a small chance we fail to acquire the lock right away, so we perform a few retries
     let conn = loop {
-        match block_in_place(|| open_db(db_path, &REPLICATION_METHODS, mk_ctx(), None, auto_checkpoint))
-        {
+        match block_in_place(|| {
+            open_conn(
+                db_path,
+                &REPLICATION_METHODS,
+                mk_ctx(),
+                None,
+                auto_checkpoint,
+            )
+        }) {
             Ok(conn) => {
                 break conn;
             }
@@ -978,7 +986,7 @@ async fn run_storage_monitor(db_path: PathBuf, stats: Weak<Stats>) -> anyhow::Re
             // fail to open it, we wait for `duration` and try again later.
             // We can safely open db with DEFAULT_AUTO_CHECKPOINT, since monitor is read-only: it 
             // won't produce new updates, frames or generate checkpoints.
-            match open_db(&db_path, &TRANSPARENT_METHODS, (), Some(rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY), DEFAULT_AUTO_CHECKPOINT) {
+            match open_conn(&db_path, &TRANSPARENT_METHODS, (), Some(rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY), DEFAULT_AUTO_CHECKPOINT) {
                 Ok(conn) => {
                     if let Ok(storage_bytes_used) =
                         conn.query_row("select sum(pgsize) from dbstat;", [], |row| {

--- a/sqld/src/namespace/mod.rs
+++ b/sqld/src/namespace/mod.rs
@@ -738,13 +738,12 @@ impl Namespace<PrimaryDatabase> {
         )
         .into();
 
-        let mut ctx = ctx_builder();
         match restore_option {
             RestoreOption::Dump(_) if !is_fresh_db => {
                 Err(LoadDumpError::LoadDumpExistingDb)?;
             }
             RestoreOption::Dump(dump) => {
-                load_dump(&db_path, dump, &mut ctx).await?;
+                load_dump(&db_path, dump, ctx_builder, logger.auto_checkpoint).await?;
             }
             _ => { /* other cases were already handled when creating bottomless */ }
         }
@@ -828,16 +827,16 @@ const WASM_TABLE_CREATE: &str =
 async fn load_dump<S>(
     db_path: &Path,
     dump: S,
-    ctx: &mut ReplicationLoggerHookCtx,
+    mk_ctx: impl Fn() -> ReplicationLoggerHookCtx,
+    auto_checkpoint: u32,
 ) -> anyhow::Result<()>
 where
     S: Stream<Item = std::io::Result<Bytes>> + Unpin,
 {
     let mut retries = 0;
-    let auto_checkpoint = ctx.logger().auto_checkpoint;
     // there is a small chance we fail to acquire the lock right away, so we perform a few retries
     let conn = loop {
-        match block_in_place(|| open_db(db_path, &REPLICATION_METHODS, ctx, None, auto_checkpoint))
+        match block_in_place(|| open_db(db_path, &REPLICATION_METHODS, mk_ctx(), None, auto_checkpoint))
         {
             Ok(conn) => {
                 break conn;
@@ -977,10 +976,9 @@ async fn run_storage_monitor(db_path: PathBuf, stats: Weak<Stats>) -> anyhow::Re
             // because closing the last connection interferes with opening a new one, we lazily
             // initialize a connection here, and keep it alive for the entirety of the program. If we
             // fail to open it, we wait for `duration` and try again later.
-            let ctx = &mut ();
             // We can safely open db with DEFAULT_AUTO_CHECKPOINT, since monitor is read-only: it 
             // won't produce new updates, frames or generate checkpoints.
-            match open_db(&db_path, &TRANSPARENT_METHODS, ctx, Some(rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY), DEFAULT_AUTO_CHECKPOINT) {
+            match open_db(&db_path, &TRANSPARENT_METHODS, (), Some(rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY), DEFAULT_AUTO_CHECKPOINT) {
                 Ok(conn) => {
                     if let Ok(storage_bytes_used) =
                         conn.query_row("select sum(pgsize) from dbstat;", [], |row| {

--- a/sqld/src/replication/replica/injector.rs
+++ b/sqld/src/replication/replica/injector.rs
@@ -5,7 +5,7 @@ use rusqlite::OpenFlags;
 
 use crate::replication::replica::hook::{SQLITE_CONTINUE_REPLICATION, SQLITE_EXIT_REPLICATION};
 
-use super::hook::{InjectorHookCtx, INJECTOR_METHODS, InjectorHook};
+use super::hook::{InjectorHook, InjectorHookCtx, INJECTOR_METHODS};
 
 pub struct FrameInjector {
     conn: sqld_libsql_bindings::Connection<InjectorHook>,

--- a/sqld/src/replication/replica/injector.rs
+++ b/sqld/src/replication/replica/injector.rs
@@ -5,14 +5,14 @@ use rusqlite::OpenFlags;
 
 use crate::replication::replica::hook::{SQLITE_CONTINUE_REPLICATION, SQLITE_EXIT_REPLICATION};
 
-use super::hook::{InjectorHookCtx, INJECTOR_METHODS};
+use super::hook::{InjectorHookCtx, INJECTOR_METHODS, InjectorHook};
 
-pub struct FrameInjector<'a> {
-    conn: sqld_libsql_bindings::Connection<'a>,
+pub struct FrameInjector {
+    conn: sqld_libsql_bindings::Connection<InjectorHook>,
 }
 
-impl<'a> FrameInjector<'a> {
-    pub fn new(db_path: &Path, hook_ctx: &'a mut InjectorHookCtx) -> anyhow::Result<Self> {
+impl FrameInjector {
+    pub fn new(db_path: &Path, hook_ctx: InjectorHookCtx) -> anyhow::Result<Self> {
         let conn = sqld_libsql_bindings::Connection::open(
             db_path,
             OpenFlags::SQLITE_OPEN_READ_WRITE

--- a/sqld/src/replication/replica/replicator.rs
+++ b/sqld/src/replication/replica/replicator.rs
@@ -109,8 +109,8 @@ impl Replicator {
         let handle = BLOCKING_RT.spawn_blocking({
             let db_path = db_path;
             move || -> anyhow::Result<()> {
-                let mut ctx = InjectorHookCtx::new(receiver, pre_commit, post_commit);
-                let mut injector = FrameInjector::new(&db_path, &mut ctx)?;
+                let ctx = InjectorHookCtx::new(receiver, pre_commit, post_commit);
+                let mut injector = FrameInjector::new(&db_path, ctx)?;
                 let _ = snd.send(());
 
                 while injector.step()? {}

--- a/sqld/src/rpc/proxy.rs
+++ b/sqld/src/rpc/proxy.rs
@@ -6,9 +6,8 @@ use async_lock::{RwLock, RwLockUpgradableReadGuard};
 use uuid::Uuid;
 
 use crate::auth::{Auth, Authenticated};
-use crate::connection::libsql::LibSqlConnection;
-use crate::connection::{Connection, TrackedConnection};
-use crate::database::Database;
+use crate::connection::Connection;
+use crate::database::{Database, PrimaryConnection};
 use crate::namespace::{NamespaceStore, PrimaryNamespaceMaker};
 use crate::query_result_builder::{
     Column, QueryBuilderConfig, QueryResultBuilder, QueryResultBuilderError,
@@ -265,7 +264,7 @@ pub mod rpc {
 }
 
 pub struct ProxyService {
-    clients: Arc<RwLock<HashMap<Uuid, Arc<TrackedConnection<LibSqlConnection>>>>>,
+    clients: RwLock<HashMap<Uuid, Arc<PrimaryConnection>>>,
     namespaces: NamespaceStore<PrimaryNamespaceMaker>,
     auth: Option<Arc<Auth>>,
     disable_namespaces: bool,
@@ -277,17 +276,15 @@ impl ProxyService {
         auth: Option<Arc<Auth>>,
         disable_namespaces: bool,
     ) -> Self {
-        let clients: Arc<RwLock<HashMap<Uuid, Arc<TrackedConnection<LibSqlConnection>>>>> =
-            Default::default();
         Self {
-            clients,
+            clients: Default::default(),
             namespaces,
             auth,
             disable_namespaces,
         }
     }
 
-    pub fn clients(&self) -> Arc<RwLock<HashMap<Uuid, Arc<TrackedConnection<LibSqlConnection>>>>> {
+    pub fn clients(&self) -> Arc<RwLock<HashMap<Uuid, Arc<PrimaryConnection>>>> {
         self.clients.clone()
     }
 }

--- a/sqld/src/rpc/proxy.rs
+++ b/sqld/src/rpc/proxy.rs
@@ -264,7 +264,7 @@ pub mod rpc {
 }
 
 pub struct ProxyService {
-    clients: RwLock<HashMap<Uuid, Arc<PrimaryConnection>>>,
+    clients: Arc<RwLock<HashMap<Uuid, Arc<PrimaryConnection>>>>,
     namespaces: NamespaceStore<PrimaryNamespaceMaker>,
     auth: Option<Arc<Auth>>,
     disable_namespaces: bool,
@@ -448,13 +448,11 @@ impl QueryResultBuilder for ExecuteResultBuilder {
 // FIXME: we should also keep a list of recently disconnected clients,
 // and if one should arrive with a late message, it should be rejected
 // with an error. A similar mechanism is already implemented in hrana-over-http.
-pub async fn garbage_collect(
-    clients: &mut HashMap<Uuid, Arc<TrackedConnection<LibSqlConnection>>>,
-) {
+pub async fn garbage_collect(clients: &mut HashMap<Uuid, Arc<PrimaryConnection>>) {
     let limit = std::time::Duration::from_secs(30);
 
     clients.retain(|_, db| db.idle_time() < limit);
-    tracing::trace!("gc: remaining client handles: {:?}", clients);
+    tracing::trace!("gc: remaining client handles count: {}", clients.len());
 }
 
 #[tonic::async_trait]


### PR DESCRIPTION
This PR removes the need to spawn long-lasting threads for libsql connections. This reduces the number of threads required by sqld, since it can now reuse threads from the thread pool for connections.


## Lock stealing

Previously, every connection spawned a blocking thread that kept track of the transaction state and timed out and rolled if a transaction didn't complete in time.

Avoiding to spawn a new thread means that we need a new mechanism to timeout a transaction. This PR introduces a lock-stealing mechanism.
The lock-stealing algorithm only monitors write locks, meaning RO transactions can continue indefinitely. Another change is that a lock is stolen i.if another connection claims it. Therefore, a write connection can go indefinitely until another connection steals the lock, guaranteeing it had at least TXN_TIMEOUT_DURATION to perform work.

Here is a detailed description of the algorithm:
- all connections to a database share a `TxnState`, that contains a `TxnSlot`
- when a connection acquires a write lock to the database, this is detected by monitoring the state of the connection before and after the call thanks to [sqlite3_txn_state()](https://www.sqlite.org/c3ref/c_txn_none.html)
- if the connection acquired a write lock (txn state none/read -> write), a new txn slot is created. A clone of the `TxnSlot` is placed in the `TxnState` shared with other connections to this database, while another clone is kept in the transaction state. The TxnSlot contains the instant the txn should timeout, a `is_stolen` flag, and a pointer to the connection currently holding the lock.
- when another connection attempts to acquire the lock, the `busy_handler` callback will be called. The callback is being passed to the `TxnState` for the connection. The handler looks at the current slot to determine when the current txn will timeout and waits for that instant before retrying. The waiting handler can also be notified that the transaction has been finished early.
- If the handler waits until the txn timeout and isn't notified of the termination of the txn, it will attempt to steal the lock. This is done by calling rollback on the slot's txn, and marking the slot as stolen.
- When a connection notices that its slot has been stolen, it returns a timed-out error to the subsequent request.
