### PR TITLE
sqld: make wasm opt-out

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.dependencies]
 rusqlite = { version = "0.29.0", git = "https://github.com/tursodatabase/rusqlite.git", rev = "a72d529", default-features = false, features = [
     "buildtime_bindgen",
-    "bundled-libsql-wasm-experimental",
+    "bundled-libsql-experimental",
     "column_decltype",
     "load_extension",
     "modern_sqlite"

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -93,8 +93,10 @@ tonic-build = "0.10"
 vergen = { version = "8", features = ["build", "git", "gitcl"] }
 
 [features]
+default = ["wasm-udfs"]
 unix-excl-vfs = ["sqld-libsql-bindings/unix-excl-vfs"]
 debug-tools = ["console-subscriber", "rusqlite/trace", "tokio/tracing"]
 sim-tests = ["libsql"]
+wasm-udfs = ["rusqlite/bundled-libsql-wasm-experimental"]
 
 


### PR DESCRIPTION
This will allow ARMv7 architecture users to compile sqld. Wasmtime currently does not have support for that arch.