### PR TITLE
flush frames and confirm snapshot completion before calling SQLite checkpoint

### DIFF
--- a/bottomless/src/backup.rs
+++ b/bottomless/src/backup.rs
@@ -56,7 +56,7 @@ impl WalCopier {
             if let Some(wal) = self.wal.as_mut() {
                 wal
             } else {
-                return Err(anyhow!("WAL file not found: \"{:?}\"", self.wal_path));
+                return Err(anyhow!("WAL file not found: `{}`", self.wal_path));
             }
         };
         let generation = if let Some(generation) = self.generation.load_full() {

--- a/sqld/src/namespace/mod.rs
+++ b/sqld/src/namespace/mod.rs
@@ -922,7 +922,9 @@ pub async fn init_bottomless_replicator(
     match action {
         bottomless::replicator::RestoreAction::SnapshotMainDbFile => {
             replicator.new_generation();
-            replicator.snapshot_main_db_file(None).await?;
+            if let Some(_handle) = replicator.snapshot_main_db_file().await? {
+                tracing::trace!("got snapshot handle after restore with generation upgrade");
+            }
             // Restoration process only leaves the local WAL file if it was
             // detected to be newer than its remote counterpart.
             replicator.maybe_replicate_wal().await?


### PR DESCRIPTION
This solves the issue when SQLite files (DB + WAL) are being modified before we confirm that they were backed up.

PS: **don't merge yet**, there's still an ongoing issue with tokio task never being scheduled causing a deadlock on subsequent checkpoints:  https://github.com/libsql/sqld/blob/dcb584019b395b966bc973f439a8750b6fe268b6/bottomless/src/replicator.rs#L751-L789 