### PR TITLE
query_analysis: show the unsupported statement, if found

### DIFF
--- a/sqld/src/connection/libsql.rs
+++ b/sqld/src/connection/libsql.rs
@@ -420,7 +420,9 @@ impl<'a> Connection<'a> {
     }
 
     fn rollback(&self) {
-        let _ = self.conn.execute("ROLLBACK", ());
+        if let Err(e) = self.conn.execute("ROLLBACK", ()) {
+            tracing::error!("failed to rollback: {e}");
+        }
     }
 
     fn checkpoint(&self) -> Result<()> {

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -190,7 +190,11 @@ where
                 match conn.checkpoint().await {
                     Ok(_) => {
                         let elapsed = Instant::now() - start;
-                        tracing::info!("database checkpoint finished (took: {:?})", elapsed);
+                        if elapsed >= Duration::from_secs(10) {
+                            tracing::warn!("database checkpoint finished (took: {:?})", elapsed);
+                        } else {
+                            tracing::info!("database checkpoint finished (took: {:?})", elapsed);
+                        }
                         None
                     }
                     Err(err) => {

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -185,7 +185,7 @@ where
         }
         retry = match connection_maker.create().await {
             Ok(conn) => {
-                tracing::trace!("database checkpoint");
+                tracing::info!("database checkpoint starts");
                 let start = Instant::now();
                 match conn.checkpoint().await {
                     Ok(_) => {

--- a/sqld/src/query_analysis.rs
+++ b/sqld/src/query_analysis.rs
@@ -214,8 +214,8 @@ impl Statement {
             has_more_stmts: bool,
             c: Cmd,
         ) -> Result<Statement> {
-            let kind =
-                StmtKind::kind(&c).ok_or_else(|| anyhow::anyhow!("unsupported statement"))?;
+            let kind = StmtKind::kind(&c)
+                .ok_or_else(|| anyhow::anyhow!("unsupported statement: {original}"))?;
 
             if stmt_count == 1 && !has_more_stmts {
                 // XXX: Temporary workaround for integration with Atlas


### PR DESCRIPTION
That would make debugging user statements much easier and reproducible.

edit: added two more observability changes