### PR TITLE
Remove `context` calls for create database

### DIFF
--- a/sqld/src/hrana/http/stream.rs
+++ b/sqld/src/hrana/http/stream.rs
@@ -148,10 +148,7 @@ pub async fn acquire<'srv, D: Connection>(
             stream
         }
         None => {
-            let db = connection_maker
-                .create()
-                .await
-                .context("Could not create a database connection")?;
+            let db = connection_maker.create().await?;
 
             let mut state = server.stream_state.lock();
             let stream = Box::new(Stream {

--- a/sqld/src/hrana/ws/session.rs
+++ b/sqld/src/hrana/ws/session.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use anyhow::{anyhow, bail, Context as _, Result};
+use anyhow::{anyhow, bail, Result};
 use futures::future::BoxFuture;
 use tokio::sync::{mpsc, oneshot};
 
@@ -195,8 +195,7 @@ pub(super) async fn handle_request<F: MakeNamespace>(
                     .with_authenticated(namespace, authenticated, |ns| ns.db.connection_maker())
                     .await?
                     .create()
-                    .await
-                    .context("Could not create a database connection")?;
+                    .await?;
                 stream.db = Some(Arc::new(db));
                 Ok(proto::Response::OpenStream(proto::OpenStreamResp {}))
             });

--- a/sqld/src/http/user/hrana_over_http_1.rs
+++ b/sqld/src/http/user/hrana_over_http_1.rs
@@ -106,10 +106,7 @@ where
         let req_body = serde_json::from_slice(&req_body)
             .map_err(|e| hrana::ProtocolError::JsonDeserialize { source: e })?;
 
-        let db = db_factory
-            .create()
-            .await
-            .context("Could not create a database connection")?;
+        let db = db_factory.create().await?;
         let resp_body = f(db, req_body).await?;
 
         Ok(json_response(hyper::StatusCode::OK, &resp_body))


### PR DESCRIPTION
Remove the context calls that end up swallowing the real error and make it hard to debug why we couldn't create a database.