### PR TITLE
ignore remote change counters on database restore if local db file exists

### DIFF
--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -1078,7 +1078,9 @@ impl Replicator {
                 if let Ok(page_size) = Self::read_page_size(&mut db).await {
                     self.set_page_size(page_size)?;
                 }
-                Self::read_change_counter(&mut db).await.unwrap_or([0u8; 4])
+                // if database file exists always treat it as new and more up to date, skipping the
+                // restoration process and calling for a new generation to be made
+                return Ok(Some(RestoreAction::SnapshotMainDbFile));
             }
             Err(_) => [0u8; 4],
         };


### PR DESCRIPTION
This PR skips process of validating local and remote change counters between local database file and remote snapshot if we found a DB file. In such case it will always call for a new snapshot.

### Concerns

1. This means that every time machine is restarted, a new generation will be created - we cannot reuse them if we're going to ignore the remote counters.
2. @psarna what if during restoration process we had a non empty WAL besides db file? Can we assume that xFrames callback will happen and that we'll pass info about frames to be send to S3 before possible checkpoint?