### PR TITLE
hrana: add diagnostics for connections

### DIFF
--- a/sqld-libsql-bindings/src/lib.rs
+++ b/sqld-libsql-bindings/src/lib.rs
@@ -24,6 +24,7 @@ pub fn get_orig_wal_methods() -> anyhow::Result<*mut libsql_wal_methods> {
     Ok(orig)
 }
 
+#[derive(Debug)]
 pub struct Connection<W: WalHook> {
     conn: rusqlite::Connection,
     // Safety: _ctx MUST be dropped after the connection, because the connection has a pointer

--- a/sqld-libsql-bindings/src/wal_hook.rs
+++ b/sqld-libsql-bindings/src/wal_hook.rs
@@ -46,8 +46,8 @@ macro_rules! init_static_wal_method {
 ///
 /// # Safety
 /// The implementer is responsible for calling the orig method with valid arguments.
-pub unsafe trait WalHook: std::fmt::Debug {
-    type Context: std::fmt::Debug;
+pub unsafe trait WalHook {
+    type Context;
 
     fn name() -> &'static CStr;
     /// Intercept `xFrame` call. `orig` is the function pointer to the underlying wal method.

--- a/sqld-libsql-bindings/src/wal_hook.rs
+++ b/sqld-libsql-bindings/src/wal_hook.rs
@@ -46,8 +46,8 @@ macro_rules! init_static_wal_method {
 ///
 /// # Safety
 /// The implementer is responsible for calling the orig method with valid arguments.
-pub unsafe trait WalHook {
-    type Context;
+pub unsafe trait WalHook: std::fmt::Debug {
+    type Context: std::fmt::Debug;
 
     fn name() -> &'static CStr;
     /// Intercept `xFrame` call. `orig` is the function pointer to the underlying wal method.
@@ -129,6 +129,7 @@ pub unsafe trait WalHook {
 init_static_wal_method!(TRANSPARENT_METHODS, TransparentMethods);
 
 /// Wal implemementation that just proxies calls to the wrapped WAL methods implementation
+#[derive(Debug)]
 pub enum TransparentMethods {}
 
 unsafe impl WalHook for TransparentMethods {

--- a/sqld/src/connection/mod.rs
+++ b/sqld/src/connection/mod.rs
@@ -24,7 +24,7 @@ pub mod write_proxy;
 const TXN_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[async_trait::async_trait]
-pub trait Connection: std::fmt::Debug + Send + Sync + 'static {
+pub trait Connection: Send + Sync + 'static {
     /// Executes a query program
     async fn execute_program<B: QueryResultBuilder>(
         &self,

--- a/sqld/src/connection/mod.rs
+++ b/sqld/src/connection/mod.rs
@@ -24,7 +24,7 @@ pub mod write_proxy;
 const TXN_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[async_trait::async_trait]
-pub trait Connection: Send + Sync + 'static {
+pub trait Connection: std::fmt::Debug + Send + Sync + 'static {
     /// Executes a query program
     async fn execute_program<B: QueryResultBuilder>(
         &self,
@@ -118,6 +118,8 @@ pub trait Connection: Send + Sync + 'static {
 
     /// Calls for database checkpoint (if supported).
     async fn checkpoint(&self) -> Result<()>;
+
+    fn diagnostics(&self) -> String;
 }
 
 fn make_batch_program(batch: Vec<Query>) -> Vec<Step> {
@@ -290,7 +292,7 @@ pub struct TrackedConnection<DB> {
     atime: AtomicU64,
 }
 
-impl<DB> TrackedConnection<DB> {
+impl<DB: Connection> TrackedConnection<DB> {
     pub fn idle_time(&self) -> Duration {
         let now = now_millis();
         let atime = self.atime.load(Ordering::Relaxed);
@@ -335,12 +337,18 @@ impl<DB: Connection> Connection for TrackedConnection<DB> {
         self.atime.store(now_millis(), Ordering::Relaxed);
         self.inner.checkpoint().await
     }
+
+    #[inline]
+    fn diagnostics(&self) -> String {
+        self.inner.diagnostics()
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
 
+    #[derive(Debug)]
     struct DummyDb;
 
     #[async_trait::async_trait]
@@ -370,6 +378,10 @@ mod test {
 
         async fn checkpoint(&self) -> Result<()> {
             unreachable!()
+        }
+
+        fn diagnostics(&self) -> String {
+            "dummy".into()
         }
     }
 

--- a/sqld/src/connection/write_proxy.rs
+++ b/sqld/src/connection/write_proxy.rs
@@ -104,6 +104,7 @@ impl MakeConnection for MakeWriteProxyConn {
     }
 }
 
+#[derive(Debug)]
 pub struct WriteProxyConnection {
     /// Lazily initialized read connection
     read_conn: LibSqlConnection<TransparentMethods>,
@@ -315,6 +316,10 @@ impl Connection for WriteProxyConnection {
     async fn checkpoint(&self) -> Result<()> {
         self.wait_replication_sync(None).await?;
         self.read_conn.checkpoint().await
+    }
+
+    fn diagnostics(&self) -> String {
+        format!("{:?}", self.state)
     }
 }
 

--- a/sqld/src/hrana/http/mod.rs
+++ b/sqld/src/hrana/http/mod.rs
@@ -25,6 +25,7 @@ pub struct Server<C> {
 pub enum Endpoint {
     Pipeline,
     Cursor,
+    Diagnostics,
 }
 
 impl<C: Connection> Server<C> {
@@ -69,6 +70,10 @@ impl<C: Connection> Server<C> {
         })
         .or_else(|err| err.downcast::<ProtocolError>().map(protocol_error_response))
     }
+
+    pub(crate) fn stream_state(&self) -> &Mutex<stream::ServerStreamState<C>> {
+        &self.stream_state
+    }
 }
 
 pub(crate) async fn handle_index() -> hyper::Response<hyper::Body> {
@@ -94,6 +99,7 @@ async fn handle_request<C: Connection>(
         Endpoint::Cursor => {
             handle_cursor(server, connection_maker, auth, req, version, encoding).await
         }
+        Endpoint::Diagnostics => handle_diagnostics(server, auth).await,
     }
 }
 
@@ -161,6 +167,34 @@ async fn handle_cursor<C: Connection>(
         .status(hyper::StatusCode::OK)
         .header(hyper::http::header::CONTENT_TYPE, content_type)
         .body(body)
+        .unwrap())
+}
+
+async fn handle_diagnostics<C: Connection>(
+    server: &Server<C>,
+    _auth: Authenticated,
+) -> Result<hyper::Response<hyper::Body>> {
+    let stream_state = server.stream_state().lock();
+    let handles = stream_state.handles();
+    let mut diagnostics: Vec<String> = Vec::with_capacity(handles.len());
+    for handle in handles.values() {
+        let handle_info: String = match handle {
+            stream::Handle::Available(stream) => match &stream.db {
+                Some(db) => db.diagnostics(),
+                None => "[BUG] available-but-closed".into(),
+            },
+            stream::Handle::Acquired => "acquired".into(),
+            stream::Handle::Expired => "expired".into(),
+        };
+        diagnostics.push(handle_info);
+    }
+    drop(stream_state);
+
+    tracing::warn!("diagnostics test: {diagnostics:?}");
+    Ok(hyper::Response::builder()
+        .status(hyper::StatusCode::OK)
+        .header(hyper::http::header::CONTENT_TYPE, "application/json")
+        .body(serde_json::to_string(&diagnostics)?.into())
         .unwrap())
 }
 

--- a/sqld/src/hrana/http/mod.rs
+++ b/sqld/src/hrana/http/mod.rs
@@ -190,7 +190,7 @@ async fn handle_diagnostics<C: Connection>(
     }
     drop(stream_state);
 
-    tracing::warn!("diagnostics test: {diagnostics:?}");
+    tracing::trace!("diagnostics: {diagnostics:?}");
     Ok(hyper::Response::builder()
         .status(hyper::StatusCode::OK)
         .header(hyper::http::header::CONTENT_TYPE, "application/json")

--- a/sqld/src/hrana/http/stream.rs
+++ b/sqld/src/hrana/http/stream.rs
@@ -34,7 +34,8 @@ pub struct ServerStreamState<D> {
 }
 
 /// Handle to a stream, owned by the [`ServerStreamState`].
-enum Handle<D> {
+#[derive(Debug)]
+pub(crate) enum Handle<D> {
     /// A stream that is open and ready to be used by requests. [`Stream::db`] should always be
     /// `Some`.
     Available(Box<Stream<D>>),
@@ -51,10 +52,11 @@ enum Handle<D> {
 ///
 /// The stream is either owned by [`Handle::Available`] (when it's not in use) or by [`Guard`]
 /// (when it's being used by a request).
-struct Stream<D> {
+#[derive(Debug)]
+pub(crate) struct Stream<D> {
     /// The database connection that corresponds to this stream. This is `None` after the `"close"`
     /// request was executed.
-    db: Option<Arc<D>>,
+    pub(crate) db: Option<Arc<D>>,
     /// The cache of SQL texts stored on the server with `"store_sql"` requests.
     sqls: HashMap<i32, String>,
     /// Stream id of this stream. The id is generated randomly (it should be unguessable).
@@ -97,6 +99,10 @@ impl<D> ServerStreamState<D> {
             expire_waker: None,
             expire_round_base: Instant::now(),
         }
+    }
+
+    pub(crate) fn handles(&self) -> &HashMap<u64, Handle<D>> {
+        &self.handles
     }
 }
 

--- a/sqld/src/http/admin/mod.rs
+++ b/sqld/src/http/admin/mod.rs
@@ -83,7 +83,7 @@ async fn handle_get_config<M: MakeNamespace>(
 
 async fn handle_diagnostics<M: MakeNamespace>(
     State(app_state): State<Arc<AppState<M>>>,
-) -> crate::Result<hyper::Response<hyper::Body>> {
+) -> crate::Result<Json<Vec<String>>> {
     use crate::connection::Connection;
     use hrana::http::stream;
 
@@ -105,11 +105,7 @@ async fn handle_diagnostics<M: MakeNamespace>(
     drop(stream_state);
 
     tracing::trace!("diagnostics: {diagnostics:?}");
-    Ok(hyper::Response::builder()
-        .status(hyper::StatusCode::OK)
-        .header(hyper::http::header::CONTENT_TYPE, "application/json")
-        .body(serde_json::to_string(&diagnostics)?.into())
-        .unwrap())
+    Ok(diagnostics)
 }
 
 #[derive(Debug, Deserialize)]

--- a/sqld/src/http/admin/mod.rs
+++ b/sqld/src/http/admin/mod.rs
@@ -105,7 +105,7 @@ async fn handle_diagnostics<M: MakeNamespace>(
     drop(stream_state);
 
     tracing::trace!("diagnostics: {diagnostics:?}");
-    Ok(diagnostics)
+    Ok(Json(diagnostics))
 }
 
 #[derive(Debug, Deserialize)]

--- a/sqld/src/http/admin/mod.rs
+++ b/sqld/src/http/admin/mod.rs
@@ -12,16 +12,26 @@ use tokio_util::io::ReaderStream;
 use url::Url;
 
 use crate::connection::config::DatabaseConfig;
+use crate::database::Database;
 use crate::error::LoadDumpError;
+use crate::hrana;
 use crate::namespace::{DumpStream, MakeNamespace, NamespaceName, NamespaceStore, RestoreOption};
 
 pub mod stats;
 
+type UserHttpServer<M> =
+    Arc<hrana::http::Server<<<M as MakeNamespace>::Database as Database>::Connection>>;
+
 struct AppState<M: MakeNamespace> {
     namespaces: NamespaceStore<M>,
+    user_http_server: UserHttpServer<M>,
 }
 
-pub async fn run<M, A>(acceptor: A, namespaces: NamespaceStore<M>) -> anyhow::Result<()>
+pub async fn run<M, A>(
+    acceptor: A,
+    user_http_server: UserHttpServer<M>,
+    namespaces: NamespaceStore<M>,
+) -> anyhow::Result<()>
 where
     A: crate::net::Accept,
     M: MakeNamespace,
@@ -43,7 +53,11 @@ where
         )
         .route("/v1/namespaces/:namespace", delete(handle_delete_namespace))
         .route("/v1/namespaces/:namespace/stats", get(stats::handle_stats))
-        .with_state(Arc::new(AppState { namespaces }));
+        .route("/v1/diagnostics", get(handle_diagnostics))
+        .with_state(Arc::new(AppState {
+            namespaces,
+            user_http_server,
+        }));
 
     hyper::server::Server::builder(acceptor)
         .serve(router.into_make_service())
@@ -65,6 +79,37 @@ async fn handle_get_config<M: MakeNamespace>(
         .config_store(NamespaceName::from_string(namespace)?)
         .await?;
     Ok(Json(store.get()))
+}
+
+async fn handle_diagnostics<M: MakeNamespace>(
+    State(app_state): State<Arc<AppState<M>>>,
+) -> crate::Result<hyper::Response<hyper::Body>> {
+    use crate::connection::Connection;
+    use hrana::http::stream;
+
+    let server = app_state.user_http_server.as_ref();
+    let stream_state = server.stream_state().lock();
+    let handles = stream_state.handles();
+    let mut diagnostics: Vec<String> = Vec::with_capacity(handles.len());
+    for handle in handles.values() {
+        let handle_info: String = match handle {
+            stream::Handle::Available(stream) => match &stream.db {
+                Some(db) => db.diagnostics(),
+                None => "[BUG] available-but-closed".into(),
+            },
+            stream::Handle::Acquired => "acquired".into(),
+            stream::Handle::Expired => "expired".into(),
+        };
+        diagnostics.push(handle_info);
+    }
+    drop(stream_state);
+
+    tracing::trace!("diagnostics: {diagnostics:?}");
+    Ok(hyper::Response::builder()
+        .status(hyper::StatusCode::OK)
+        .header(hyper::http::header::CONTENT_TYPE, "application/json")
+        .body(serde_json::to_string(&diagnostics)?.into())
+        .unwrap())
 }
 
 #[derive(Debug, Deserialize)]

--- a/sqld/src/http/user/mod.rs
+++ b/sqld/src/http/user/mod.rs
@@ -340,6 +340,14 @@ where
                         hrana::Encoding::Json,
                     )),
                 )
+                .route(
+                    "/v2/diagnostics",
+                    get(handle_hrana!(
+                        hrana::http::Endpoint::Diagnostics,
+                        hrana::Version::Hrana2,
+                        hrana::Encoding::Json,
+                    )),
+                )
                 .route("/v3", get(crate::hrana::http::handle_index))
                 .route(
                     "/v3/pipeline",

--- a/sqld/src/http/user/mod.rs
+++ b/sqld/src/http/user/mod.rs
@@ -233,7 +233,10 @@ where
     P: Proxy,
     S: ReplicationLog,
 {
-    pub fn configure(self, join_set: &mut JoinSet<anyhow::Result<()>>) {
+    pub fn configure(
+        self,
+        join_set: &mut JoinSet<anyhow::Result<()>>,
+    ) -> Arc<hrana::http::Server<<<M as MakeNamespace>::Database as Database>::Connection>> {
         let (hrana_accept_tx, hrana_accept_rx) = mpsc::channel(8);
         let (hrana_upgrade_tx, hrana_upgrade_rx) = mpsc::channel(8);
         let hrana_http_srv = Arc::new(hrana::http::Server::new(self.self_url.clone()));
@@ -283,7 +286,7 @@ where
             let state = AppState {
                 auth: self.auth,
                 upgrade_tx: hrana_upgrade_tx,
-                hrana_http_srv,
+                hrana_http_srv: hrana_http_srv.clone(),
                 enable_console: self.enable_console,
                 namespaces: self.namespaces,
                 disable_default_namespace: self.disable_default_namespace,
@@ -336,14 +339,6 @@ where
                     "/v2/pipeline",
                     post(handle_hrana!(
                         hrana::http::Endpoint::Pipeline,
-                        hrana::Version::Hrana2,
-                        hrana::Encoding::Json,
-                    )),
-                )
-                .route(
-                    "/v2/diagnostics",
-                    get(handle_hrana!(
-                        hrana::http::Endpoint::Diagnostics,
                         hrana::Version::Hrana2,
                         hrana::Encoding::Json,
                     )),
@@ -426,6 +421,7 @@ where
                 Ok(())
             });
         }
+        hrana_http_srv
     }
 }
 

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -151,10 +151,14 @@ where
             path: self.path.clone(),
         };
 
-        user_http.configure(join_set);
+        let user_http_service = user_http.configure(join_set);
 
         if let Some(AdminApiConfig { acceptor }) = self.admin_api_config {
-            join_set.spawn(http::admin::run(acceptor, self.namespaces));
+            join_set.spawn(http::admin::run(
+                acceptor,
+                user_http_service,
+                self.namespaces,
+            ));
         }
     }
 }

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -20,8 +20,7 @@ use crate::libsql_bindings::ffi::SQLITE_IOERR_WRITE;
 use crate::libsql_bindings::ffi::{
     sqlite3,
     types::{XWalCheckpointFn, XWalFrameFn, XWalSavePointUndoFn, XWalUndoFn},
-    PageHdrIter, PgHdr, Wal, SQLITE_CHECKPOINT_PASSIVE, SQLITE_CHECKPOINT_TRUNCATE, SQLITE_IOERR,
-    SQLITE_OK,
+    PageHdrIter, PgHdr, Wal, SQLITE_CHECKPOINT_TRUNCATE, SQLITE_IOERR, SQLITE_OK,
 };
 use crate::libsql_bindings::wal_hook::WalHook;
 use crate::replication::frame::{Frame, FrameHeader};
@@ -201,9 +200,6 @@ unsafe impl WalHook for ReplicationLoggerHook {
                     "Ignoring a checkpoint request weaker than TRUNCATE: {}",
                     emode
                 );
-                if emode == SQLITE_CHECKPOINT_PASSIVE {
-                    return SQLITE_OK;
-                }
                 // Return an error to signal to sqlite that the WAL was not checkpointed, and it is
                 // therefore not safe to delete it.
                 return SQLITE_BUSY;

--- a/sqld/src/replication/replica/hook.rs
+++ b/sqld/src/replication/replica/hook.rs
@@ -70,6 +70,7 @@ init_static_wal_method!(INJECTOR_METHODS, InjectorHook);
 /// The Caller must first call `set_frames`, passing the frames to be injected, then trigger a call
 /// to xFrames from the libsql connection (see dummy write in `injector`), and can then collect the
 /// result on the injection with `take_result`
+#[derive(Debug)]
 pub enum InjectorHook {}
 
 pub struct InjectorHookCtx {
@@ -81,6 +82,14 @@ pub struct InjectorHookCtx {
     pre_commit: Box<dyn Fn(FrameNo) -> anyhow::Result<()>>,
     /// invoked after injecting frames
     post_commit: Box<dyn Fn(FrameNo) -> anyhow::Result<()>>,
+}
+
+impl std::fmt::Debug for InjectorHookCtx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InjectorHookCtx")
+            .field("is_txn", &self.is_txn)
+            .finish()
+    }
 }
 
 impl InjectorHookCtx {

--- a/sqld/src/replication/snapshot.rs
+++ b/sqld/src/replication/snapshot.rs
@@ -163,7 +163,7 @@ impl SnapshotFile {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct LogCompactor {
     sender: crossbeam::channel::Sender<(LogFile, PathBuf, u32)>,
 }


### PR DESCRIPTION
This commit adds a `/v1/diagnostics` admin endpoint which prints various information about current hrana-over-http connections.

Draft, because the diagnostics are currently in a very debuggy format, and I'm figuring out if we can make it more human-readable. Still, they're enough to determine if something is holding a lock via an abandoned hrana-over-http stream.

Example:
```
$ curl -s http://localhost:8082/v1/diagnostics | jq
[
  "expired",
  "(conn: Mutex { data: <locked> }, timeout_ms: 0, stolen: true)",
  "expired",
  "(conn: Mutex { data: <locked> }, timeout_ms: 4291, stolen: false)",
  "expired",
  "expired",
  "<no-transaction>",
  "acquired"
]
```