### PR TITLE
bottomless: don't snapshot empty db files

### DIFF
--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -1095,12 +1095,16 @@ impl Replicator {
                 if let Ok(page_size) = Self::read_page_size(&mut db).await {
                     self.set_page_size(page_size)?;
                 }
-                // if database file exists always treat it as new and more up to date, skipping the
-                // restoration process and calling for a new generation to be made
-                return Ok(Some(RestoreAction::SnapshotMainDbFile));
+                Self::read_change_counter(&mut db).await.unwrap_or([0u8; 4])
             }
             Err(_) => [0u8; 4],
         };
+
+        if local_counter != [0u8; 4] {
+            // if a non-empty database file exists always treat it as new and more up to date,
+            // skipping the restoration process and calling for a new generation to be made
+            return Ok(Some(RestoreAction::SnapshotMainDbFile));
+        }
 
         let remote_counter = self.get_remote_change_counter(&generation).await?;
         tracing::debug!("Counters: l={:?}, r={:?}", local_counter, remote_counter);


### PR DESCRIPTION
This PR prevents us from accidentally snapshotting empty database files during recovery check.

It's basically more sane approach to #718 