### PR TITLE
Vacuum before checkpointing

### DIFF
--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -587,7 +587,10 @@ impl Replicator {
     pub fn register_last_valid_frame(&mut self, frame: u32) {
         let last_valid_frame = self.peek_last_valid_frame();
         if frame != last_valid_frame {
-            if last_valid_frame != 0 {
+            // If frame >=  last_valid_frame, it comes from a transaction large enough
+            // that it got split to multiple xFrames calls. In this case, we just
+            // update the last_valid_frame to this one, all good.
+            if last_valid_frame != 0 && frame < last_valid_frame {
                 tracing::error!(
                     "[BUG] Local max valid frame is {}, while replicator thinks it's {}",
                     frame,

--- a/sqld/src/connection/mod.rs
+++ b/sqld/src/connection/mod.rs
@@ -119,6 +119,9 @@ pub trait Connection: Send + Sync + 'static {
     /// Calls for database checkpoint (if supported).
     async fn checkpoint(&self) -> Result<()>;
 
+    // Calls for database vacuum (if supported).
+    async fn vacuum_if_needed(&self) -> Result<()>;
+
     fn diagnostics(&self) -> String;
 }
 
@@ -339,6 +342,11 @@ impl<DB: Connection> Connection for TrackedConnection<DB> {
     }
 
     #[inline]
+    async fn vacuum_if_needed(&self) -> Result<()> {
+        self.inner.vacuum_if_needed().await
+    }
+
+    #[inline]
     fn diagnostics(&self) -> String {
         self.inner.diagnostics()
     }
@@ -377,6 +385,10 @@ mod test {
         }
 
         async fn checkpoint(&self) -> Result<()> {
+            unreachable!()
+        }
+
+        async fn vacuum_if_needed(&self) -> Result<()> {
             unreachable!()
         }
 

--- a/sqld/src/connection/write_proxy.rs
+++ b/sqld/src/connection/write_proxy.rs
@@ -318,6 +318,11 @@ impl Connection for WriteProxyConnection {
         self.read_conn.checkpoint().await
     }
 
+    async fn vacuum_if_needed(&self) -> Result<()> {
+        tracing::warn!("vacuum is not supported on write proxy");
+        Ok(())
+    }
+
     fn diagnostics(&self) -> String {
         format!("{:?}", self.state)
     }

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -190,6 +190,9 @@ where
         }
         retry = match connection_maker.create().await {
             Ok(conn) => {
+                if let Err(e) = conn.vacuum_if_needed().await {
+                    tracing::warn!("vacuum failed: {}", e);
+                }
                 tracing::info!("database checkpoint starts");
                 let start = Instant::now();
                 match conn.checkpoint().await {


### PR DESCRIPTION
This commit adds an optional VACUUM operation before our
periodic checkpoint -- since VACUUM should always be followe
by a checkpoint.
The are two criteria to qualify for vacuuming:
1. We have at least 32MiB of data
2. There are more free pages in the db than regular ones

If that's the case, we keep the db file more than 2x larger
than it could be, and that calls for a vacuum.
Also, for small databases, we entirely skip vacuuming.

Fixes #734
