### PR TITLE
Make cargo-chef effective for CI builds

### DIFF
--- a/.github/workflows/pr-images.yml
+++ b/.github/workflows/pr-images.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+  
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -42,3 +45,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}-${{ github.event.pull_request.head.sha }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -44,3 +47,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,19 @@ RUN cargo build -p sqld --release
 
 # runtime
 FROM debian:bullseye-slim
-COPY --from=builder /target/release/sqld /bin/sqld
+
+EXPOSE 5001 8080
+VOLUME [ "/var/lib/sqld" ]
+
 RUN groupadd --system --gid 666 sqld
 RUN adduser --system --home /var/lib/sqld --uid 666 --gid 666 sqld
-RUN apt-get update && apt-get install -y ca-certificates
-COPY docker-entrypoint.sh /usr/local/bin
-ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
-VOLUME [ "/var/lib/sqld" ]
 WORKDIR /var/lib/sqld
 USER sqld
-EXPOSE 5001 8080
+
+COPY docker-entrypoint.sh /usr/local/bin
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /target/release/sqld /bin/sqld
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/bin/sqld"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,9 @@
-# build sqld
-FROM rust:slim-bullseye AS chef
-RUN apt update \
-    && apt install -y libclang-dev clang \
-        build-essential tcl protobuf-compiler file \
-        libssl-dev pkg-config git\
-    && apt clean \
-    && cargo install cargo-chef
-# We need to install and set as default the toolchain specified in rust-toolchain.toml
-# Otherwise cargo-chef will build dependencies using wrong toolchain
-# This also prevents planner and builder steps from installing the toolchain over and over again
-COPY rust-toolchain.toml rust-toolchain.toml
-RUN cat rust-toolchain.toml | grep "channel" | awk '{print $3}' | sed 's/\"//g' > toolchain.txt \
-    && rustup update $(cat toolchain.txt) \
-    && rustup default $(cat toolchain.txt) \
-    && rm toolchain.txt rust-toolchain.toml
-
-FROM chef AS planner
+# TODO: replace athosturso/sqld-builder with something like ghcr.io/libsql/sqld-builder
+FROM athosturso/sqld-builder AS planner
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM chef AS builder
+FROM athosturso/sqld-builder AS builder
 COPY --from=planner /recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,17 @@
+FROM rust:slim-bullseye
+
+RUN apt update 
+RUN apt install -y libclang-dev clang \
+    build-essential tcl protobuf-compiler file \
+    libssl-dev pkg-config git
+
+# We need to install and set as default the toolchain specified in rust-toolchain.toml
+# Otherwise cargo-chef will build dependencies using wrong toolchain
+# This also prevents planner and builder steps from installing the toolchain over and over again
+COPY rust-toolchain.toml rust-toolchain.toml
+RUN cat rust-toolchain.toml | grep "channel" | awk '{print $3}' | sed 's/\"//g' > toolchain.txt \
+    && rustup update $(cat toolchain.txt) \
+    && rustup default $(cat toolchain.txt) \
+    && rm toolchain.txt rust-toolchain.toml
+
+RUN cargo install cargo-chef


### PR DESCRIPTION
This PR has two changes that should make `cargo-chef` effective for CI docker builds.

- Use another image (`athosturso/sqld-builder`, built from `Dockerfile.builder`) as a base for both `cargo-chef` steps.
- Enable registry caching for Docker layers, allowing Docker layers to be reused between runs.

The first step is necessary because we can't reuse cached layers if the previous layers have changed.
And layers that run `apt update`, `rustup update` and `cargo install` can invalidate those caches.
The solution is to create an external image that has a separate lifecycle and does those unreproducible operations.

If this is accepted, we should create an `sqld-builder` package to store images for `Dockerfile.builder`.

The second step generates a tag inside the package to store the build cache (see [this](https://github.com/libsql/sqld/pkgs/container/sqld-devel/136494657?tag=buildcache) for example).
We may choose to have a different package to store only build caches as well.

---

When no dependencies are changed and `cargo-chef` works correctly, it takes [4 minutes](https://github.com/libsql/sqld/actions/runs/6486191875/job/17613868839) to build the Docker image, instead of [20](https://github.com/libsql/sqld/actions/runs/6485615033).