### PR TITLE
Limit maximum DB size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,6 +902,9 @@ name = "bytesize"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cap-fs-ext"

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -15,7 +15,7 @@ bincode = "1.3.3"
 bottomless = { version = "0", path = "../bottomless", features = ["libsql_linked_statically"] }
 bytemuck = { version = "1.13.0", features = ["derive"] }
 bytes = { version = "1.2.1", features = ["serde"] }
-bytesize = "1.2.0"
+bytesize = { version = "1.2.0", features = ["serde"] }
 clap = { version = "4.0.23", features = [ "derive", "env", "string" ] }
 # console-subscriber = { version = "0.1.10", optional = true }
 console-subscriber = { git = "https://github.com/tokio-rs/console.git", rev = "5a80b98", optional = true }

--- a/sqld/src/connection/config.rs
+++ b/sqld/src/connection/config.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::{fs, io};
 
 use crate::error::Error;
-use crate::Result;
+use crate::{Result, LIBSQL_PAGE_SIZE};
 
 #[derive(Debug)]
 pub struct DatabaseConfigStore {
@@ -29,7 +29,7 @@ pub struct DatabaseConfig {
 }
 
 const fn default_max_size() -> u64 {
-    bytesize::ByteSize::pb(1000).as_u64() / 4096
+    bytesize::ByteSize::pb(1000).as_u64() / LIBSQL_PAGE_SIZE
 }
 
 impl Default for DatabaseConfig {

--- a/sqld/src/connection/config.rs
+++ b/sqld/src/connection/config.rs
@@ -43,7 +43,6 @@ impl Default for DatabaseConfig {
     }
 }
 
-
 impl DatabaseConfigStore {
     pub fn load(db_path: &Path) -> Result<Self> {
         let config_path = db_path.join("config.json");

--- a/sqld/src/connection/config.rs
+++ b/sqld/src/connection/config.rs
@@ -14,7 +14,7 @@ pub struct DatabaseConfigStore {
     config: Mutex<Arc<DatabaseConfig>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatabaseConfig {
     #[serde(default)]
     pub block_reads: bool,
@@ -23,7 +23,26 @@ pub struct DatabaseConfig {
     /// The reason why operations are blocked. This will be included in [`Error::Blocked`].
     #[serde(default)]
     pub block_reason: Option<String>,
+    /// maximum db size (in pages)
+    #[serde(default = "default_max_size")]
+    pub max_db_pages: u64,
 }
+
+const fn default_max_size() -> u64 {
+    bytesize::ByteSize::pb(1000).as_u64() / 4096
+}
+
+impl Default for DatabaseConfig {
+    fn default() -> Self {
+        Self {
+            block_reads: Default::default(),
+            block_writes: Default::default(),
+            block_reason: Default::default(),
+            max_db_pages: default_max_size(),
+        }
+    }
+}
+
 
 impl DatabaseConfigStore {
     pub fn load(db_path: &Path) -> Result<Self> {

--- a/sqld/src/connection/libsql.rs
+++ b/sqld/src/connection/libsql.rs
@@ -208,7 +208,8 @@ where
                 current_frame_no_receiver,
                 state,
             )?;
-            conn.conn.pragma_update(None, "max_page_count", max_db_size)?;
+            conn.conn
+                .pragma_update(None, "max_page_count", max_db_size)?;
             Ok(conn)
         })
         .await

--- a/sqld/src/connection/libsql.rs
+++ b/sqld/src/connection/libsql.rs
@@ -195,8 +195,9 @@ where
         current_frame_no_receiver: watch::Receiver<Option<FrameNo>>,
         state: Arc<TxnState<W>>,
     ) -> crate::Result<Self> {
-        let conn = tokio::task::spawn_blocking(move || {
-            Connection::new(
+        let max_db_size = config_store.get().max_db_pages;
+        let conn = tokio::task::spawn_blocking(move || -> crate::Result<_> {
+            let conn = Connection::new(
                 path.as_ref(),
                 extensions,
                 wal_hook,
@@ -206,7 +207,9 @@ where
                 builder_config,
                 current_frame_no_receiver,
                 state,
-            )
+            )?;
+            conn.conn.pragma_update(None, "max_page_count", max_db_size)?;
+            Ok(conn)
         })
         .await
         .unwrap()?;

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -67,6 +67,7 @@ mod utils;
 const MAX_CONCURRENT_DBS: usize = 128;
 const DB_CREATE_TIMEOUT: Duration = Duration::from_secs(1);
 const DEFAULT_AUTO_CHECKPOINT: u32 = 1000;
+const LIBSQL_PAGE_SIZE: u64 = 4096;
 
 pub(crate) static BLOCKING_RT: Lazy<Runtime> = Lazy::new(|| {
     tokio::runtime::Builder::new_multi_thread()

--- a/sqld/src/namespace/fork.rs
+++ b/sqld/src/namespace/fork.rs
@@ -17,7 +17,6 @@ use crate::{BLOCKING_RT, LIBSQL_PAGE_SIZE};
 
 use super::{MakeNamespace, NamespaceName, ResetCb, RestoreOption};
 
-
 type Result<T> = crate::Result<T, ForkError>;
 
 #[derive(Debug, thiserror::Error)]

--- a/sqld/src/namespace/fork.rs
+++ b/sqld/src/namespace/fork.rs
@@ -13,12 +13,10 @@ use crate::database::PrimaryDatabase;
 use crate::replication::frame::Frame;
 use crate::replication::primary::frame_stream::FrameStream;
 use crate::replication::{LogReadError, ReplicationLogger};
-use crate::BLOCKING_RT;
+use crate::{BLOCKING_RT, LIBSQL_PAGE_SIZE};
 
 use super::{MakeNamespace, NamespaceName, ResetCb, RestoreOption};
 
-// FIXME: get this const from somewhere else (crate wide)
-const PAGE_SIZE: usize = 4096;
 
 type Result<T> = crate::Result<T, ForkError>;
 
@@ -46,7 +44,7 @@ impl From<tokio::task::JoinError> for ForkError {
 
 async fn write_frame(frame: Frame, temp_file: &mut tokio::fs::File) -> Result<()> {
     let page_no = frame.header().page_no;
-    let page_pos = (page_no - 1) as usize * PAGE_SIZE;
+    let page_pos = (page_no - 1) as usize * LIBSQL_PAGE_SIZE as usize;
     temp_file.seek(SeekFrom::Start(page_pos as u64)).await?;
     temp_file.write_all(frame.page()).await?;
 

--- a/sqld/src/namespace/mod.rs
+++ b/sqld/src/namespace/mod.rs
@@ -728,7 +728,7 @@ impl Namespace<PrimaryDatabase> {
         .await?;
 
         let db_config_store = Arc::new(
-            dbg!(DatabaseConfigStore::load(&db_path)).context("Could not load database config")?,
+            DatabaseConfigStore::load(&db_path).context("Could not load database config")?,
         );
 
         let connection_maker: Arc<_> = MakeLibSqlConn::new(

--- a/sqld/src/namespace/mod.rs
+++ b/sqld/src/namespace/mod.rs
@@ -728,7 +728,7 @@ impl Namespace<PrimaryDatabase> {
         .await?;
 
         let db_config_store = Arc::new(
-            DatabaseConfigStore::load(&db_path).context("Could not load database config")?,
+            dbg!(DatabaseConfigStore::load(&db_path)).context("Could not load database config")?,
         );
 
         let connection_maker: Arc<_> = MakeLibSqlConn::new(

--- a/sqld/src/replication/frame.rs
+++ b/sqld/src/replication/frame.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 use bytemuck::{bytes_of, pod_read_unaligned, try_from_bytes, Pod, Zeroable};
 use bytes::{Bytes, BytesMut};
 
-use crate::replication::WAL_PAGE_SIZE;
+use crate::LIBSQL_PAGE_SIZE;
 
 use super::FrameNo;
 
@@ -45,10 +45,10 @@ impl fmt::Debug for Frame {
 
 impl Frame {
     /// size of a single frame
-    pub const SIZE: usize = size_of::<FrameHeader>() + WAL_PAGE_SIZE as usize;
+    pub const SIZE: usize = size_of::<FrameHeader>() + LIBSQL_PAGE_SIZE as usize;
 
     pub fn from_parts(header: &FrameHeader, data: &[u8]) -> Self {
-        assert_eq!(data.len(), WAL_PAGE_SIZE as usize);
+        assert_eq!(data.len(), LIBSQL_PAGE_SIZE as usize);
         let mut buf = BytesMut::with_capacity(Self::SIZE);
         buf.extend_from_slice(bytes_of(header));
         buf.extend_from_slice(data);

--- a/sqld/src/replication/mod.rs
+++ b/sqld/src/replication/mod.rs
@@ -7,7 +7,6 @@ use crc::Crc;
 pub use primary::logger::{LogReadError, ReplicationLogger, ReplicationLoggerHook};
 pub use snapshot::{NamespacedSnapshotCallback, SnapshotCallback};
 
-pub const WAL_PAGE_SIZE: i32 = 4096;
 pub const WAL_MAGIC: u64 = u64::from_le_bytes(*b"SQLDWAL\0");
 const CRC_64_GO_ISO: Crc<u64> = Crc::<u64>::new(&crc::CRC_64_GO_ISO);
 

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -16,7 +16,6 @@ use tokio::sync::watch;
 use tokio::time::{Duration, Instant};
 use uuid::Uuid;
 
-use crate::LIBSQL_PAGE_SIZE;
 use crate::libsql_bindings::ffi::SQLITE_IOERR_WRITE;
 use crate::libsql_bindings::ffi::{
     sqlite3,
@@ -27,6 +26,7 @@ use crate::libsql_bindings::wal_hook::WalHook;
 use crate::replication::frame::{Frame, FrameHeader};
 use crate::replication::snapshot::{find_snapshot_file, LogCompactor, SnapshotFile};
 use crate::replication::{FrameNo, SnapshotCallback, CRC_64_GO_ISO, WAL_MAGIC};
+use crate::LIBSQL_PAGE_SIZE;
 
 init_static_wal_method!(REPLICATION_METHODS, ReplicationLoggerHook);
 

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -859,14 +859,14 @@ impl ReplicationLogger {
         let data_file = File::open(&data_path)?;
         let size = data_path.metadata()?.len();
         assert!(
-            size % LIBSQL_PAGE_SIZE as u64 == 0,
+            size % LIBSQL_PAGE_SIZE == 0,
             "database file size is not a multiple of page size"
         );
         let num_page = size / LIBSQL_PAGE_SIZE;
         let mut buf = [0; LIBSQL_PAGE_SIZE as usize];
         let mut page_no = 1; // page numbering starts at 1
         for i in 0..num_page {
-            data_file.read_exact_at(&mut buf, i * LIBSQL_PAGE_SIZE as u64)?;
+            data_file.read_exact_at(&mut buf, i * LIBSQL_PAGE_SIZE)?;
             log_file.push_page(&WalPage {
                 page_no,
                 size_after: if i == num_page - 1 { num_page as _ } else { 0 },

--- a/sqld/src/replication/primary/logger.rs
+++ b/sqld/src/replication/primary/logger.rs
@@ -16,6 +16,7 @@ use tokio::sync::watch;
 use tokio::time::{Duration, Instant};
 use uuid::Uuid;
 
+use crate::LIBSQL_PAGE_SIZE;
 use crate::libsql_bindings::ffi::SQLITE_IOERR_WRITE;
 use crate::libsql_bindings::ffi::{
     sqlite3,
@@ -25,7 +26,7 @@ use crate::libsql_bindings::ffi::{
 use crate::libsql_bindings::wal_hook::WalHook;
 use crate::replication::frame::{Frame, FrameHeader};
 use crate::replication::snapshot::{find_snapshot_file, LogCompactor, SnapshotFile};
-use crate::replication::{FrameNo, SnapshotCallback, CRC_64_GO_ISO, WAL_MAGIC, WAL_PAGE_SIZE};
+use crate::replication::{FrameNo, SnapshotCallback, CRC_64_GO_ISO, WAL_MAGIC};
 
 init_static_wal_method!(REPLICATION_METHODS, ReplicationLoggerHook);
 
@@ -375,7 +376,7 @@ pub enum LogReadError {
 
 impl LogFile {
     /// size of a single frame
-    pub const FRAME_SIZE: usize = size_of::<FrameHeader>() + WAL_PAGE_SIZE as usize;
+    pub const FRAME_SIZE: usize = size_of::<FrameHeader>() + LIBSQL_PAGE_SIZE as usize;
 
     pub fn new(
         file: File,
@@ -392,7 +393,7 @@ impl LogFile {
                 version: 2,
                 start_frame_no: 0,
                 magic: WAL_MAGIC,
-                page_size: WAL_PAGE_SIZE,
+                page_size: LIBSQL_PAGE_SIZE as i32,
                 start_checksum: 0,
                 db_id: db_id.as_u128(),
                 frame_count: 0,
@@ -858,14 +859,14 @@ impl ReplicationLogger {
         let data_file = File::open(&data_path)?;
         let size = data_path.metadata()?.len();
         assert!(
-            size % WAL_PAGE_SIZE as u64 == 0,
+            size % LIBSQL_PAGE_SIZE as u64 == 0,
             "database file size is not a multiple of page size"
         );
-        let num_page = size / WAL_PAGE_SIZE as u64;
-        let mut buf = [0; WAL_PAGE_SIZE as usize];
+        let num_page = size / LIBSQL_PAGE_SIZE;
+        let mut buf = [0; LIBSQL_PAGE_SIZE as usize];
         let mut page_no = 1; // page numbering starts at 1
         for i in 0..num_page {
-            data_file.read_exact_at(&mut buf, i * WAL_PAGE_SIZE as u64)?;
+            data_file.read_exact_at(&mut buf, i * LIBSQL_PAGE_SIZE as u64)?;
             log_file.push_page(&WalPage {
                 page_no,
                 size_after: if i == num_page - 1 { num_page as _ } else { 0 },
@@ -977,9 +978,9 @@ pub fn checkpoint_db(data_path: &Path) -> anyhow::Result<()> {
         conn.pragma_query(None, "page_size", |row| {
             let page_size = row.get::<_, i32>(0).unwrap();
             assert_eq!(
-                page_size, WAL_PAGE_SIZE,
+                page_size, LIBSQL_PAGE_SIZE as i32,
                 "invalid database file, expected page size to be {}, but found {} instead",
-                WAL_PAGE_SIZE, page_size
+                LIBSQL_PAGE_SIZE, page_size
             );
             Ok(())
         })?;

--- a/sqld/src/replication/replica/hook.rs
+++ b/sqld/src/replication/replica/hook.rs
@@ -6,8 +6,9 @@ use sqld_libsql_bindings::ffi::Wal;
 use sqld_libsql_bindings::init_static_wal_method;
 use sqld_libsql_bindings::{ffi::types::XWalFrameFn, wal_hook::WalHook};
 
+use crate::LIBSQL_PAGE_SIZE;
 use crate::replication::frame::{Frame, FrameBorrowed};
-use crate::replication::{FrameNo, WAL_PAGE_SIZE};
+use crate::replication::FrameNo;
 
 use super::snapshot::TempSnapshot;
 
@@ -123,7 +124,7 @@ impl InjectorHookCtx {
         let ret = unsafe {
             orig(
                 wal,
-                WAL_PAGE_SIZE,
+                LIBSQL_PAGE_SIZE as i32,
                 page_headers.as_ptr(),
                 size_after,
                 (size_after != 0) as _,

--- a/sqld/src/replication/replica/hook.rs
+++ b/sqld/src/replication/replica/hook.rs
@@ -6,9 +6,9 @@ use sqld_libsql_bindings::ffi::Wal;
 use sqld_libsql_bindings::init_static_wal_method;
 use sqld_libsql_bindings::{ffi::types::XWalFrameFn, wal_hook::WalHook};
 
-use crate::LIBSQL_PAGE_SIZE;
 use crate::replication::frame::{Frame, FrameBorrowed};
 use crate::replication::FrameNo;
+use crate::LIBSQL_PAGE_SIZE;
 
 use super::snapshot::TempSnapshot;
 


### PR DESCRIPTION
This PR adds the ability to limit the maximum db size. This is done on a per-namespace basis, by sending a request to the `/v1/namespaces/foo/config` on the admin API. e.g:
```json
{
    "block_reads": false,
    "block_writes": false,
    "block_reason": null,
    "max_db_size": "10gb",
}
```

it is also possible to set the maximum db size on namespace creation