### PR TITLE
Make cargo-chef effective for CI builds

### DIFF
--- a/.github/workflows/pr-images.yml
+++ b/.github/workflows/pr-images.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+  
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -42,3 +45,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}-${{ github.event.pull_request.head.sha }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -44,3 +47,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN apt update \
     && apt install -y libclang-dev clang \
         build-essential tcl protobuf-compiler file \
         libssl-dev pkg-config git\
-    && apt clean \
-    && cargo install cargo-chef
+    && apt clean && rm -rf /var/lib/apt/lists/*
+
 # We need to install and set as default the toolchain specified in rust-toolchain.toml
 # Otherwise cargo-chef will build dependencies using wrong toolchain
 # This also prevents planner and builder steps from installing the toolchain over and over again
@@ -13,7 +13,8 @@ COPY rust-toolchain.toml rust-toolchain.toml
 RUN cat rust-toolchain.toml | grep "channel" | awk '{print $3}' | sed 's/\"//g' > toolchain.txt \
     && rustup update $(cat toolchain.txt) \
     && rustup default $(cat toolchain.txt) \
-    && rm toolchain.txt rust-toolchain.toml
+    && rm toolchain.txt rust-toolchain.toml \
+    && cargo install cargo-chef
 
 FROM chef AS planner
 COPY . .
@@ -27,14 +28,19 @@ RUN cargo build -p sqld --release
 
 # runtime
 FROM debian:bullseye-slim
-COPY --from=builder /target/release/sqld /bin/sqld
+
+EXPOSE 5001 8080
+VOLUME [ "/var/lib/sqld" ]
+
 RUN groupadd --system --gid 666 sqld
 RUN adduser --system --home /var/lib/sqld --uid 666 --gid 666 sqld
-RUN apt-get update && apt-get install -y ca-certificates
-COPY docker-entrypoint.sh /usr/local/bin
-ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
-VOLUME [ "/var/lib/sqld" ]
 WORKDIR /var/lib/sqld
 USER sqld
-EXPOSE 5001 8080
+
+COPY docker-entrypoint.sh /usr/local/bin
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /target/release/sqld /bin/sqld
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/bin/sqld"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN apt update \
     && apt install -y libclang-dev clang \
         build-essential tcl protobuf-compiler file \
         libssl-dev pkg-config git\
-    && apt clean && rm -rf /var/lib/apt/lists/*
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # We need to install and set as default the toolchain specified in rust-toolchain.toml
 # Otherwise cargo-chef will build dependencies using wrong toolchain


### PR DESCRIPTION
We need to cache Docker layers to `cargo-chef` to work properly.
This uses the Github Actions cache to save Docker layers, making docker build faster when no deps are changed.
It also changes the order of docker layers, to optimize cache usage when rebuilding and layer reutilization when pushing to the registry.