### PR TITLE
add retry to s3 uploads in bottomless

### DIFF
--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -142,6 +142,7 @@ impl Options {
                 None,
                 "Static",
             ))
+            .retry_config(aws_sdk_s3::config::retry::RetryConfig::standard().with_max_attempts(6))
             .build();
         Ok(conf)
     }


### PR DESCRIPTION
This adds retry logic to our AWS SDK. The default backoff delay is 1s and with 6 retries, this can withhold network issues upto a minute.

