### PR TITLE
libsql: vacuum less often

### DIFF
--- a/sqld/src/connection/libsql.rs
+++ b/sqld/src/connection/libsql.rs
@@ -630,9 +630,9 @@ impl<W: WalHook> Connection<W> {
         let freelist_count = self
             .conn
             .query_row("PRAGMA freelist_count", (), |row| row.get::<_, i64>(0))?;
-        // NOTICE: don't bother vacuuming if we don't have at least 32MiB of data
-        if page_count >= 8192 && freelist_count * 2 > page_count {
-            tracing::debug!("Vacuuming: pages={page_count} freelist={freelist_count}");
+        // NOTICE: don't bother vacuuming if we don't have at least 256MiB of data
+        if page_count >= 65536 && freelist_count * 2 > page_count {
+            tracing::info!("Vacuuming: pages={page_count} freelist={freelist_count}");
             self.conn.execute("VACUUM", ())?;
         } else {
             tracing::debug!("Not vacuuming: pages={page_count} freelist={freelist_count}");


### PR DESCRIPTION
For specific edge cases, a 32MiB threshold is a little small. Let's bump it to at least 256MiB of data and inform about vacuuming with info log level.