### PR TITLE
sqld: Revert be7386 and remove decoding limits

### DIFF
--- a/sqld/src/rpc/mod.rs
+++ b/sqld/src/rpc/mod.rs
@@ -85,9 +85,8 @@ pub async fn run_rpc_server<A: crate::net::Accept>(
             .await
             .context("http server")?;
     } else {
-        let proxy = ProxyServer::new(proxy_service).max_encoding_message_size(usize::MAX);
-        let replication =
-            ReplicationLogServer::new(logger_service).max_encoding_message_size(usize::MAX);
+        let proxy = ProxyServer::new(proxy_service);
+        let replication = ReplicationLogServer::new(logger_service);
 
         let router = tonic::transport::Server::builder()
             .layer(&option_layer(idle_shutdown_layer))

--- a/sqld/src/rpc/replication_log_proxy.rs
+++ b/sqld/src/rpc/replication_log_proxy.rs
@@ -12,7 +12,9 @@ pub struct ReplicationLogProxyService {
 
 impl ReplicationLogProxyService {
     pub fn new(channel: Channel, uri: Uri) -> Self {
-        let client = ReplicationLogClient::with_origin(channel, uri);
+        let client =
+            ReplicationLogClient::with_origin(channel, uri).max_decoding_message_size(usize::MAX);
+
         Self { client }
     }
 }


### PR DESCRIPTION
This reverts be7386 and removes decoding limits for the `ReplicationLogProxyClient` so that when replication requests get forwarded to the primary and it returns a full batch of `1024` frames it does not trigger the 4mb decoding limit set by default for tonic gRPC clients.